### PR TITLE
fix: env overrides when config.json is missing and add regression test

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -340,6 +340,9 @@ func LoadConfig(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			if err := env.Parse(cfg); err != nil {
+				return nil, err
+			}
 			return cfg, nil
 		}
 		return nil, err

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -10,6 +11,21 @@ func TestDefaultConfig_HeartbeatEnabled(t *testing.T) {
 
 	if !cfg.Heartbeat.Enabled {
 		t.Error("Heartbeat should be enabled by default")
+	}
+}
+
+// TestLoadConfig_EnvOverridesWithoutFile ensures env vars are applied when the config file is missing.
+func TestLoadConfig_EnvOverridesWithoutFile(t *testing.T) {
+	t.Setenv("PICOCLAW_AGENTS_DEFAULTS_MODEL", "env-model")
+
+	missing := filepath.Join(t.TempDir(), "missing.json")
+	cfg, err := LoadConfig(missing)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if got := cfg.Agents.Defaults.Model; got != "env-model" {
+		t.Fatalf("expected model from env, got %q", got)
 	}
 }
 


### PR DESCRIPTION
- **Problem**: When config.json is absent (common in Fly deployments using secrets/env only), LoadConfig returned defaults without applying env overrides, so the app still used the default model (glm-4.7) and failed due to missing credentials.
- **Fix**: Always run env.Parse(cfg) even when config.json is missing, so secrets/env values take effect in env-only deployments.
- **Test**: Added TestLoadConfig_EnvOverridesWithoutFile to verify env vars (e.g., Fly secrets for model/provider) are honored without a config file.