### PR TITLE
fix(claude): resolve empty tool name in Claude API requests

### DIFF
--- a/pkg/providers/claude_provider.go
+++ b/pkg/providers/claude_provider.go
@@ -81,7 +81,15 @@ func buildClaudeParams(messages []Message, tools []ToolDefinition, model string,
 					blocks = append(blocks, anthropic.NewTextBlock(msg.Content))
 				}
 				for _, tc := range msg.ToolCalls {
-					blocks = append(blocks, anthropic.NewToolUseBlock(tc.ID, tc.Arguments, tc.Name))
+					name := tc.Name
+					if name == "" && tc.Function != nil {
+						name = tc.Function.Name
+					}
+					args := tc.Arguments
+					if args == nil && tc.Function != nil && tc.Function.Arguments != "" {
+						json.Unmarshal([]byte(tc.Function.Arguments), &args)
+					}
+					blocks = append(blocks, anthropic.NewToolUseBlock(tc.ID, args, name))
 				}
 				anthropicMessages = append(anthropicMessages, anthropic.NewAssistantMessage(blocks...))
 			} else {


### PR DESCRIPTION
## Summary

- Fix 400 Bad Request errors when using Claude/Anthropic as the LLM provider
- The `ToolCall` struct stores tool names in `Function.Name` (OpenAI format), but `claude_provider.go` was reading `tc.Name` (top-level), which is always empty
- Also handles `Arguments` stored as a JSON string in `Function.Arguments` rather than the top-level map

## Root Cause

In `pkg/agent/loop.go`, tool calls are stored in OpenAI's format:
```go
ToolCall{
    Function: &FunctionCall{
        Name:      tc.Name,      // name goes here
        Arguments: string(JSON),  // args go here as string
    },
    // tc.Name is empty
    // tc.Arguments is nil
}
```

But `pkg/providers/claude_provider.go` reads the top-level fields:
```go
anthropic.NewToolUseBlock(tc.ID, tc.Arguments, tc.Name)  // both empty/nil
```

This causes every multi-turn conversation with tool calls to fail with:
```
messages.N.content.0.tool_use.name: String should have at least 1 character
```

## Fix

Fall back to `Function.Name` and `Function.Arguments` when top-level fields are empty:
```go
name := tc.Name
if name == "" && tc.Function != nil {
    name = tc.Function.Name
}
args := tc.Arguments
if args == nil && tc.Function != nil && tc.Function.Arguments != "" {
    json.Unmarshal([]byte(tc.Function.Arguments), &args)
}
blocks = append(blocks, anthropic.NewToolUseBlock(tc.ID, args, name))
```

## Test plan

- [x] `go build ./...` compiles
- [x] Tested with Claude Sonnet 4.5 via setup-token auth — multi-turn conversations with tool calls work correctly
- [x] Verified on Telegram channel with real tool executions (web search, file read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)