### PR TITLE
feat(providers): add OpenAI-compatible endpoint support for GLM/Zai m…

### DIFF
--- a/pkg/providers/http_provider.go
+++ b/pkg/providers/http_provider.go
@@ -348,6 +348,13 @@ func CreateProvider(cfg *config.Config) (LLMProvider, error) {
 				apiBase = "https://generativelanguage.googleapis.com/v1beta"
 			}
 
+		// GLM/Zai via OpenAI-compatible endpoint (ex: Chutes.ai)
+		case (strings.Contains(lowerModel, "glm") || strings.Contains(lowerModel, "zai")) && cfg.Providers.OpenAI.APIKey != "" &&
+			cfg.Providers.OpenAI.APIBase != "" && cfg.Providers.OpenAI.APIBase != "https://api.openai.com/v1":
+			apiKey = cfg.Providers.OpenAI.APIKey
+			apiBase = cfg.Providers.OpenAI.APIBase
+			proxy = cfg.Providers.OpenAI.Proxy
+
 		case (strings.Contains(lowerModel, "glm") || strings.Contains(lowerModel, "zhipu") || strings.Contains(lowerModel, "zai")) && cfg.Providers.Zhipu.APIKey != "":
 			apiKey = cfg.Providers.Zhipu.APIKey
 			apiBase = cfg.Providers.Zhipu.APIBase


### PR DESCRIPTION
…odels

Enables using GLM and Zai models (e.g. zai-org/GLM-4.6) with custom OpenAI-compatible API endpoints like Chutes.ai.

When model contains 'glm' or 'zai' and OpenAI provider has a custom api_base (not api.openai.com), the provider will route requests to the custom endpoint with the model name passed as-is.

Resolves configuration issues when using Chutes.ai with PicoClaw.