### PR TITLE
Fix: LLM call failed: API error #132

### DIFF
--- a/pkg/providers/http_provider.go
+++ b/pkg/providers/http_provider.go
@@ -42,7 +42,7 @@ func NewHTTPProvider(apiKey, apiBase, proxy string) *HTTPProvider {
 
 	return &HTTPProvider{
 		apiKey:     apiKey,
-		apiBase:    apiBase,
+		apiBase:    strings.TrimRight(apiBase, "/"),
 		httpClient: client,
 	}
 }
@@ -116,7 +116,7 @@ func (p *HTTPProvider) Chat(ctx context.Context, messages []Message, tools []Too
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API error: %s", string(body))
+		return nil, fmt.Errorf("API request failed:\n  Status: %d\n  Body:   %s", resp.StatusCode, string(body))
 	}
 
 	return p.parseResponse(body)


### PR DESCRIPTION
# Fix "LLM call failed: API error"
## Problem
When a user sets the api_base URL in the configuration with a trailing slash (e.g., https://generativelanguage.googleapis.com/v1beta/openai/), the API call fails with a generic "API error".

## Root Cause
The current code does not sanitize the api_base URL. It appends the endpoint path directly to the base URL, which can result in double slashes (e.g., https://generativelanguage.googleapis.com/v1beta/openai//chat/completions) if the user unknowingly includes a trailing slash. This leads to 404 errors.

## Solution
Sanitize URL: Modified the code to automatically remove any trailing slashes from the api_base URL during initialization. This ensures a clean base URL regardless of user input.
Improve Error Logging: Added the HTTP status code to the error message for API failures. This provides more context for debugging (e.g., distinguishing between 401 Unauthorized and 404 Not Found).

Closes #132