### PR TITLE
Fix LLM error by cleaning up CONSCIOUSLY message history

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -189,6 +189,17 @@ func (cb *ContextBuilder) BuildMessages(history []providers.Message, summary str
 		systemPrompt += "\n\n## Summary of Previous Conversation\n\n" + summary
 	}
 
+	//This fix prevents the session memory from LLM failure due to elimination of toolu_IDs required from LLM
+	// --- INICIO DEL FIX ---
+	//Diegox-17
+	for len(history) > 0 && (history[0].Role == "tool") {
+    	logger.DebugCF("agent", "Removing orphaned tool message from history to prevent LLM error", 
+        	map[string]interface{}{"role": history[0].Role})
+    	history = history[1:]
+	}
+	//Diegox-17
+	// --- FIN DEL FIX ---
+
 	messages = append(messages, providers.Message{
 		Role:    "system",
 		Content: systemPrompt,


### PR DESCRIPTION
Added logic to remove orphaned tool messages from history to prevent LLM errors.

I´ve been experiencing a BUG using Anthropic LLMs. Whenever the task is long enough, the session summarizes, this cause trouble with the LLM Memory, cause its looking for a Toolu_ID that now can not be foun in history.