### PR TITLE
feat: implement file/image support in chat channels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,6 @@ require (
 	golang.org/x/oauth2 v0.35.0
 )
 
-
-
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
@@ -28,9 +26,9 @@ require (
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/github/copilot-sdk/go v0.1.23
-	github.com/google/jsonschema-go v0.4.2 // indirect
-	github.com/go-resty/resty/v2 v2.17.1 // indirect
+	github.com/go-resty/resty/v2 v2.17.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/grbit/go-json v0.11.0 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
@@ -47,5 +45,4 @@ require (
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
-
 )

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/github/copilot-sdk/go v0.1.23 h1:uExtO/inZQndCZMiSAA1hvXINiz9tqo/MZgQ
 github.com/github/copilot-sdk/go v0.1.23/go.mod h1:GdwwBfMbm9AABLEM3x5IZKw4ZfwCYxZ1BgyytmZenQ0=
 github.com/go-redis/redis/v8 v8.11.4/go.mod h1:2Z2wHZXdQpCDXEGzqMockDpNyYvi2l4Pxt6RJr792+w=
 github.com/go-resty/resty/v2 v2.6.0/go.mod h1:PwvJS6hvaPkjtjNg9ph+VrSD92bi5Zq73w/BIH7cC3Q=
-github.com/go-resty/resty/v2 v2.17.1 h1:x3aMpHK1YM9e4va/TMDRlusDDoZiQ+ViDu/WpA6xTM4=
-github.com/go-resty/resty/v2 v2.17.1/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
+github.com/go-resty/resty/v2 v2.17.2 h1:FQW5oHYcIlkCNrMD2lloGScxcHJ0gkjshV3qcQAyHQk=
+github.com/go-resty/resty/v2 v2.17.2/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
@@ -58,6 +58,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
 github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pkg/channels/line.go
+++ b/pkg/channels/line.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -307,18 +306,7 @@ func (c *LINEChannel) processEvent(event lineEvent) {
 
 	var content string
 	var mediaPaths []string
-	localFiles := []string{}
-
-	defer func() {
-		for _, file := range localFiles {
-			if err := os.Remove(file); err != nil {
-				logger.DebugCF("line", "Failed to cleanup temp file", map[string]interface{}{
-					"file":  file,
-					"error": err.Error(),
-				})
-			}
-		}
-	}()
+	// Note: Files will be cleaned up by context.buildUserContent after base64 encoding
 
 	switch msg.Type {
 	case "text":
@@ -330,21 +318,18 @@ func (c *LINEChannel) processEvent(event lineEvent) {
 	case "image":
 		localPath := c.downloadContent(msg.ID, "image.jpg")
 		if localPath != "" {
-			localFiles = append(localFiles, localPath)
 			mediaPaths = append(mediaPaths, localPath)
 			content = "[image]"
 		}
 	case "audio":
 		localPath := c.downloadContent(msg.ID, "audio.m4a")
 		if localPath != "" {
-			localFiles = append(localFiles, localPath)
 			mediaPaths = append(mediaPaths, localPath)
 			content = "[audio]"
 		}
 	case "video":
 		localPath := c.downloadContent(msg.ID, "video.mp4")
 		if localPath != "" {
-			localFiles = append(localFiles, localPath)
 			mediaPaths = append(mediaPaths, localPath)
 			content = "[video]"
 		}

--- a/pkg/providers/claude_cli_provider.go
+++ b/pkg/providers/claude_cli_provider.go
@@ -71,11 +71,14 @@ func (p *ClaudeCliProvider) messagesToPrompt(messages []Message) string {
 		case "system":
 			// handled via --system-prompt flag
 		case "user":
-			parts = append(parts, "User: "+msg.Content)
+			userText := ContentToString(msg.Content)
+			parts = append(parts, "User: "+userText)
 		case "assistant":
-			parts = append(parts, "Assistant: "+msg.Content)
+			assistantText := ContentToString(msg.Content)
+			parts = append(parts, "Assistant: "+assistantText)
 		case "tool":
-			parts = append(parts, fmt.Sprintf("[Tool Result for %s]: %s", msg.ToolCallID, msg.Content))
+			toolText := ContentToString(msg.Content)
+			parts = append(parts, fmt.Sprintf("[Tool Result for %s]: %s", msg.ToolCallID, toolText))
 		}
 	}
 
@@ -93,7 +96,8 @@ func (p *ClaudeCliProvider) buildSystemPrompt(messages []Message, tools []ToolDe
 
 	for _, msg := range messages {
 		if msg.Role == "system" {
-			parts = append(parts, msg.Content)
+			systemText := ContentToString(msg.Content)
+			parts = append(parts, systemText)
 		}
 	}
 

--- a/pkg/providers/codex_provider.go
+++ b/pkg/providers/codex_provider.go
@@ -75,30 +75,33 @@ func buildCodexParams(messages []Message, tools []ToolDefinition, model string, 
 	for _, msg := range messages {
 		switch msg.Role {
 		case "system":
-			instructions = msg.Content
+			instructions = ContentToString(msg.Content)
 		case "user":
 			if msg.ToolCallID != "" {
+				resultText := ContentToString(msg.Content)
 				inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
 					OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
 						CallID: msg.ToolCallID,
-						Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{OfString: openai.Opt(msg.Content)},
+						Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{OfString: openai.Opt(resultText)},
 					},
 				})
 			} else {
+				userText := ContentToString(msg.Content)
 				inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
 					OfMessage: &responses.EasyInputMessageParam{
 						Role:    responses.EasyInputMessageRoleUser,
-						Content: responses.EasyInputMessageContentUnionParam{OfString: openai.Opt(msg.Content)},
+						Content: responses.EasyInputMessageContentUnionParam{OfString: openai.Opt(userText)},
 					},
 				})
 			}
 		case "assistant":
 			if len(msg.ToolCalls) > 0 {
-				if msg.Content != "" {
+				assistantText := ContentToString(msg.Content)
+				if assistantText != "" {
 					inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
 						OfMessage: &responses.EasyInputMessageParam{
 							Role:    responses.EasyInputMessageRoleAssistant,
-							Content: responses.EasyInputMessageContentUnionParam{OfString: openai.Opt(msg.Content)},
+							Content: responses.EasyInputMessageContentUnionParam{OfString: openai.Opt(assistantText)},
 						},
 					})
 				}
@@ -113,18 +116,20 @@ func buildCodexParams(messages []Message, tools []ToolDefinition, model string, 
 					})
 				}
 			} else {
+				assistantText := ContentToString(msg.Content)
 				inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
 					OfMessage: &responses.EasyInputMessageParam{
 						Role:    responses.EasyInputMessageRoleAssistant,
-						Content: responses.EasyInputMessageContentUnionParam{OfString: openai.Opt(msg.Content)},
+						Content: responses.EasyInputMessageContentUnionParam{OfString: openai.Opt(assistantText)},
 					},
 				})
 			}
 		case "tool":
