### PR TITLE
Fix Telegram channel permission check

### DIFF
--- a/pkg/channels/telegram.go
+++ b/pkg/channels/telegram.go
@@ -343,7 +343,7 @@ func (c *TelegramChannel) handleMessage(ctx context.Context, update telego.Updat
 		"is_group":   fmt.Sprintf("%t", message.Chat.Type != "private"),
 	}
 
-	c.HandleMessage(senderID, fmt.Sprintf("%d", chatID), content, mediaPaths, metadata)
+	c.HandleMessage(fmt.Sprintf("%d", user.ID), fmt.Sprintf("%d", chatID), content, mediaPaths, metadata)
 }
 
 func (c *TelegramChannel) downloadPhoto(ctx context.Context, fileID string) string {


### PR DESCRIPTION
## Summary
Fixed a critical bug where Telegram messages were never processed by the agent loop.

## Bug
The Telegram channel was creating sender IDs with username suffix (e.g., `7567444967|username`) but `allow_from` configuration contained only numeric IDs (e.g., `7567444967`). The `IsAllowed()` check failed, preventing messages from being published to the inbound message bus. This caused the bot to show "Thinking..." but never respond.

## Solution
Modified `TelegramChannel.handleMessage()` to pass only the numeric user ID to `HandleMessage()` for permission checking, matching the format expected by `allow_from` configuration.

## Changed Files
- `pkg/channels/telegram.go`: Line 346 - Use numeric ID for permission check

## Testing
Verified that Telegram messages are now processed correctly and the agent responds as expected.