### PR TITLE
feat: Add DingTalk channel support via Stream Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,12 +177,13 @@ That's it! You have a working AI assistant in 2 minutes.
 
 ## 💬 Chat Apps
 
-Talk to your picoclaw through Telegram
+Talk to your picoclaw through Telegram, Discord, or DingTalk
 
 | Channel | Setup |
 |---------|-------|
 | **Telegram** | Easy (just a token) |
 | **Discord** | Easy (bot token + intents) |
+| **DingTalk** | Medium (app credentials) |
 
 <details>
 <summary><b>Telegram</b> (Recommended)</summary>
@@ -257,6 +258,39 @@ picoclaw gateway
 
 ```bash
 nanobot gateway
+```
+
+</details>
+
+
+<details>
+<summary><b>DingTalk</b></summary>
+
+**1. Create a bot**
+
+- Go to [Open Platform](https://open.dingtalk.com/)
+- Create an internal app
+- Copy Client ID and Client Secret
+
+**2. Configure**
+
+```json
+{
+  "channels": {
+    "dingtalk": {
+      "enabled": true,
+      "client_id": "YOUR_CLIENT_ID",
+      "client_secret": "YOUR_CLIENT_SECRET",
+      "allow_from": []
+    }
+  }
+}
+```
+
+**3. Run**
+
+```bash
+picoclaw gateway
 ```
 
 </details>

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,12 @@ require (
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3
+	github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1
 )
 
 require (
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,14 @@ github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
 github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
@@ -20,6 +24,12 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/larksuite/oapi-sdk-go/v3 v3.5.3 h1:xvf8Dv29kBXC5/DNDCLhHkAFW8l/0LlQJimO5Zn+JUk=
 github.com/larksuite/oapi-sdk-go/v3 v3.5.3/go.mod h1:ZEplY+kwuIrj/nqw5uSCINNATcH3KdxSN7y+UxYY5fI=
+github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1 h1:Lb/Uzkiw2Ugt2Xf03J5wmv81PdkYOiWbI8CNBi1boC8=
+github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1/go.mod h1:ln3IqPYYocZbYvl9TAOrG/cxGR9xcn4pnZRLdCTEGEU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -56,3 +66,5 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/channels/dingtalk.go
+++ b/pkg/channels/dingtalk.go
@@ -1,0 +1,193 @@
+// PicoClaw - Ultra-lightweight personal AI agent
+// DingTalk channel implementation using Stream Mode
+
+package channels
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
+	"github.com/open-dingtalk/dingtalk-stream-sdk-go/client"
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/config"
+)
+
+// DingTalkChannel implements the Channel interface for DingTalk (钉钉)
+// It uses WebSocket for receiving messages via stream mode and API for sending
+type DingTalkChannel struct {
+	*BaseChannel
+	config         config.DingTalkConfig
+	clientID       string
+	clientSecret   string
+	streamClient   *client.StreamClient
+	ctx            context.Context
+	cancel         context.CancelFunc
+	// Map to store session webhooks for each chat
+	sessionWebhooks sync.Map // chatID -> sessionWebhook
+}
+
+// NewDingTalkChannel creates a new DingTalk channel instance
+func NewDingTalkChannel(cfg config.DingTalkConfig, messageBus *bus.MessageBus) (*DingTalkChannel, error) {
+	if cfg.ClientID == "" || cfg.ClientSecret == "" {
+		return nil, fmt.Errorf("dingtalk client_id and client_secret are required")
+	}
+
+	base := NewBaseChannel("dingtalk", cfg, messageBus, cfg.AllowFrom)
+
+	return &DingTalkChannel{
+		BaseChannel:  base,
+		config:       cfg,
+		clientID:     cfg.ClientID,
+		clientSecret: cfg.ClientSecret,
+	}, nil
+}
+
+// Start initializes the DingTalk channel with Stream Mode
+func (c *DingTalkChannel) Start(ctx context.Context) error {
+	log.Printf("Starting DingTalk channel (Stream Mode)...")
+
+	c.ctx, c.cancel = context.WithCancel(ctx)
+
+	// Create credential config
+	cred := client.NewAppCredentialConfig(c.clientID, c.clientSecret)
+
+	// Create the stream client with options
+	c.streamClient = client.NewStreamClient(
+		client.WithAppCredential(cred),
+		client.WithAutoReconnect(true),
+	)
+
+	// Register chatbot callback handler (IChatBotMessageHandler is a function type)
+	c.streamClient.RegisterChatBotCallbackRouter(c.onChatBotMessageReceived)
+
+	// Start the stream client
+	if err := c.streamClient.Start(c.ctx); err != nil {
+		return fmt.Errorf("failed to start stream client: %w", err)
+	}
+
+	c.setRunning(true)
+	log.Println("DingTalk channel started (Stream Mode)")
+	return nil
+}
+
+// Stop gracefully stops the DingTalk channel
+func (c *DingTalkChannel) Stop(ctx context.Context) error {
+	log.Println("Stopping DingTalk channel...")
+
+	if c.cancel != nil {
+		c.cancel()
+	}
+
+	if c.streamClient != nil {
+		c.streamClient.Close()
+	}
+
+	c.setRunning(false)
+	log.Println("DingTalk channel stopped")
+	return nil
+}
+
+// Send sends a message to DingTalk via the chatbot reply API
+func (c *DingTalkChannel) Send(ctx context.Context, msg bus.OutboundMessage) error {
+	if !c.IsRunning() {
+		return fmt.Errorf("dingtalk channel not running")
+	}
+
+	// Get session webhook from storage
+	sessionWebhookRaw, ok := c.sessionWebhooks.Load(msg.ChatID)
+	if !ok {
+		return fmt.Errorf("no session_webhook found for chat %s, cannot send message", msg.ChatID)
+	}
+
+	sessionWebhook, ok := sessionWebhookRaw.(string)
+	if !ok {
+		return fmt.Errorf("invalid session_webhook type for chat %s", msg.ChatID)
+	}
+
+	log.Printf("DingTalk message to %s: %s", msg.ChatID, truncateStringDingTalk(msg.Content, 100))
+
+	// Use the session webhook to send the reply
+	return c.SendDirectReply(sessionWebhook, msg.Content)
+}
+
+// onChatBotMessageReceived implements the IChatBotMessageHandler function signature
+// This is called by the Stream SDK when a new message arrives
+// IChatBotMessageHandler is: func(c context.Context, data *chatbot.BotCallbackDataModel) ([]byte, error)
+func (c *DingTalkChannel) onChatBotMessageReceived(ctx context.Context, data *chatbot.BotCallbackDataModel) ([]byte, error) {
+	// Extract message content from Text field
+	content := data.Text.Content
+	if content == "" {
+		// Try to extract from Content interface{} if Text is empty
+		if contentMap, ok := data.Content.(map[string]interface{}); ok {
+			if textContent, ok := contentMap["content"].(string); ok {
+				content = textContent
+			}
+		}
+	}
+
+	if content == "" {
+		return nil, nil // Ignore empty messages
+	}
+
+	senderID := data.SenderStaffId
+	senderNick := data.SenderNick
+	chatID := senderID
+	if data.ConversationType != "1" {
+		// For group chats
+		chatID = data.ConversationId
+	}
+
+	// Store the session webhook for this chat so we can reply later
+	c.sessionWebhooks.Store(chatID, data.SessionWebhook)
+
+	metadata := map[string]string{
+		"sender_name":       senderNick,
+		"conversation_id":   data.ConversationId,
+		"conversation_type": data.ConversationType,
+		"platform":          "dingtalk",
+		"session_webhook":   data.SessionWebhook,
+	}
+
+	log.Printf("DingTalk message from %s (%s): %s", senderNick, senderID, truncateStringDingTalk(content, 50))
+
+	// Handle the message through the base channel
+	c.HandleMessage(senderID, chatID, content, nil, metadata)
+
+	// Return nil to indicate we've handled the message asynchronously
+	// The response will be sent through the message bus
+	return nil, nil
+}
+
+// SendDirectReply sends a direct reply using the session webhook
+func (c *DingTalkChannel) SendDirectReply(sessionWebhook, content string) error {
+	replier := chatbot.NewChatbotReplier()
+
+	// Convert string content to []byte for the API
+	contentBytes := []byte(content)
+	titleBytes := []byte("PicoClaw")
+
+	// Send markdown formatted reply
+	err := replier.SimpleReplyMarkdown(
+		context.Background(),
+		sessionWebhook,
+		titleBytes,
+		contentBytes,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to send reply: %w", err)
+	}
+
+	return nil
+}
+
+// truncateStringDingTalk truncates a string to max length for logging (avoiding name collision with telegram.go)
+func truncateStringDingTalk(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen]
+}

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -110,6 +110,19 @@ func (m *Manager) initChannels() error {
 		}
 	}
 
