### PR TITLE
Replace \s+ with [^\S\n]+ to preserve newlines

### DIFF
--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -419,8 +419,10 @@ func (t *WebFetchTool) extractText(htmlContent string) string {
 
 	result = strings.TrimSpace(result)
 
-	re = regexp.MustCompile(`\s+`)
-	result = re.ReplaceAllLiteralString(result, " ")
+	re = regexp.MustCompile(`[^\S\n]+`)
+	result = re.ReplaceAllString(result, " ")
+	re = regexp.MustCompile(`\n{3,}`)
+	result = re.ReplaceAllString(result, "\n\n")
 
 	lines := strings.Split(result, "\n")
 	var cleanLines []string


### PR DESCRIPTION
`extractText` in `pkg/tools/web.go` replaces all whitespace (including newlines) with a single space using `\s+`, then tries to split by `\n` to filter empty lines. Since all newlines are already gone, the output is always a single line.