### PR TITLE
fix(web): ensure fresh URL fetch context reaches model

### DIFF
--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -477,7 +477,7 @@ func (t *WebFetchTool) Execute(ctx context.Context, args map[string]interface{})
 	resultJSON, _ := json.MarshalIndent(result, "", "  ")
 
 	return &ToolResult{
-		ForLLM:  fmt.Sprintf("Fetched %d bytes from %s (extractor: %s, truncated: %v)", len(text), urlStr, extractor, truncated),
+		ForLLM:  string(resultJSON),
 		ForUser: string(resultJSON),
 	}
 }


### PR DESCRIPTION
Make web_fetch return the fetched payload to the LLM (not just metadata), fix HTML text extraction regex replacements, and add a prompt rule requiring fresh web_fetch calls for URL visit/check requests to prevent stale memory answers.

The bot was constantly hallucinating when asked e.g to visit the website 