### PR TITLE
fix(codex): omit max_output_tokens for ChatGPT codex backend

### DIFF
--- a/pkg/providers/codex_provider.go
+++ b/pkg/providers/codex_provider.go
@@ -260,9 +260,8 @@ func buildCodexParams(messages []Message, tools []ToolDefinition, model string, 
 		params.Instructions = openai.Opt(defaultCodexInstructions)
 	}
 
-	if maxTokens, ok := options["max_tokens"].(int); ok {
-		params.MaxOutputTokens = openai.Opt(int64(maxTokens))
-	}
+	// ChatGPT Codex backend currently rejects max_output_tokens with 400.
+	// Keep token budgeting at the agent layer for this provider.
 
 	if len(tools) > 0 {
 		params.Tools = translateToolsForCodex(tools)

--- a/pkg/providers/codex_provider_test.go
+++ b/pkg/providers/codex_provider_test.go
@@ -29,6 +29,9 @@ func TestBuildCodexParams_BasicMessage(t *testing.T) {
 	if params.Instructions.Or("") != defaultCodexInstructions {
 		t.Errorf("Instructions = %q, want %q", params.Instructions.Or(""), defaultCodexInstructions)
 	}
+	if params.MaxOutputTokens.Valid() {
+		t.Errorf("MaxOutputTokens should be omitted for codex backend, got %d", params.MaxOutputTokens.Or(0))
+	}
 }
 
 func TestBuildCodexParams_SystemAsInstructions(t *testing.T) {
@@ -423,6 +426,8 @@ func TestResolveCodexModel(t *testing.T) {
 		{name: "empty", input: "", wantModel: codexDefaultModel, wantFallback: true},
 		{name: "unsupported namespace", input: "anthropic/claude-3.5", wantModel: codexDefaultModel, wantFallback: true},
 		{name: "non-openai prefixed", input: "glm-4.7", wantModel: codexDefaultModel, wantFallback: true},
+		{name: "codex alias", input: "gpt-5.3-codex", wantModel: "gpt-5.3-codex", wantFallback: false},
+		{name: "codex alias with openai prefix", input: "openai/gpt-5.3-codex", wantModel: "gpt-5.3-codex", wantFallback: false},
 		{name: "openai prefix", input: "openai/gpt-5.2", wantModel: "gpt-5.2", wantFallback: false},
 		{name: "direct gpt", input: "gpt-4o", wantModel: "gpt-4o", wantFallback: false},
 	}


### PR DESCRIPTION
## Summary
- stop sending `max_output_tokens` in Codex provider requests
- keep model aliases like `gpt-5.3-codex` unchanged
- add a regression assertion that `MaxOutputTokens` is omitted in codex params

## Why
ChatGPT codex backend currently rejects `max_output_tokens` with HTTP 400 (`Unsupported parameter: max_output_tokens`).

Fixes #279

## Testing
- go test ./pkg/providers -run 'TestResolveCodexModel|TestBuildCodexParams_BasicMessage|TestCodexProvider_ChatRoundTrip'
- manual: `go run ./cmd/picoclaw agent -m "hi"`
