### PR TITLE
feat(auth): add Anthropic setup-token authentication

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -31,6 +31,40 @@ func LoginPasteToken(provider string, r io.Reader) (*AuthCredential, error) {
 	}, nil
 }
 
+const anthropicSetupTokenPrefix = "sk-ant-oat01-"
+
+func LoginSetupToken(r io.Reader) (*AuthCredential, error) {
+	fmt.Println("Paste your setup-token from Claude CLI (claude setup-token):")
+	fmt.Print("> ")
+
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("reading setup-token: %w", err)
+		}
+		return nil, fmt.Errorf("no input received")
+	}
+
+	token := strings.TrimSpace(scanner.Text())
+	if token == "" {
+		return nil, fmt.Errorf("setup-token cannot be empty")
+	}
+
+	if !strings.HasPrefix(token, anthropicSetupTokenPrefix) {
+		return nil, fmt.Errorf("invalid setup-token: must start with %s", anthropicSetupTokenPrefix)
+	}
+
+	if len(token) < 80 {
+		return nil, fmt.Errorf("invalid setup-token: too short (expected at least 80 characters)")
+	}
+
+	return &AuthCredential{
+		AccessToken: token,
+		Provider:    "anthropic",
+		AuthMethod:  "setup-token",
+	}, nil
+}
+
 func providerDisplayName(provider string) string {
 	switch provider {
 	case "anthropic":

--- a/pkg/providers/http_provider.go
+++ b/pkg/providers/http_provider.go
@@ -205,6 +205,9 @@ func createClaudeAuthProvider() (LLMProvider, error) {
 	if cred == nil {
 		return nil, fmt.Errorf("no credentials for anthropic. Run: picoclaw auth login --provider anthropic")
 	}
+	if cred.AuthMethod == "oauth" || cred.AuthMethod == "setup-token" {
+		return NewClaudeProviderWithTokenSourceBearer(cred.AccessToken, createClaudeTokenSource()), nil
+	}
 	return NewClaudeProviderWithTokenSource(cred.AccessToken, createClaudeTokenSource()), nil
 }
 
@@ -251,7 +254,7 @@ func CreateProvider(cfg *config.Config) (LLMProvider, error) {
 			}
 		case "anthropic", "claude":
 			if cfg.Providers.Anthropic.APIKey != "" || cfg.Providers.Anthropic.AuthMethod != "" {
-				if cfg.Providers.Anthropic.AuthMethod == "oauth" || cfg.Providers.Anthropic.AuthMethod == "token" {
+				if cfg.Providers.Anthropic.AuthMethod == "oauth" || cfg.Providers.Anthropic.AuthMethod == "token" || cfg.Providers.Anthropic.AuthMethod == "setup-token" {
 					return createClaudeAuthProvider()
 				}
 				apiKey = cfg.Providers.Anthropic.APIKey
@@ -348,7 +351,7 @@ func CreateProvider(cfg *config.Config) (LLMProvider, error) {
 			}
 
 		case (strings.Contains(lowerModel, "claude") || strings.HasPrefix(model, "anthropic/")) && (cfg.Providers.Anthropic.APIKey != "" || cfg.Providers.Anthropic.AuthMethod != ""):
-			if cfg.Providers.Anthropic.AuthMethod == "oauth" || cfg.Providers.Anthropic.AuthMethod == "token" {
+			if cfg.Providers.Anthropic.AuthMethod == "oauth" || cfg.Providers.Anthropic.AuthMethod == "token" || cfg.Providers.Anthropic.AuthMethod == "setup-token" {
 				return createClaudeAuthProvider()
 			}
 			apiKey = cfg.Providers.Anthropic.APIKey


### PR DESCRIPTION
## Summary
- Add support for Claude CLI setup-tokens (`sk-ant-oat01-*`) as authentication method for the Anthropic provider
- Complement the existing API key paste flow without modifying it
- Setup-tokens use `Authorization: Bearer` with required `anthropic-beta: claude-code-20250219,oauth-2025-04-20` header to enable OAuth on the Anthropic API

## Changes
- `pkg/auth/token.go`: new `LoginSetupToken()` with prefix and length validation
- `pkg/providers/claude_provider.go`: new `NewClaudeProviderWithBearerToken()` with OAuth headers; `useAPIKey` field to distinguish `x-api-key` (regular keys) vs Bearer (setup-token/oauth)
- `pkg/providers/http_provider.go`: route `setup-token` credentials through Bearer provider
- `cmd/picoclaw/main.go`: new `--setup-token` CLI flag, handler, and updated help

## Usage
```bash
claude setup-token              # generate token in Claude CLI
picoclaw auth login --provider anthropic --setup-token   # paste it
picoclaw agent -m "hello"       # works with Claude subscription
```

## Test plan
- [x] Build passes (`go build ./...`)
- [x] Existing tests pass (`go test ./...` — 2 pre-existing Windows failures unrelated)
- [x] Tested manually: `picoclaw agent -m "hola"` responds successfully with setup-token auth

Author: Edgar Gomero

🤖 Generated with [Claude Code](https://claude.ai/claude-code)