### PR TITLE
Add production media pipeline for vision, file delivery, and screenshots

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -103,10 +103,20 @@
   },
   "tools": {
     "web": {
-      "search": {
+      "brave": {
+        "enabled": false,
         "api_key": "YOUR_BRAVE_API_KEY",
         "max_results": 5
+      },
+      "duckduckgo": {
+        "enabled": true,
+        "max_results": 5
       }
+    },
+    "media": {
+      "max_inbound_image_bytes": 5242880,
+      "max_inbound_images": 3,
+      "max_outbound_file_bytes": 10485760
     }
   },
   "heartbeat": {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -49,6 +49,7 @@ type processOptions struct {
 	Channel         string // Target channel for tool execution
 	ChatID          string // Target chat ID for tool execution
 	UserMessage     string // User message content (may include prefix)
+	Media           []string
 	DefaultResponse string // Response when LLM returns empty
 	EnableSummary   bool   // Whether to trigger summarization
 	SendResponse    bool   // Whether to send response via bus
@@ -59,6 +60,10 @@ type processOptions struct {
 // This is shared between main agent and subagents.
 func createToolRegistry(workspace string, restrict bool, cfg *config.Config, msgBus *bus.MessageBus) *tools.ToolRegistry {
 	registry := tools.NewToolRegistry()
+	maxOutboundFileBytes := cfg.Tools.Media.MaxOutboundFileBytes
+	if maxOutboundFileBytes <= 0 {
+		maxOutboundFileBytes = 10 * 1024 * 1024
+	}
 
 	// File system tools
 	registry.Register(tools.NewReadFileTool(workspace, restrict))
@@ -94,6 +99,20 @@ func createToolRegistry(workspace string, restrict bool, cfg *config.Config, msg
 	})
 	registry.Register(messageTool)
 
+	sendFileTool := tools.NewSendFileTool(workspace, restrict, maxOutboundFileBytes)
+	sendFileTool.SetSendCallback(func(msg bus.OutboundMessage) error {
+		msgBus.PublishOutbound(msg)
+		return nil
+	})
+	registry.Register(sendFileTool)
+
+	screenshotTool := tools.NewScreenshotTool(workspace, restrict, maxOutboundFileBytes)
+	screenshotTool.SetSendCallback(func(msg bus.OutboundMessage) error {
+		msgBus.PublishOutbound(msg)
+		return nil
+	})
+	registry.Register(screenshotTool)
+
 	return registry
 }
 
@@ -128,6 +147,7 @@ func NewAgentLoop(cfg *config.Config, msgBus *bus.MessageBus, provider providers
 	// Create context builder and set tools registry
 	contextBuilder := NewContextBuilder(workspace)
 	contextBuilder.SetToolsRegistry(toolsRegistry)
+	contextBuilder.SetMediaLimits(cfg.Tools.Media.MaxInboundImages, cfg.Tools.Media.MaxInboundImageBytes)
 
 	return &AgentLoop{
 		bus:            msgBus,
@@ -264,6 +284,7 @@ func (al *AgentLoop) processMessage(ctx context.Context, msg bus.InboundMessage)
 		Channel:         msg.Channel,
 		ChatID:          msg.ChatID,
 		UserMessage:     msg.Content,
+		Media:           msg.Media,
 		DefaultResponse: "I've completed processing but have no response to give.",
 		EnableSummary:   true,
 		SendResponse:    false,
@@ -350,7 +371,7 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (str
 		history,
 		summary,
 		opts.UserMessage,
-		nil,
+		opts.Media,
 		opts.Channel,
 		opts.ChatID,
 	)
@@ -577,6 +598,16 @@ func (al *AgentLoop) updateToolContexts(channel, chatID string) {
 		}
 	}
 	if tool, ok := al.tools.Get("subagent"); ok {
+		if st, ok := tool.(tools.ContextualTool); ok {
+			st.SetContext(channel, chatID)
+		}
+	}
+	if tool, ok := al.tools.Get("send_file"); ok {
+		if ft, ok := tool.(tools.ContextualTool); ok {
+			ft.SetContext(channel, chatID)
+		}
+	}
+	if tool, ok := al.tools.Get("screenshot"); ok {
 		if st, ok := tool.(tools.ContextualTool); ok {
 			st.SetContext(channel, chatID)
 		}

--- a/pkg/bus/types.go
+++ b/pkg/bus/types.go
@@ -10,10 +10,19 @@ type InboundMessage struct {
 	Metadata   map[string]string `json:"metadata,omitempty"`
 }
 
+type Attachment struct {
+	Type     string `json:"type"` // image | file | audio | video
+	Path     string `json:"path,omitempty"`
+	URL      string `json:"url,omitempty"`
+	FileName string `json:"file_name,omitempty"`
+	MIMEType string `json:"mime_type,omitempty"`
+}
+
 type OutboundMessage struct {
-	Channel string `json:"channel"`
-	ChatID  string `json:"chat_id"`
-	Content string `json:"content"`
+	Channel     string       `json:"channel"`
+	ChatID      string       `json:"chat_id"`
+	Content     string       `json:"content"`
+	Attachments []Attachment `json:"attachments,omitempty"`
 }
 
 type MessageHandler func(InboundMessage) error

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -191,8 +191,15 @@ type WebToolsConfig struct {
 	DuckDuckGo DuckDuckGoConfig `json:"duckduckgo"`
 }
 
+type MediaToolsConfig struct {
+	MaxInboundImageBytes int64 `json:"max_inbound_image_bytes" env:"PICOCLAW_TOOLS_MEDIA_MAX_INBOUND_IMAGE_BYTES"`
+	MaxInboundImages     int   `json:"max_inbound_images" env:"PICOCLAW_TOOLS_MEDIA_MAX_INBOUND_IMAGES"`
+	MaxOutboundFileBytes int64 `json:"max_outbound_file_bytes" env:"PICOCLAW_TOOLS_MEDIA_MAX_OUTBOUND_FILE_BYTES"`
+}
+
 type ToolsConfig struct {
-	Web WebToolsConfig `json:"web"`
+	Web   WebToolsConfig   `json:"web"`
+	Media MediaToolsConfig `json:"media"`
 }
 
 func DefaultConfig() *Config {
@@ -293,6 +300,11 @@ func DefaultConfig() *Config {
 					Enabled:    true,
 					MaxResults: 5,
 				},
+			},
+			Media: MediaToolsConfig{
+				MaxInboundImageBytes: 5 * 1024 * 1024,
+				MaxInboundImages:     3,
+				MaxOutboundFileBytes: 10 * 1024 * 1024,
 			},
 		},
 		Heartbeat: HeartbeatConfig{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -145,6 +145,16 @@ func TestDefaultConfig_WebTools(t *testing.T) {
 	if cfg.Tools.Web.DuckDuckGo.MaxResults != 5 {
 		t.Error("Expected DuckDuckGo MaxResults 5, got ", cfg.Tools.Web.DuckDuckGo.MaxResults)
 	}
+
+	if cfg.Tools.Media.MaxInboundImageBytes <= 0 {
+		t.Error("Expected positive MaxInboundImageBytes")
+	}
+	if cfg.Tools.Media.MaxInboundImages <= 0 {
+		t.Error("Expected positive MaxInboundImages")
+	}
+	if cfg.Tools.Media.MaxOutboundFileBytes <= 0 {
+		t.Error("Expected positive MaxOutboundFileBytes")
+	}
 }
 
 // TestConfig_Complete verifies all config fields are set

--- a/pkg/providers/http_provider_test.go
+++ b/pkg/providers/http_provider_test.go
@@ -1,0 +1,54 @@
+package providers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBuildOpenAICompatMessages_WithImageMedia(t *testing.T) {
+	messages := []Message{
+		{
+			Role:    "user",
+			Content: "Describe this image",
+			Media: []MediaItem{
+				{Type: "image_url", URL: "data:image/png;base64,abc"},
+			},
+		},
+	}
+
+	out := buildOpenAICompatMessages(messages)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(out))
+	}
+
+	content, ok := out[0]["content"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected content parts array")
+	}
+	if len(content) != 2 {
+		t.Fatalf("expected 2 content parts, got %d", len(content))
+	}
+	if content[1]["type"] != "image_url" {
+		t.Fatalf("expected image_url part")
+	}
+}
+
+func TestParseOpenAIContent_TextArray(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"type":"text","text":"line1"},
+		{"type":"text","text":"line2"}
+	]`)
+	got := parseOpenAIContent(raw)
+	if !strings.Contains(got, "line1") || !strings.Contains(got, "line2") {
+		t.Fatalf("unexpected parsed content: %q", got)
+	}
+}
+
+func TestParseOpenAIContent_String(t *testing.T) {
+	raw := json.RawMessage(`"hello"`)
+	got := parseOpenAIContent(raw)
+	if got != "hello" {
+		t.Fatalf("expected hello, got %q", got)
+	}
+}

--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -31,8 +31,16 @@ type UsageInfo struct {
 type Message struct {
 	Role       string     `json:"role"`
 	Content    string     `json:"content"`
+	Media      []MediaItem `json:"media,omitempty"`
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string     `json:"tool_call_id,omitempty"`
+}
+
+type MediaItem struct {
+	Type      string `json:"type"` // currently supports "image_url"
+	URL       string `json:"url,omitempty"`
+	MIMEType  string `json:"mime_type,omitempty"`
+	SourceRef string `json:"source_ref,omitempty"`
 }
 
 type LLMProvider interface {

--- a/pkg/tools/screenshot.go
+++ b/pkg/tools/screenshot.go
@@ -1,0 +1,294 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/utils"
+)
+
+type ScreenshotTool struct {
+	workspace      string
+	restrict       bool
+	maxFileBytes   int64
+	timeout        time.Duration
+	sendCallback   SendFileCallback
+	defaultChannel string
+	defaultChatID  string
+	lookPath       func(string) (string, error)
+	runCommand     func(ctx context.Context, command string, args ...string) error
+	now            func() time.Time
+}
+
+func NewScreenshotTool(workspace string, restrict bool, maxFileBytes int64) *ScreenshotTool {
+	return &ScreenshotTool{
+		workspace:    workspace,
+		restrict:     restrict,
+		maxFileBytes: maxFileBytes,
+		timeout:      45 * time.Second,
+		lookPath:     exec.LookPath,
+		runCommand: func(ctx context.Context, command string, args ...string) error {
+			cmd := exec.CommandContext(ctx, command, args...)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+			}
+			return nil
+		},
+		now: time.Now,
+	}
+}
+
+func (t *ScreenshotTool) Name() string {
+	return "screenshot"
+}
+
+func (t *ScreenshotTool) Description() string {
+	return "Capture a screenshot (web URL or desktop) and optionally send it to user."
+}
+
+func (t *ScreenshotTool) Parameters() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"url": map[string]interface{}{
+				"type":        "string",
+				"description": "Web page URL to capture. If omitted, captures local desktop screen.",
+			},
+			"path": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional output image path. Defaults to workspace/tmp/screenshots/*.png",
+			},
+			"caption": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional caption when sending screenshot.",
+			},
+			"send": map[string]interface{}{
+				"type":        "boolean",
+				"description": "Whether to send the screenshot to chat. Default true.",
+			},
+			"keep_local": map[string]interface{}{
+				"type":        "boolean",
+				"description": "Whether to keep local screenshot file after sending. Default false.",
+			},
+			"width": map[string]interface{}{
+				"type":        "integer",
+				"description": "Browser viewport width for URL screenshot. Default 1366.",
+			},
+			"height": map[string]interface{}{
+				"type":        "integer",
+				"description": "Browser viewport height for URL screenshot. Default 768.",
+			},
+			"channel": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional target channel override.",
+			},
+			"chat_id": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional target chat id override.",
+			},
+		},
+	}
+}
+
+func (t *ScreenshotTool) SetContext(channel, chatID string) {
+	t.defaultChannel = channel
+	t.defaultChatID = chatID
+}
+
+func (t *ScreenshotTool) SetSendCallback(callback SendFileCallback) {
+	t.sendCallback = callback
+}
+
+func (t *ScreenshotTool) Execute(ctx context.Context, args map[string]interface{}) *ToolResult {
+	outputPath, err := t.resolveOutputPath(args)
+	if err != nil {
+		return ErrorResult(err.Error())
+	}
+
+	width := intFromArgs(args, "width", 1366)
+	height := intFromArgs(args, "height", 768)
+	targetURL, _ := args["url"].(string)
+
+	cmdCtx, cancel := context.WithTimeout(ctx, t.timeout)
+	defer cancel()
+
+	if strings.TrimSpace(targetURL) != "" {
+		if err := t.captureURL(cmdCtx, targetURL, outputPath, width, height); err != nil {
+			return ErrorResult(fmt.Sprintf("capture URL screenshot failed: %v", err))
+		}
+	} else {
+		if err := t.captureDesktop(cmdCtx, outputPath); err != nil {
+			return ErrorResult(fmt.Sprintf("capture desktop screenshot failed: %v", err))
+		}
+	}
+
+	info, err := os.Stat(outputPath)
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("screenshot not created: %v", err))
+	}
+	if info.Size() == 0 {
+		return ErrorResult("screenshot is empty")
+	}
+	if t.maxFileBytes > 0 && info.Size() > t.maxFileBytes {
+		return ErrorResult(fmt.Sprintf("screenshot too large: %d bytes (limit %d bytes)", info.Size(), t.maxFileBytes))
+	}
+
+	send := boolFromArgs(args, "send", true)
+	keepLocal := boolFromArgs(args, "keep_local", false)
+	caption, _ := args["caption"].(string)
+
+	if !send {
+		return UserResult(fmt.Sprintf("Screenshot saved: %s", outputPath))
+	}
+
+	channel, _ := args["channel"].(string)
+	chatID, _ := args["chat_id"].(string)
+	if channel == "" {
+		channel = t.defaultChannel
+	}
+	if chatID == "" {
+		chatID = t.defaultChatID
+	}
+	if channel == "" || chatID == "" {
+		return ErrorResult("No target channel/chat specified")
+	}
+	if t.sendCallback == nil {
+		return ErrorResult("Screenshot sending not configured")
+	}
+
+	if err := t.sendCallback(bus.OutboundMessage{
+		Channel: channel,
+		ChatID:  chatID,
+		Content: caption,
+		Attachments: []bus.Attachment{
+			{
+				Type:     "image",
+				Path:     outputPath,
+				FileName: filepath.Base(outputPath),
+				MIMEType: "image/png",
+			},
+		},
+	}); err != nil {
+		return ErrorResult(fmt.Sprintf("sending screenshot: %v", err))
+	}
+
+	if !keepLocal {
+		utils.ScheduleFileCleanup(outputPath, 15*time.Minute, "screenshot")
+	}
+
+	return SilentResult(fmt.Sprintf("Screenshot sent to %s:%s", channel, chatID))
+}
+
+func (t *ScreenshotTool) resolveOutputPath(args map[string]interface{}) (string, error) {
+	rawPath, _ := args["path"].(string)
+	if strings.TrimSpace(rawPath) == "" {
+		rawPath = filepath.Join("tmp", "screenshots", t.now().Format("20060102_150405")+".png")
+	}
+
+	resolvedPath, err := validatePath(rawPath, t.workspace, t.restrict)
+	if err != nil {
+		return "", err
+	}
+	if ext := strings.ToLower(filepath.Ext(resolvedPath)); ext == "" {
+		resolvedPath += ".png"
+	}
+
+	if err := os.MkdirAll(filepath.Dir(resolvedPath), 0755); err != nil {
+		return "", fmt.Errorf("failed to create screenshot directory: %w", err)
+	}
+	return resolvedPath, nil
+}
+
+func (t *ScreenshotTool) captureURL(ctx context.Context, targetURL, outputPath string, width, height int) error {
+	browsers := []string{"chromium-browser", "chromium", "google-chrome", "google-chrome-stable"}
+	var browser string
+	for _, candidate := range browsers {
+		if _, err := t.lookPath(candidate); err == nil {
+			browser = candidate
+			break
+		}
+	}
+	if browser == "" {
+		return fmt.Errorf("no headless browser found (tried: %s)", strings.Join(browsers, ", "))
+	}
+
+	args := []string{
+		"--headless",
+		"--disable-gpu",
+		"--hide-scrollbars",
+		"--no-sandbox",
+		fmt.Sprintf("--window-size=%d,%d", width, height),
+		fmt.Sprintf("--screenshot=%s", outputPath),
+		targetURL,
+	}
+	return t.runCommand(ctx, browser, args...)
+}
+
+func (t *ScreenshotTool) captureDesktop(ctx context.Context, outputPath string) error {
+	type command struct {
+		name string
+		args []string
+	}
+
+	candidates := []command{
+		{name: "scrot", args: []string{outputPath}},
+		{name: "grim", args: []string{outputPath}},
+		{name: "import", args: []string{"-window", "root", outputPath}},
+	}
+
+	var available []command
+	for _, candidate := range candidates {
+		if _, err := t.lookPath(candidate.name); err == nil {
+			available = append(available, candidate)
+		}
+	}
+	if len(available) == 0 {
+		return fmt.Errorf("no desktop screenshot command found (tried: scrot, grim, import)")
+	}
+
+	var lastErr error
+	for _, cmd := range available {
+		if err := t.runCommand(ctx, cmd.name, cmd.args...); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func intFromArgs(args map[string]interface{}, key string, fallback int) int {
+	v, ok := args[key]
+	if !ok {
+		return fallback
+	}
+	switch n := v.(type) {
+	case int:
+		if n > 0 {
+			return n
+		}
+	case float64:
+		if int(n) > 0 {
+			return int(n)
+		}
+	}
+	return fallback
+}
+
+func boolFromArgs(args map[string]interface{}, key string, fallback bool) bool {
+	v, ok := args[key]
+	if !ok {
+		return fallback
+	}
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return fallback
+}

--- a/pkg/tools/screenshot_test.go
+++ b/pkg/tools/screenshot_test.go
@@ -1,0 +1,104 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+)
+
+func TestScreenshotTool_Execute_URL_Send(t *testing.T) {
+	tmpDir := t.TempDir()
+	tool := NewScreenshotTool(tmpDir, true, 1024*1024)
+	tool.SetContext("telegram", "999")
+
+	tool.lookPath = func(s string) (string, error) { return "/usr/bin/" + s, nil }
+	tool.runCommand = func(ctx context.Context, command string, args ...string) error {
+		var output string
+		for _, arg := range args {
+			if len(arg) > len("--screenshot=") && arg[:13] == "--screenshot=" {
+				output = arg[13:]
+			}
+		}
+		if output == "" {
+			t.Fatalf("missing screenshot output arg")
+		}
+		return os.WriteFile(output, []byte("fake-image"), 0644)
+	}
+
+	var sent bus.OutboundMessage
+	tool.SetSendCallback(func(msg bus.OutboundMessage) error {
+		sent = msg
+		return nil
+	})
+
+	result := tool.Execute(context.Background(), map[string]interface{}{
+		"url":     "https://example.com",
+		"caption": "cap",
+	})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.ForLLM)
+	}
+	if !result.Silent {
+		t.Fatalf("expected silent result")
+	}
+	if len(sent.Attachments) != 1 {
+		t.Fatalf("expected one attachment, got %d", len(sent.Attachments))
+	}
+	if sent.Attachments[0].Type != "image" {
+		t.Fatalf("expected image attachment")
+	}
+}
+
+func TestScreenshotTool_Execute_NoSendReturnsPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	tool := NewScreenshotTool(tmpDir, true, 1024*1024)
+
+	tool.lookPath = func(s string) (string, error) { return "/usr/bin/" + s, nil }
+	tool.runCommand = func(ctx context.Context, command string, args ...string) error {
+		output := filepath.Join(tmpDir, "tmp", "screenshots", "out.png")
+		for _, arg := range args {
+			if len(arg) > len("--screenshot=") && arg[:13] == "--screenshot=" {
+				output = arg[13:]
+			}
+		}
+		return os.WriteFile(output, []byte("fake-image"), 0644)
+	}
+	tool.now = func() time.Time { return time.Date(2026, 2, 14, 10, 0, 0, 0, time.UTC) }
+
+	result := tool.Execute(context.Background(), map[string]interface{}{
+		"url":  "https://example.com",
+		"send": false,
+	})
+	if result.IsError {
+		t.Fatalf("expected success, got %s", result.ForLLM)
+	}
+	if result.ForUser == "" {
+		t.Fatalf("expected user-visible path")
+	}
+}
+
+func TestScreenshotTool_Execute_NoTargetWhenSend(t *testing.T) {
+	tmpDir := t.TempDir()
+	tool := NewScreenshotTool(tmpDir, true, 1024*1024)
+	tool.lookPath = func(s string) (string, error) { return "/usr/bin/" + s, nil }
+	tool.runCommand = func(ctx context.Context, command string, args ...string) error {
+		for _, arg := range args {
+			if len(arg) > len("--screenshot=") && arg[:13] == "--screenshot=" {
+				return os.WriteFile(arg[13:], []byte("fake-image"), 0644)
+			}
+		}
+		return nil
+	}
+	tool.SetSendCallback(func(msg bus.OutboundMessage) error { return nil })
+
+	result := tool.Execute(context.Background(), map[string]interface{}{
+		"url": "https://example.com",
+	})
+	if !result.IsError {
+		t.Fatalf("expected error without target context")
+	}
+}

--- a/pkg/tools/send_file.go
+++ b/pkg/tools/send_file.go
@@ -1,0 +1,165 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+)
+
+type SendFileCallback func(msg bus.OutboundMessage) error
+
+type SendFileTool struct {
+	workspace      string
+	restrict       bool
+	maxFileBytes   int64
+	sendCallback   SendFileCallback
+	defaultChannel string
+	defaultChatID  string
+}
+
+func NewSendFileTool(workspace string, restrict bool, maxFileBytes int64) *SendFileTool {
+	return &SendFileTool{
+		workspace:    workspace,
+		restrict:     restrict,
+		maxFileBytes: maxFileBytes,
+	}
+}
+
+func (t *SendFileTool) Name() string {
+	return "send_file"
+}
+
+func (t *SendFileTool) Description() string {
+	return "Send a local file to the user on the current chat channel."
+}
+
+func (t *SendFileTool) Parameters() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"path": map[string]interface{}{
+				"type":        "string",
+				"description": "Path to the local file. Relative paths are resolved from workspace.",
+			},
+			"caption": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional text to include with the file.",
+			},
+			"attachment_type": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional attachment type: image or file.",
+			},
+			"filename": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional custom filename shown to user.",
+			},
+			"mime_type": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional mime type hint, for example image/png.",
+			},
+			"channel": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional target channel override.",
+			},
+			"chat_id": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional target chat id override.",
+			},
+		},
+		"required": []string{"path"},
+	}
+}
+
+func (t *SendFileTool) SetContext(channel, chatID string) {
+	t.defaultChannel = channel
+	t.defaultChatID = chatID
+}
+
+func (t *SendFileTool) SetSendCallback(callback SendFileCallback) {
+	t.sendCallback = callback
+}
+
+func (t *SendFileTool) Execute(ctx context.Context, args map[string]interface{}) *ToolResult {
+	path, ok := args["path"].(string)
+	if !ok || strings.TrimSpace(path) == "" {
+		return ErrorResult("path is required")
+	}
+
+	channel, _ := args["channel"].(string)
+	chatID, _ := args["chat_id"].(string)
+	if channel == "" {
+		channel = t.defaultChannel
+	}
+	if chatID == "" {
+		chatID = t.defaultChatID
+	}
+	if channel == "" || chatID == "" {
+		return ErrorResult("No target channel/chat specified")
+	}
+	if t.sendCallback == nil {
+		return ErrorResult("File sending not configured")
+	}
+
+	resolvedPath, err := validatePath(path, t.workspace, t.restrict)
+	if err != nil {
+		return ErrorResult(err.Error())
+	}
+
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		return ErrorResult(fmt.Sprintf("failed to stat file: %v", err))
+	}
+	if info.IsDir() {
+		return ErrorResult("path points to a directory, expected a file")
+	}
+	if t.maxFileBytes > 0 && info.Size() > t.maxFileBytes {
+		return ErrorResult(fmt.Sprintf("file too large: %d bytes (limit %d bytes)", info.Size(), t.maxFileBytes))
+	}
+
+	attachmentType, _ := args["attachment_type"].(string)
+	if attachmentType == "" {
+		attachmentType = detectAttachmentType(resolvedPath)
+	}
+	if attachmentType != "image" && attachmentType != "file" {
+		attachmentType = "file"
+	}
+
+	fileName, _ := args["filename"].(string)
+	if fileName == "" {
+		fileName = filepath.Base(resolvedPath)
+	}
+	mimeType, _ := args["mime_type"].(string)
+	caption, _ := args["caption"].(string)
+
+	outbound := bus.OutboundMessage{
+		Channel: channel,
+		ChatID:  chatID,
+		Content: caption,
+		Attachments: []bus.Attachment{
+			{
+				Type:     attachmentType,
+				Path:     resolvedPath,
+				FileName: fileName,
+				MIMEType: mimeType,
+			},
+		},
+	}
+	if err := t.sendCallback(outbound); err != nil {
+		return ErrorResult(fmt.Sprintf("sending file: %v", err))
+	}
+
+	return SilentResult(fmt.Sprintf("File sent to %s:%s (%s)", channel, chatID, fileName))
+}
+
+func detectAttachmentType(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp":
+		return "image"
+	default:
+		return "file"
+	}
+}

--- a/pkg/tools/send_file_test.go
+++ b/pkg/tools/send_file_test.go
@@ -1,0 +1,86 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+)
+
+func TestSendFileTool_Execute_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.png")
+	if err := os.WriteFile(filePath, []byte("png-data"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tool := NewSendFileTool(tmpDir, true, 1024*1024)
+	tool.SetContext("telegram", "123")
+
+	var sent bus.OutboundMessage
+	tool.SetSendCallback(func(msg bus.OutboundMessage) error {
+		sent = msg
+		return nil
+	})
+
+	result := tool.Execute(context.Background(), map[string]interface{}{
+		"path":    "test.png",
+		"caption": "hello",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.ForLLM)
+	}
+	if !result.Silent {
+		t.Fatalf("expected silent result")
+	}
+	if sent.Channel != "telegram" || sent.ChatID != "123" {
+		t.Fatalf("unexpected target: %s:%s", sent.Channel, sent.ChatID)
+	}
+	if len(sent.Attachments) != 1 {
+		t.Fatalf("expected one attachment, got %d", len(sent.Attachments))
+	}
+	if sent.Attachments[0].Type != "image" {
+		t.Fatalf("expected image attachment, got %s", sent.Attachments[0].Type)
+	}
+}
+
+func TestSendFileTool_Execute_NoTarget(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(filePath, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tool := NewSendFileTool(tmpDir, true, 1024*1024)
+	tool.SetSendCallback(func(msg bus.OutboundMessage) error { return nil })
+
+	result := tool.Execute(context.Background(), map[string]interface{}{
+		"path": filePath,
+	})
+
+	if !result.IsError {
+		t.Fatalf("expected error when no channel/chat context")
+	}
+}
+
+func TestSendFileTool_Execute_TooLarge(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "big.bin")
+	if err := os.WriteFile(filePath, make([]byte, 64), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tool := NewSendFileTool(tmpDir, true, 32)
+	tool.SetContext("telegram", "123")
+	tool.SetSendCallback(func(msg bus.OutboundMessage) error { return nil })
+
+	result := tool.Execute(context.Background(), map[string]interface{}{
+		"path": filePath,
+	})
+	if !result.IsError {
+		t.Fatalf("expected too large error")
+	}
+}

--- a/pkg/utils/media.go
+++ b/pkg/utils/media.go
@@ -141,3 +141,30 @@ func DownloadFileSimple(url, filename string) string {
 		LoggerPrefix: "media",
 	})
 }
+
+// ScheduleFileCleanup removes a file after delay in a background goroutine.
+// Use this for transient media files that must survive past the current stack frame.
+func ScheduleFileCleanup(path string, delay time.Duration, loggerPrefix string) {
+	if path == "" {
+		return
+	}
+	if delay <= 0 {
+		delay = 10 * time.Minute
+	}
+	if loggerPrefix == "" {
+		loggerPrefix = "media"
+	}
+
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		<-timer.C
+
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			logger.DebugCF(loggerPrefix, "Failed to cleanup temp file", map[string]interface{}{
+				"path":  path,
+				"error": err.Error(),
+			})
+		}
+	}()
+}


### PR DESCRIPTION
## Summary
- add multimodal image forwarding from inbound channel media to OpenAI-compatible provider payloads
- add outbound attachment support (bus schema + Telegram sendPhoto/sendDocument path)
- add production tools: `send_file` and `screenshot` with workspace safety, size limits, and delivery callbacks
- add delayed temp-media cleanup utility so vision/file tools can read inbound media safely
- add configurable media limits in config defaults/example and corresponding tests

## Notes
- this PR is designed for low-resource deployments (Raspberry Pi), with bounded media/image sizes and limited image count per request

## Testing
- added unit tests for provider multimodal conversion and new tools
- runtime tests could not be executed in this environment earlier due missing `go` binary
