### PR TITLE
docs: update QQ Open Platform link to correct URL

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -314,7 +314,7 @@ picoclaw gateway
 
 **1. Bot を作成**
 
-- [QQ オープンプラットフォーム](https://connect.qq.com/) にアクセス
+- [QQ オープンプラットフォーム](https://q.qq.com/#) にアクセス
 - アプリケーションを作成 → **AppID** と **AppSecret** を取得
 
 **2. 設定**

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ picoclaw gateway
 
 **1. Create a bot**
 
-- Go to [QQ Open Platform](https://connect.qq.com/)
+- Go to [QQ Open Platform](https://q.qq.com/#)
 - Create an application → Get **AppID** and **AppSecret**
 
 **2. Configure**

--- a/README.zh.md
+++ b/README.zh.md
@@ -342,7 +342,7 @@ picoclaw gateway
 
 **1. 创建机器人**
 
-* 前往 [QQ 开放平台](https://connect.qq.com/)
+* 前往 [QQ 开放平台](https://q.qq.com/#)
 * 创建应用 → 获取 **AppID** 和 **AppSecret**
 
 **2. 配置**


### PR DESCRIPTION
Change the QQ Open Platform link in the document from `https://connect.qq.com/` to the correct `https://q.qq.com/`.
Closes #152 