### PR TITLE
fix: correct index bug in extractCodeBlocks and extractInlineCodes

### DIFF
--- a/pkg/channels/telegram.go
+++ b/pkg/channels/telegram.go
@@ -470,8 +470,11 @@ func extractCodeBlocks(text string) codeBlockMatch {
 		codes = append(codes, match[1])
 	}
 
+	i := 0
 	text = re.ReplaceAllStringFunc(text, func(m string) string {
-		return fmt.Sprintf("\x00CB%d\x00", len(codes)-1)
+		placeholder := fmt.Sprintf("\x00CB%d\x00", i)
+		i++
+		return placeholder
 	})
 
 	return codeBlockMatch{text: text, codes: codes}
@@ -491,8 +494,11 @@ func extractInlineCodes(text string) inlineCodeMatch {
 		codes = append(codes, match[1])
 	}
 
+	i := 0
 	text = re.ReplaceAllStringFunc(text, func(m string) string {
-		return fmt.Sprintf("\x00IC%d\x00", len(codes)-1)
+		placeholder := fmt.Sprintf("\x00IC%d\x00", i)
+		i++
+		return placeholder
 	})
 
 	return inlineCodeMatch{text: text, codes: codes}


### PR DESCRIPTION
The previous implementation used len(codes)-1 in ReplaceAllStringFunc, which caused all placeholders to point to the same (last) index. This resulted in only the last code block being displayed correctly when multiple code blocks were present in a message.

Now using a proper counter variable that increments for each match, ensuring each code block gets a unique placeholder index.