### PR TITLE
fix(auth): support string interval in OpenAI device-code flow

### DIFF
--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -197,3 +197,43 @@ func TestOpenAIOAuthConfig(t *testing.T) {
 		t.Errorf("Port = %d, want 1455", cfg.Port)
 	}
 }
+
+func TestParseDeviceCodeResponseIntervalAsNumber(t *testing.T) {
+	body := []byte(`{"device_auth_id":"abc","user_code":"DEF-1234","interval":5}`)
+
+	resp, err := parseDeviceCodeResponse(body)
+	if err != nil {
+		t.Fatalf("parseDeviceCodeResponse() error: %v", err)
+	}
+
+	if resp.DeviceAuthID != "abc" {
+		t.Errorf("DeviceAuthID = %q, want %q", resp.DeviceAuthID, "abc")
+	}
+	if resp.UserCode != "DEF-1234" {
+		t.Errorf("UserCode = %q, want %q", resp.UserCode, "DEF-1234")
+	}
+	if resp.Interval != 5 {
+		t.Errorf("Interval = %d, want %d", resp.Interval, 5)
+	}
+}
+
+func TestParseDeviceCodeResponseIntervalAsString(t *testing.T) {
+	body := []byte(`{"device_auth_id":"abc","user_code":"DEF-1234","interval":"5"}`)
+
+	resp, err := parseDeviceCodeResponse(body)
+	if err != nil {
+		t.Fatalf("parseDeviceCodeResponse() error: %v", err)
+	}
+
+	if resp.Interval != 5 {
+		t.Errorf("Interval = %d, want %d", resp.Interval, 5)
+	}
+}
+
+func TestParseDeviceCodeResponseInvalidInterval(t *testing.T) {
+	body := []byte(`{"device_auth_id":"abc","user_code":"DEF-1234","interval":"abc"}`)
+
+	if _, err := parseDeviceCodeResponse(body); err == nil {
+		t.Fatal("expected error for invalid interval")
+	}
+}


### PR DESCRIPTION
## Summary
- fix OpenAI device-code login parsing when `interval` is returned as a string (e.g. `5`)
- keep support for numeric `interval` values
- add auth tests for numeric/string/invalid interval payloads
- print the browser auth URL before waiting and include a headless fallback hint

## Why
`picoclaw auth login --provider openai --device-code` currently fails with:
`json: cannot unmarshal string into Go struct field .interval of type int`

OpenAI's device auth endpoint returns `interval` as a string in practice, so unmarshalling into `int` breaks login.

## Changes
- add `parseDeviceCodeResponse` and `parseFlexibleInt` in `pkg/auth/oauth.go`
- switch `LoginDeviceCode` to use the flexible parser
- add:
  - `TestParseDeviceCodeResponseIntervalAsNumber`
  - `TestParseDeviceCodeResponseIntervalAsString`
  - `TestParseDeviceCodeResponseInvalidInterval`

## Validation
- `go test ./pkg/auth -run Test(ParseDeviceCodeResponse|BuildAuthorizeURL)`

## Related
- Closes #50