### PR TITLE
Remove duplicate truncate functions, reuse utils.Truncate

### DIFF
--- a/pkg/channels/dingtalk.go
+++ b/pkg/channels/dingtalk.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-dingtalk/dingtalk-stream-sdk-go/client"
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
 // DingTalkChannel implements the Channel interface for DingTalk (钉钉)
@@ -107,7 +108,7 @@ func (c *DingTalkChannel) Send(ctx context.Context, msg bus.OutboundMessage) err
 		return fmt.Errorf("invalid session_webhook type for chat %s", msg.ChatID)
 	}
 
-	log.Printf("DingTalk message to %s: %s", msg.ChatID, truncateStringDingTalk(msg.Content, 100))
+	log.Printf("DingTalk message to %s: %s", msg.ChatID, utils.Truncate(msg.Content, 100))
 
 	// Use the session webhook to send the reply
 	return c.SendDirectReply(sessionWebhook, msg.Content)
@@ -151,7 +152,7 @@ func (c *DingTalkChannel) onChatBotMessageReceived(ctx context.Context, data *ch
 		"session_webhook":   data.SessionWebhook,
 	}
 
-	log.Printf("DingTalk message from %s (%s): %s", senderNick, senderID, truncateStringDingTalk(content, 50))
+	log.Printf("DingTalk message from %s (%s): %s", senderNick, senderID, utils.Truncate(content, 50))
 
 	// Handle the message through the base channel
 	c.HandleMessage(senderID, chatID, content, nil, metadata)
@@ -182,12 +183,4 @@ func (c *DingTalkChannel) SendDirectReply(sessionWebhook, content string) error 
 	}
 
 	return nil
-}
-
-// truncateStringDingTalk truncates a string to max length for logging (avoiding name collision with telegram.go)
-func truncateStringDingTalk(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen]
 }

--- a/pkg/channels/discord.go
+++ b/pkg/channels/discord.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
 	"github.com/sipeed/picoclaw/pkg/logger"
+	"github.com/sipeed/picoclaw/pkg/utils"
 	"github.com/sipeed/picoclaw/pkg/voice"
 )
 
@@ -172,7 +173,7 @@ func (c *DiscordChannel) handleMessage(s *discordgo.Session, m *discordgo.Messag
 	logger.DebugCF("discord", "Received message", map[string]interface{}{
 		"sender_name": senderName,
 		"sender_id":   senderID,
-		"preview":     truncateString(content, 50),
+		"preview":     utils.Truncate(content, 50),
 	})
 
 	metadata := map[string]string{

--- a/pkg/channels/feishu.go
+++ b/pkg/channels/feishu.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
 	"github.com/sipeed/picoclaw/pkg/logger"
+	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
 type FeishuChannel struct {
@@ -165,7 +166,7 @@ func (c *FeishuChannel) handleMessageReceive(_ context.Context, event *larkim.P2
 	logger.InfoCF("feishu", "Feishu message received", map[string]interface{}{
 		"sender_id": senderID,
 		"chat_id":   chatID,
-		"preview":   truncateString(content, 80),
+		"preview":   utils.Truncate(content, 80),
 	})
 
 	c.HandleMessage(senderID, chatID, content, nil, metadata)

--- a/pkg/channels/telegram.go
+++ b/pkg/channels/telegram.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sipeed/picoclaw/pkg/utils"
 	"github.com/sipeed/picoclaw/pkg/voice"
 )
 
@@ -247,7 +248,7 @@ func (c *TelegramChannel) handleMessage(update tgbotapi.Update) {
 		content = "[empty message]"
 	}
 
-	log.Printf("Telegram message from %s: %s...", senderID, truncateString(content, 50))
+	log.Printf("Telegram message from %s: %s...", senderID, utils.Truncate(content, 50))
 
 	// Thinking indicator
 	c.bot.Send(tgbotapi.NewChatAction(chatID, tgbotapi.ChatTyping))
@@ -392,13 +393,6 @@ func parseChatID(chatIDStr string) (int64, error) {
 	var id int64
 	_, err := fmt.Sscanf(chatIDStr, "%d", &id)
 	return id, err
-}
-
-func truncateString(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen]
 }
 
 func markdownToTelegramHTML(text string) string {

--- a/pkg/channels/whatsapp.go
+++ b/pkg/channels/whatsapp.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
 type WhatsAppChannel struct {
@@ -177,7 +178,7 @@ func (c *WhatsAppChannel) handleIncomingMessage(msg map[string]interface{}) {
 		metadata["user_name"] = userName
 	}
 
-	log.Printf("WhatsApp message from %s: %s...", senderID, truncateString(content, 50))
+	log.Printf("WhatsApp message from %s: %s...", senderID, utils.Truncate(content, 50))
 
 	c.HandleMessage(senderID, chatID, content, mediaPaths, metadata)
 }

--- a/pkg/voice/transcriber.go
+++ b/pkg/voice/transcriber.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sipeed/picoclaw/pkg/logger"
+	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
 type GroqTranscriber struct {
@@ -145,7 +146,7 @@ func (t *GroqTranscriber) Transcribe(ctx context.Context, audioFilePath string) 
 		"text_length":           len(result.Text),
 		"language":              result.Language,
 		"duration_seconds":      result.Duration,
-		"transcription_preview": truncateText(result.Text, 50),
+		"transcription_preview": utils.Truncate(result.Text, 50),
 	})
 
 	return &result, nil
@@ -155,11 +156,4 @@ func (t *GroqTranscriber) IsAvailable() bool {
 	available := t.apiKey != ""
 	logger.DebugCF("voice", "Checking transcriber availability", map[string]interface{}{"available": available})
 	return available
-}
-
-func truncateText(text string, maxLen int) string {
-	if len(text) <= maxLen {
-		return text
-	}
-	return text[:maxLen] + "..."
 }


### PR DESCRIPTION
## Summary

- Remove 3 duplicate private truncate implementations across the codebase, replacing them with the existing `utils.Truncate`
- The removed functions (`truncateString`, `truncateStringDingTalk`, `truncateText`) were byte-based and could corrupt multi-byte UTF-8 characters; `utils.Truncate` is rune-safe

## Details

| Package | Removed function | Issue |
|---------|-----------------|-------|
| `channels/telegram.go` | `truncateString` | byte-based, no "..." suffix |
| `channels/dingtalk.go` | `truncateStringDingTalk` | byte-based, no "..." suffix |
| `voice/transcriber.go` | `truncateText` | byte-based, has "..." but not rune-safe |

All call sites now use `utils.Truncate` which already exists and handles Unicode correctly.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing tests green)