### PR TITLE
refactor: remove unused min func

### DIFF
--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -171,13 +171,6 @@ func (p *DuckDuckGoSearchProvider) extractResults(html string, count int, query 
 	return strings.Join(lines, "\n"), nil
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func stripTags(content string) string {
 	re := regexp.MustCompile(`<[^>]+>`)
 	return re.ReplaceAllString(content, "")


### PR DESCRIPTION
Go 1.21 adds built-in functions min and max. https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in methods with the same names.