### PR TITLE
feat(web): Exa web search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@
 
 # ── Web Search (optional) ────────────────
 # BRAVE_SEARCH_API_KEY=BSA...
+# EXA_API_KEY=...
 
 # ── Timezone ──────────────────────────────
 TZ=Asia/Tokyo

--- a/README.ja.md
+++ b/README.ja.md
@@ -162,7 +162,7 @@ docker compose --profile gateway up -d
 > [!TIP]
 > `~/.picoclaw/config.json` に API キーを設定してください。
 > API キーの取得先: [OpenRouter](https://openrouter.ai/keys) (LLM) · [Zhipu](https://open.bigmodel.cn/usercenter/proj-mgmt/apikeys) (LLM)
-> Web 検索は **任意** です - 無料の [Brave Search API](https://brave.com/search/api) (月 2000 クエリ無料)
+> Web 検索は **任意** です - 無料の [Brave Search API](https://brave.com/search/api) (月 2000 クエリ無料) または無料の [Exa Search API](https://exa.ai) (AI ネイティブ検索)
 
 **1. 初期化**
 
@@ -191,8 +191,18 @@ picoclaw onboard
   },
   "tools": {
     "web": {
-      "search": {
+      "brave": {
+        "enabled": false,
         "api_key": "YOUR_BRAVE_API_KEY",
+        "max_results": 5
+      },
+      "exa": {
+        "enabled": false,
+        "api_key": "YOUR_EXA_API_KEY",
+        "max_results": 5
+      },
+      "duckduckgo": {
+        "enabled": true,
         "max_results": 5
       }
     }
@@ -207,7 +217,7 @@ picoclaw onboard
 **3. API キーの取得**
 
 - **LLM プロバイダー**: [OpenRouter](https://openrouter.ai/keys) · [Zhipu](https://open.bigmodel.cn/usercenter/proj-mgmt/apikeys) · [Anthropic](https://console.anthropic.com) · [OpenAI](https://platform.openai.com) · [Gemini](https://aistudio.google.com/api-keys)
-- **Web 検索**（任意）: [Brave Search](https://brave.com/search/api) - 無料枠あり（月 2000 リクエスト）
+- **Web 検索**（任意）: [Brave Search](https://brave.com/search/api) (月 2000 リクエスト無料) · [Exa Search](https://exa.ai) (無料 API キー)
 
 > **注意**: 完全な設定テンプレートは `config.example.json` を参照してください。
 
@@ -734,15 +744,23 @@ Discord: https://discord.gg/V4sAZ9XWpN
 検索 API キーをまだ設定していない場合、これは正常です。PicoClaw は手動検索用の便利なリンクを提供します。
 
 Web 検索を有効にするには：
-1. [https://brave.com/search/api](https://brave.com/search/api) で無料の API キーを取得（月 2000 クエリ無料）
-2. `~/.picoclaw/config.json` に追加：
+1. [Brave Search](https://brave.com/search/api) で無料の API キーを取得（月 2000 クエリ無料）
+2. または [Exa](https://exa.ai) で無料の API キーを取得（AI ネイティブ検索）
+3. `~/.picoclaw/config.json` に追加：
    ```json
    {
      "tools": {
        "web": {
-         "search": {
+         "brave": {
+           "enabled": false,
            "api_key": "YOUR_BRAVE_API_KEY",
            "max_results": 5
+         },
+         "exa": {
+           "enabled": false,
+           "api_key": "YOUR_EXA_API_KEY",
+           "max_results": 5,
+           "search_type": "auto"
          }
        }
      }
@@ -766,4 +784,5 @@ Web 検索を有効にするには：
 | **OpenRouter** | 月 200K トークン | 複数モデル（Claude, GPT-4 など） |
 | **Zhipu** | 月 200K トークン | 中国ユーザー向け最適 |
 | **Brave Search** | 月 2000 クエリ | Web 検索機能 |
+| **Exa Search** | 無料 API キー | AI ネイティブ Web 検索 |
 | **Groq** | 無料枠あり | 高速推論（Llama, Mixtral） |

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ docker compose --profile gateway up -d
 > [!TIP]
 > Set your API key in `~/.picoclaw/config.json`.
 > Get API keys: [OpenRouter](https://openrouter.ai/keys) (LLM) · [Zhipu](https://open.bigmodel.cn/usercenter/proj-mgmt/apikeys) (LLM)
-> Web search is **optional** - get free [Brave Search API](https://brave.com/search/api) (2000 free queries/month) or use built-in auto fallback.
+> Web search is **optional** - get free [Brave Search API](https://brave.com/search/api) (2000 free queries/month) or free [Exa Search API](https://exa.ai) (AI-native search), or use built-in auto fallback.
 
 **1. Initialize**
 
@@ -211,6 +211,11 @@ picoclaw onboard
         "api_key": "YOUR_BRAVE_API_KEY",
         "max_results": 5
       },
+      "exa": {
+        "enabled": false,
+        "api_key": "YOUR_EXA_API_KEY",
+        "max_results": 5
+      },
       "duckduckgo": {
         "enabled": true,
         "max_results": 5
@@ -223,7 +228,7 @@ picoclaw onboard
 **3. Get API Keys**
 
 * **LLM Provider**: [OpenRouter](https://openrouter.ai/keys) · [Zhipu](https://open.bigmodel.cn/usercenter/proj-mgmt/apikeys) · [Anthropic](https://console.anthropic.com) · [OpenAI](https://platform.openai.com) · [Gemini](https://aistudio.google.com/api-keys)
-* **Web Search** (optional): [Brave Search](https://brave.com/search/api) - Free tier available (2000 requests/month)
+* **Web Search** (optional): [Brave Search](https://brave.com/search/api) (2000 free requests/month) · [Exa Search](https://exa.ai) (free API key)
 
 > **Note**: See `config.example.json` for a complete configuration template.
 
@@ -753,6 +758,11 @@ picoclaw agent -m "Hello"
         "api_key": "BSA...",
         "max_results": 5
       },
+      "exa": {
+        "enabled": false,
+        "api_key": "YOUR_EXA_API_KEY",
+        "max_results": 5
+      },
       "duckduckgo": {
         "enabled": true,
         "max_results": 5
@@ -812,10 +822,11 @@ This is normal if you haven't configured a search API key yet. PicoClaw will pro
 
 To enable web search:
 
-1. **Option 1 (Recommended)**: Get a free API key at [https://brave.com/search/api](https://brave.com/search/api) (2000 free queries/month) for the best results.
-2. **Option 2 (No Credit Card)**: If you don't have a key, we automatically fall back to **DuckDuckGo** (no key required).
+1. **Option 1**: Get a free API key at [Brave Search](https://brave.com/search/api) (2000 free queries/month).
+2. **Option 2**: Get a free API key at [Exa](https://exa.ai) for AI-native neural search.
+3. **Option 3 (No Credit Card)**: If you don't have a key, we automatically fall back to **DuckDuckGo** (no key required).
 
-Add the key to `~/.picoclaw/config.json` if using Brave:
+Add the key to `~/.picoclaw/config.json`:
 
 ```json
 {
@@ -824,6 +835,11 @@ Add the key to `~/.picoclaw/config.json` if using Brave:
       "brave": {
         "enabled": false,
         "api_key": "YOUR_BRAVE_API_KEY",
+        "max_results": 5
+      },
+      "exa": {
+        "enabled": false,
+        "api_key": "YOUR_EXA_API_KEY",
         "max_results": 5
       },
       "duckduckgo": {
@@ -852,4 +868,5 @@ This happens when another instance of the bot is running. Make sure only one `pi
 | **OpenRouter**   | 200K tokens/month   | Multiple models (Claude, GPT-4, etc.) |
 | **Zhipu**        | 200K tokens/month   | Best for Chinese users                |
 | **Brave Search** | 2000 queries/month  | Web search functionality              |
+| **Exa Search**   | Free API key        | AI-native neural web search           |
 | **Groq**         | Free tier available | Fast inference (Llama, Mixtral)       |

--- a/README.zh.md
+++ b/README.zh.md
@@ -183,7 +183,7 @@ docker compose --profile gateway up -d
 > [!TIP]
 > 在 `~/.picoclaw/config.json` 中设置您的 API Key。
 > 获取 API Key: [OpenRouter](https://openrouter.ai/keys) (LLM) · [Zhipu (智谱)](https://open.bigmodel.cn/usercenter/proj-mgmt/apikeys) (LLM)
-> 网络搜索是 **可选的** - 获取免费的 [Brave Search API](https://brave.com/search/api) (每月 2000 次免费查询)
+> 网络搜索是 **可选的** - 获取免费的 [Brave Search API](https://brave.com/search/api) (每月 2000 次免费查询) 或免费的 [Exa Search API](https://exa.ai) (AI 原生搜索)
 
 **1. 初始化 (Initialize)**
 
@@ -213,8 +213,18 @@ picoclaw onboard
   },
   "tools": {
     "web": {
-      "search": {
+      "brave": {
+        "enabled": false,
         "api_key": "YOUR_BRAVE_API_KEY",
+        "max_results": 5
+      },
+      "exa": {
+        "enabled": false,
+        "api_key": "YOUR_EXA_API_KEY",
+        "max_results": 5
+      },
+      "duckduckgo": {
+        "enabled": true,
         "max_results": 5
       }
     }
@@ -226,7 +236,7 @@ picoclaw onboard
 **3. 获取 API Key**
 
 * **LLM 提供商**: [OpenRouter](https://openrouter.ai/keys) · [Zhipu](https://open.bigmodel.cn/usercenter/proj-mgmt/apikeys) · [Anthropic](https://console.anthropic.com) · [OpenAI](https://platform.openai.com) · [Gemini](https://aistudio.google.com/api-keys)
-* **网络搜索** (可选): [Brave Search](https://brave.com/search/api) - 提供免费层级 (2000 请求/月)
+* **网络搜索** (可选): [Brave Search](https://brave.com/search/api) (2000 请求/月) · [Exa Search](https://exa.ai) (免费 API Key)
 
 > **注意**: 完整的配置模板请参考 `config.example.json`。
 
@@ -681,14 +691,21 @@ Discord:  [https://discord.gg/V4sAZ9XWpN](https://discord.gg/V4sAZ9XWpN)
 
 启用网络搜索：
 
-1. 在 [https://brave.com/search/api](https://brave.com/search/api) 获取免费 API Key (每月 2000 次免费查询)
-2. 添加到 `~/.picoclaw/config.json`:
+1. 在 [Brave Search](https://brave.com/search/api) 获取免费 API Key (每月 2000 次免费查询)
+2. 或在 [Exa](https://exa.ai) 获取免费 API Key (AI 原生搜索)
+3. 添加到 `~/.picoclaw/config.json`:
 ```json
 {
   "tools": {
     "web": {
-      "search": {
+      "brave": {
+        "enabled": false,
         "api_key": "YOUR_BRAVE_API_KEY",
+        "max_results": 5
+      },
+      "exa": {
+        "enabled": false,
+        "api_key": "YOUR_EXA_API_KEY",
         "max_results": 5
       }
     }
@@ -716,4 +733,5 @@ Discord:  [https://discord.gg/V4sAZ9XWpN](https://discord.gg/V4sAZ9XWpN)
 | **OpenRouter** | 200K tokens/月 | 多模型聚合 (Claude, GPT-4 等) |
 | **智谱 (Zhipu)** | 200K tokens/月 | 最适合中国用户 |
 | **Brave Search** | 2000 次查询/月 | 网络搜索功能 |
+| **Exa Search** | 免费 API Key | AI 原生网络搜索 |
 | **Groq** | 提供免费层级 | 极速推理 (Llama, Mixtral) |

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -115,8 +115,14 @@
   },
   "tools": {
     "web": {
-      "search": {
+      "brave": {
+        "enabled": false,
         "api_key": "YOUR_BRAVE_API_KEY",
+        "max_results": 5
+      },
+      "exa": {
+        "enabled": false,
+        "api_key": "YOUR_EXA_API_KEY",
         "max_results": 5
       }
     }

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -75,6 +75,9 @@ func createToolRegistry(workspace string, restrict bool, cfg *config.Config, msg
 		BraveAPIKey:          cfg.Tools.Web.Brave.APIKey,
 		BraveMaxResults:      cfg.Tools.Web.Brave.MaxResults,
 		BraveEnabled:         cfg.Tools.Web.Brave.Enabled,
+		ExaAPIKey:            cfg.Tools.Web.Exa.APIKey,
+		ExaMaxResults:        cfg.Tools.Web.Exa.MaxResults,
+		ExaEnabled:           cfg.Tools.Web.Exa.Enabled,
 		DuckDuckGoMaxResults: cfg.Tools.Web.DuckDuckGo.MaxResults,
 		DuckDuckGoEnabled:    cfg.Tools.Web.DuckDuckGo.Enabled,
 	}); searchTool != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -201,6 +201,12 @@ type BraveConfig struct {
 	MaxResults int    `json:"max_results" env:"PICOCLAW_TOOLS_WEB_BRAVE_MAX_RESULTS"`
 }
 
+type ExaConfig struct {
+	Enabled    bool   `json:"enabled" env:"PICOCLAW_TOOLS_WEB_EXA_ENABLED"`
+	APIKey     string `json:"api_key" env:"PICOCLAW_TOOLS_WEB_EXA_API_KEY"`
+	MaxResults int    `json:"max_results" env:"PICOCLAW_TOOLS_WEB_EXA_MAX_RESULTS"`
+}
+
 type DuckDuckGoConfig struct {
 	Enabled    bool `json:"enabled" env:"PICOCLAW_TOOLS_WEB_DUCKDUCKGO_ENABLED"`
 	MaxResults int  `json:"max_results" env:"PICOCLAW_TOOLS_WEB_DUCKDUCKGO_MAX_RESULTS"`
@@ -208,6 +214,7 @@ type DuckDuckGoConfig struct {
 
 type WebToolsConfig struct {
 	Brave      BraveConfig      `json:"brave"`
+	Exa        ExaConfig        `json:"exa"`
 	DuckDuckGo DuckDuckGoConfig `json:"duckduckgo"`
 }
 
@@ -313,6 +320,11 @@ func DefaultConfig() *Config {
 		Tools: ToolsConfig{
 			Web: WebToolsConfig{
 				Brave: BraveConfig{
+					Enabled:    false,
+					APIKey:     "",
+					MaxResults: 5,
+				},
+				Exa: ExaConfig{
 					Enabled:    false,
 					APIKey:     "",
 					MaxResults: 5,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -142,6 +142,12 @@ func TestDefaultConfig_WebTools(t *testing.T) {
 	if cfg.Tools.Web.Brave.APIKey != "" {
 		t.Error("Brave API key should be empty by default")
 	}
+	if cfg.Tools.Web.Exa.MaxResults != 5 {
+		t.Error("Expected Exa MaxResults 5, got ", cfg.Tools.Web.Exa.MaxResults)
+	}
+	if cfg.Tools.Web.Exa.APIKey != "" {
+		t.Error("Exa API key should be empty by default")
+	}
 	if cfg.Tools.Web.DuckDuckGo.MaxResults != 5 {
 		t.Error("Expected DuckDuckGo MaxResults 5, got ", cfg.Tools.Web.DuckDuckGo.MaxResults)
 	}

--- a/pkg/migrate/config.go
+++ b/pkg/migrate/config.go
@@ -279,6 +279,9 @@ func MergeConfig(existing, incoming *config.Config) *config.Config {
 	if existing.Tools.Web.Brave.APIKey == "" {
 		existing.Tools.Web.Brave = incoming.Tools.Web.Brave
 	}
+	if existing.Tools.Web.Exa.APIKey == "" {
+		existing.Tools.Web.Exa = incoming.Tools.Web.Exa
+	}
 
 	return existing
 }

--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -78,6 +79,78 @@ func (p *BraveSearchProvider) Search(ctx context.Context, query string, count in
 		lines = append(lines, fmt.Sprintf("%d. %s\n   %s", i+1, item.Title, item.URL))
 		if item.Description != "" {
 			lines = append(lines, fmt.Sprintf("   %s", item.Description))
+		}
+	}
+
+	return strings.Join(lines, "\n"), nil
+}
+
+type ExaSearchProvider struct {
+	apiKey string
+}
+
+func (p *ExaSearchProvider) Search(ctx context.Context, query string, count int) (string, error) {
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"query":      query,
+		"numResults": count,
+		"contents": map[string]interface{}{
+			"text": map[string]interface{}{
+				"maxCharacters": 10000,
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.exa.ai/search", bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", p.apiKey)
+	req.Header.Set("x-exa-integration", "picoclaw")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var searchResp struct {
+		Results []struct {
+			Title string `json:"title"`
+			URL   string `json:"url"`
+			Text  string `json:"text"`
+		} `json:"results"`
+	}
+
+	if err := json.Unmarshal(body, &searchResp); err != nil {
+		fmt.Printf("Exa API Error Body: %s\n", string(body))
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	results := searchResp.Results
+	if len(results) == 0 {
+		return fmt.Sprintf("No results for: %s", query), nil
+	}
+
+	var lines []string
+	lines = append(lines, fmt.Sprintf("Results for: %s", query))
+	for i, item := range results {
+		if i >= count {
+			break
+		}
+		lines = append(lines, fmt.Sprintf("%d. %s\n   %s", i+1, item.Title, item.URL))
+		if item.Text != "" {
+			lines = append(lines, fmt.Sprintf("   %s", item.Text))
 		}
 	}
 
@@ -185,6 +258,9 @@ type WebSearchToolOptions struct {
 	BraveAPIKey          string
 	BraveMaxResults      int
 	BraveEnabled         bool
+	ExaAPIKey            string
+	ExaMaxResults        int
+	ExaEnabled           bool
 	DuckDuckGoMaxResults int
 	DuckDuckGoEnabled    bool
 }
@@ -193,11 +269,16 @@ func NewWebSearchTool(opts WebSearchToolOptions) *WebSearchTool {
 	var provider SearchProvider
 	maxResults := 5
 
-	// Priority: Brave > DuckDuckGo
+	// Priority: Brave > Exa > DuckDuckGo
 	if opts.BraveEnabled && opts.BraveAPIKey != "" {
 		provider = &BraveSearchProvider{apiKey: opts.BraveAPIKey}
 		if opts.BraveMaxResults > 0 {
 			maxResults = opts.BraveMaxResults
+		}
+	} else if opts.ExaEnabled && opts.ExaAPIKey != "" {
+		provider = &ExaSearchProvider{apiKey: opts.ExaAPIKey}
+		if opts.ExaMaxResults > 0 {
+			maxResults = opts.ExaMaxResults
 		}
 	} else if opts.DuckDuckGoEnabled {
 		provider = &DuckDuckGoSearchProvider{}


### PR DESCRIPTION
Add ExaSearchProvider implementing the SearchProvider interface, using the Exa AI neural search API (api.exa.ai) with inline highlights for content snippets. Provider priority is Brave > Exa > DuckDuckGo.

Changes:
- New ExaSearchProvider with POST-based API, x-api-key auth, and x-exa-integration header
- ExaConfig with enabled, api_key, max_results fields
- Configurable via JSON config or env vars (PICOCLAW_TOOLS_WEB_EXA_*)
- Config migration support for Exa settings
- Unit tests for provider creation, priority, and missing key handling
- Updated all READMEs (en, ja, zh), config examples, and .env.example