+			resultText := ContentToString(msg.Content)
 			inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
 				OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
 					CallID: msg.ToolCallID,
-					Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{OfString: openai.Opt(msg.Content)},
+					Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{OfString: openai.Opt(resultText)},
 				},
 			})
 		}

--- a/pkg/providers/github_copilot_provider.go
+++ b/pkg/providers/github_copilot_provider.go
@@ -59,7 +59,7 @@ func (p *GitHubCopilotProvider) Chat(ctx context.Context, messages []Message, to
 	for _, msg := range messages {
 		out = append(out, tempMessage{
 			Role:    msg.Role,
-			Content: msg.Content,
+			Content: ContentToString(msg.Content),
 		})
 	}
 

--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -1,6 +1,9 @@
 package providers
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 type ToolCall struct {
 	ID        string                 `json:"id"`
@@ -29,10 +32,10 @@ type UsageInfo struct {
 }
 
 type Message struct {
-	Role       string     `json:"role"`
-	Content    string     `json:"content"`
-	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
-	ToolCallID string     `json:"tool_call_id,omitempty"`
+	Role       string      `json:"role"`
+	Content    interface{} `json:"content"` // Can be string or []interface{} for multipart content (text + images)
+	ToolCalls  []ToolCall  `json:"tool_calls,omitempty"`
+	ToolCallID string      `json:"tool_call_id,omitempty"`
 }
 
 type LLMProvider interface {
@@ -49,4 +52,33 @@ type ToolFunctionDefinition struct {
 	Name        string                 `json:"name"`
 	Description string                 `json:"description"`
 	Parameters  map[string]interface{} `json:"parameters"`
+}
+
+// ContentToString extracts text from Content (interface{}).
+// Handles both string content and multipart []interface{} content (text + images).
+// For multipart content, extracts only the text parts and joins them with newlines.
+func ContentToString(content interface{}) string {
+	if content == nil {
+		return ""
+	}
+	if s, ok := content.(string); ok {
+		return s
+	}
+	// If content is multipart ([]interface{}), extract text parts
+	if parts, ok := content.([]interface{}); ok {
+		var texts []string
+		for _, part := range parts {
+			partMap, ok := part.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if partType, _ := partMap["type"].(string); partType == "text" {
+				if text, ok := partMap["text"].(string); ok {
+					texts = append(texts, text)
+				}
+			}
+		}
+		return strings.Join(texts, "\n")
+	}
+	return ""
 }

--- a/pkg/utils/media.go
+++ b/pkg/utils/media.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"io"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -11,6 +12,44 @@ import (
 	"github.com/google/uuid"
 	"github.com/sipeed/picoclaw/pkg/logger"
 )
+
+// GetMimeType returns the MIME type for a file based on its extension.
+// If the MIME type cannot be determined, returns "application/octet-stream".
+func GetMimeType(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext == "" {
+		return "application/octet-stream"
+	}
+	mimeType := mime.TypeByExtension(ext)
+	if mimeType == "" {
+		return "application/octet-stream"
+	}
+	// Remove charset parameter if present (e.g., "text/html; charset=utf-8" -> "text/html")
+	if idx := strings.Index(mimeType, ";"); idx > 0 {
+		mimeType = mimeType[:idx]
+	}
+	return mimeType
+}
+
+// IsImageFile checks if a file is an image file based on its filename extension and content type.
+func IsImageFile(filename, contentType string) bool {
+	imageExtensions := []string{".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg"}
+	imageTypes := []string{"image/"}
+
+	for _, ext := range imageExtensions {
+		if strings.HasSuffix(strings.ToLower(filename), ext) {
+			return true
+		}
+	}
+
+	for _, imageType := range imageTypes {
+		if strings.HasPrefix(strings.ToLower(contentType), imageType) {
+			return true
+		}
+	}
+
+	return false
+}
 
 // IsAudioFile checks if a file is an audio file based on its filename extension and content type.
 func IsAudioFile(filename, contentType string) bool {


### PR DESCRIPTION
## Summary

Implements file and image support for chat channels, addressing issue #61. This allows picoclaw to receive and process images from various chat platforms (Discord, Telegram, LINE, Slack), similar to nanobot's implementation.

## Changes

### Core Changes
- **Modified Message.Content type**: Changed from `string` to `interface{}` to support both plain text and multipart content (text + images)
- **Added buildUserContent() method**: Base64-encodes images and creates multipart content structure for LLM APIs
- **Updated all providers**: Claude, Codex, GitHub Copilot, and Claude CLI now handle multipart content

### Provider Implementation
- **Claude Provider**: Added `buildContentBlocks()` to convert multipart content to Anthropic API format with `Base64ImageSourceParam`
- **Other Providers**: Consolidated duplicate `contentToString*` functions into shared `providers.ContentToString()` helper

### Utility Improvements
- **GetMimeType()**: Fixed to use `filepath.Ext()` to prevent potential panic
- **IsImageFile()**: New helper function to detect image files by extension and MIME type

### Channel Updates
- **Discord**: Downloads image attachments to local files (similar to audio handling)
- **Telegram**: Already supported (no changes needed)
- **LINE**: Image download support, removed premature file cleanup
- **Slack**: Image download support, removed premature file cleanup
- **WhatsApp**: Gets paths from external bridge (should work)

### Bug Fixes
- **Critical P0 Bug**: Fixed issue where media paths weren't reaching the LLM due to missing `Media` field in `processOptions` struct
- **File Cleanup**: Moved cleanup from channels to `context.buildUserContent()` after base64 encoding, ensuring files aren't deleted before processing

## Testing

- ✅ Built successfully on all platforms (linux-amd64, linux-arm64, linux-riscv64, darwin-arm64, windows-amd64)
- ✅ **Tested with Discord channel** - images are successfully processed and recognized by the LLM
- ✅ **Tested with Telegram channel** - images are successfully processed and recognized by the LLM
- ✅ Fixed LINE and Slack to match Discord/Telegram behavior

## Implementation Pattern

The implementation follows nanobot's pattern:
1. **Download**: Channel downloads image to local temp file
2. **Process**: Agent receives local file path
3. **Encode**: `buildUserContent()` reads file and base64-encodes it
4. **Cleanup**: File is deleted after encoding
5. **Send**: Multipart content (text + images) sent to LLM API

## Related

Closes #61