### PR TITLE
build: temporary disable UPX compression

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,10 +66,10 @@ changelog:
       - "^docs:"
       - "^test:"
 
-upx:
-   - enabled: true
-     compress: best
-     lzma: true
+# upx:
+#    - enabled: true
+#      compress: best
+#      lzma: true
 
 release:
   footer: >-


### PR DESCRIPTION
Currently, UPX compression doubles memory consumption, so it should be temporarily disabled until a better solution is found.