+	if m.config.Channels.DingTalk.Enabled && m.config.Channels.DingTalk.ClientID != "" {
+		logger.DebugC("channels", "Attempting to initialize DingTalk channel")
+		dingtalk, err := NewDingTalkChannel(m.config.Channels.DingTalk, m.bus)
+		if err != nil {
+			logger.ErrorCF("channels", "Failed to initialize DingTalk channel", map[string]interface{}{
+				"error": err.Error(),
+			})
+		} else {
+			m.channels["dingtalk"] = dingtalk
+			logger.InfoC("channels", "DingTalk channel enabled successfully")
+		}
+	}
+
 	logger.InfoCF("channels", "Channel initialization completed", map[string]interface{}{
 		"enabled_channels": len(m.channels),
 	})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ type ChannelsConfig struct {
 	Feishu   FeishuConfig   `json:"feishu"`
 	Discord  DiscordConfig  `json:"discord"`
 	MaixCam  MaixCamConfig  `json:"maixcam"`
+	DingTalk DingTalkConfig `json:"dingtalk"`
 }
 
 type WhatsAppConfig struct {
@@ -70,6 +71,13 @@ type MaixCamConfig struct {
 	Host      string   `json:"host" env:"PICOCLAW_CHANNELS_MAIXCAM_HOST"`
 	Port      int      `json:"port" env:"PICOCLAW_CHANNELS_MAIXCAM_PORT"`
 	AllowFrom []string `json:"allow_from" env:"PICOCLAW_CHANNELS_MAIXCAM_ALLOW_FROM"`
+}
+
+type DingTalkConfig struct {
+	Enabled          bool     `json:"enabled" env:"PICOCLAW_CHANNELS_DINGTALK_ENABLED"`
+	ClientID         string   `json:"client_id" env:"PICOCLAW_CHANNELS_DINGTALK_CLIENT_ID"`
+	ClientSecret     string   `json:"client_secret" env:"PICOCLAW_CHANNELS_DINGTALK_CLIENT_SECRET"`
+	AllowFrom        []string `json:"allow_from" env:"PICOCLAW_CHANNELS_DINGTALK_ALLOW_FROM"`
 }
 
 type ProvidersConfig struct {
@@ -145,6 +153,12 @@ func DefaultConfig() *Config {
 				Host:      "0.0.0.0",
 				Port:      18790,
 				AllowFrom: []string{},
+			},
+			DingTalk: DingTalkConfig{
+				Enabled:      false,
+				ClientID:     "",
+				ClientSecret: "",
+				AllowFrom:    []string{},
 			},
 		},
 		Providers: ProvidersConfig{


### PR DESCRIPTION
- Add pkg/channels/dingtalk.go with WebSocket Stream Mode
- Add DingTalkConfig to config.go
- Register DingTalk in manager.go
- Update README with DingTalk setup instructions
- Add open-dingtalk/dingtalk-stream-sdk-go v0.9.1 dependency