### PR TITLE
fix: only handle @bot message from slack once. This removes @bot call…

### DIFF
--- a/pkg/channels/slack.go
+++ b/pkg/channels/slack.go
@@ -198,6 +198,11 @@ func (c *SlackChannel) handleMessageEvent(ev *slackevents.MessageEvent) {
 		return
 	}
 
+	// Check if this is an app mention (bot was mentioned) - if so, let handleAppMention handle it
+	if strings.Contains(ev.Text, fmt.Sprintf("<@%s>", c.botUserID)) {
+		return
+	}
+
 	// 检查白名单，避免为被拒绝的用户下载附件
 	if !c.IsAllowed(ev.User) {
 		logger.DebugCF("slack", "Message rejected by allowlist", map[string]interface{}{
@@ -227,7 +232,6 @@ func (c *SlackChannel) handleMessageEvent(ev *slackevents.MessageEvent) {
 	})
 
 	content := ev.Text
-	content = c.stripBotMention(content)
 
 	var mediaPaths []string
 	localFiles := []string{} // 跟踪需要清理的本地文件


### PR DESCRIPTION
…s from handleMessageEvent handler

The slack integration currently gives 2 replies for @slack-bot calls. This pr makes it so if you @slack-bot you will get a message in the slack thread and not both the slack thread and main conversation window. 