### PR TITLE
security: fix workspace path restriction bypass in validatePath

### DIFF
--- a/pkg/tools/filesystem.go
+++ b/pkg/tools/filesystem.go
@@ -29,7 +29,7 @@ func validatePath(path, workspace string, restrict bool) (string, error) {
 		}
 	}
 
-	if restrict && !strings.HasPrefix(absPath, absWorkspace) {
+	if restrict && absPath != absWorkspace && !strings.HasPrefix(absPath, absWorkspace+string(filepath.Separator)) {
 		return "", fmt.Errorf("access denied: path is outside the workspace")
 	}
 


### PR DESCRIPTION
Fix a path validation bypass where paths outside the workspace could be accessed when the workspace path was a prefix of the target path.

Example: workspace `/tmp/abc` would allow access to `/tmp/abcdef/secret`.
