### PR TITLE
fix(heartbeat): resolve bug where service could never start

### DIFF
--- a/pkg/heartbeat/service.go
+++ b/pkg/heartbeat/service.go
@@ -14,6 +14,7 @@ type HeartbeatService struct {
 	interval    time.Duration
 	enabled     bool
 	mu          sync.RWMutex
+	started     bool
 	stopChan    chan struct{}
 }
 
@@ -31,7 +32,7 @@ func (hs *HeartbeatService) Start() error {
 	hs.mu.Lock()
 	defer hs.mu.Unlock()
 
-	if hs.running() {
+	if hs.started {
 		return nil
 	}
 
@@ -39,6 +40,7 @@ func (hs *HeartbeatService) Start() error {
 		return fmt.Errorf("heartbeat service is disabled")
 	}
 
+	hs.started = true
 	go hs.runLoop()
 
 	return nil
@@ -48,10 +50,11 @@ func (hs *HeartbeatService) Stop() {
 	hs.mu.Lock()
 	defer hs.mu.Unlock()
 
-	if !hs.running() {
+	if !hs.started {
 		return
 	}
 
+	hs.started = false
 	close(hs.stopChan)
 }
 


### PR DESCRIPTION
## Summary

- **HeartbeatService.Start() never launched the goroutine** due to a logic error in state detection: `running()` checks whether `stopChan` is closed, but a newly created service has an open channel, so `running()` always returned `true`, causing `Start()` to exit early thinking it was already running.
- Introduced a `started bool` field to separate "has been started" from "has not been stopped", which also prevents a potential double-close panic when `Stop()` is called more than once.

| State | `started` | `stopChan` | Behavior |
|-------|-----------|------------|----------|
| New | `false` | open | `Start()` proceeds, launches goroutine |
| Running | `true` | open | `Start()` is idempotent (no-op) |
| Stopped | `false` | closed | `Stop()` is idempotent, `runLoop` exits |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./pkg/heartbeat/...` passes
- [x] Verify heartbeat goroutine launches after `Start()` (enable heartbeat in config, observe periodic heartbeat logs)
- [x] Verify `Stop()` is safe to call multiple times without panic