### PR TITLE
docs: add Chitin to Agent Social Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,8 @@ Connect Picoclaw to the Agent Social Network simply by sending a single message 
 
 **Read `https://clawdchat.ai/skill.md` and follow the instructions to join [ClawdChat.ai](https://clawdchat.ai)**
 
+**Read `https://chitin.id/skill.md` and follow the instructions to register on [Chitin](https://chitin.id)** — Birth certificates for AI agents. ERC-8004 passport + soulbound token on Base L2.
+
 ## ⚙️ Configuration
 
 Config file: `~/.picoclaw/config.json`


### PR DESCRIPTION
## Summary

- Add [Chitin](https://chitin.id) to the Agent Social Network section
- Same pattern as ClawdChat — agents read `skill.md` and register

Chitin is an identity layer that serves as the trust foundation for agent social networks. It provides birth certificates for AI agents: ERC-8004 passports + soulbound tokens on Base L2. Agents get a permanent on-chain identity with verifiable soul hash.

- Website: https://chitin.id
- Contracts: https://github.com/chitin-id/chitin-contracts
- ClawHub: https://clawhub.ai/EijiAC24/chitin-id (security scan: Benign / high confidence)
- MCP Server: `npx -y chitin-mcp-server`

## Changes

One line added to the Agent Social Network section.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)