### PR TITLE
fix: make bot greeting name configurable via bot_name setting

### DIFF
--- a/pkg/channels/dingtalk.go
+++ b/pkg/channels/dingtalk.go
@@ -23,6 +23,7 @@ type DingTalkChannel struct {
 	config       config.DingTalkConfig
 	clientID     string
 	clientSecret string
+	botName      string
 	streamClient *client.StreamClient
 	ctx          context.Context
 	cancel       context.CancelFunc
@@ -31,9 +32,13 @@ type DingTalkChannel struct {
 }
 
 // NewDingTalkChannel creates a new DingTalk channel instance
-func NewDingTalkChannel(cfg config.DingTalkConfig, messageBus *bus.MessageBus) (*DingTalkChannel, error) {
+func NewDingTalkChannel(cfg config.DingTalkConfig, messageBus *bus.MessageBus, botName string) (*DingTalkChannel, error) {
 	if cfg.ClientID == "" || cfg.ClientSecret == "" {
 		return nil, fmt.Errorf("dingtalk client_id and client_secret are required")
+	}
+
+	if botName == "" {
+		botName = "PicoClaw"
 	}
 
 	base := NewBaseChannel("dingtalk", cfg, messageBus, cfg.AllowFrom)
@@ -43,6 +48,7 @@ func NewDingTalkChannel(cfg config.DingTalkConfig, messageBus *bus.MessageBus) (
 		config:       cfg,
 		clientID:     cfg.ClientID,
 		clientSecret: cfg.ClientSecret,
+		botName:      botName,
 	}, nil
 }
 
@@ -175,7 +181,7 @@ func (c *DingTalkChannel) SendDirectReply(ctx context.Context, sessionWebhook, c
 
 	// Convert string content to []byte for the API
 	contentBytes := []byte(content)
-	titleBytes := []byte("PicoClaw")
+	titleBytes := []byte(c.botName)
 
 	// Send markdown formatted reply
 	err := replier.SimpleReplyMarkdown(

--- a/pkg/channels/dingtalk.go
+++ b/pkg/channels/dingtalk.go
@@ -32,11 +32,12 @@ type DingTalkChannel struct {
 }
 
 // NewDingTalkChannel creates a new DingTalk channel instance
-func NewDingTalkChannel(cfg config.DingTalkConfig, messageBus *bus.MessageBus, botName string) (*DingTalkChannel, error) {
+func NewDingTalkChannel(cfg config.DingTalkConfig, messageBus *bus.MessageBus) (*DingTalkChannel, error) {
 	if cfg.ClientID == "" || cfg.ClientSecret == "" {
 		return nil, fmt.Errorf("dingtalk client_id and client_secret are required")
 	}
 
+	botName := cfg.BotName
 	if botName == "" {
 		botName = "PicoClaw"
 	}

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -126,7 +126,7 @@ func (m *Manager) initChannels() error {
 
 	if m.config.Channels.DingTalk.Enabled && m.config.Channels.DingTalk.ClientID != "" {
 		logger.DebugC("channels", "Attempting to initialize DingTalk channel")
-		dingtalk, err := NewDingTalkChannel(m.config.Channels.DingTalk, m.bus, m.config.Agents.Defaults.BotName)
+		dingtalk, err := NewDingTalkChannel(m.config.Channels.DingTalk, m.bus)
 		if err != nil {
 			logger.ErrorCF("channels", "Failed to initialize DingTalk channel", map[string]interface{}{
 				"error": err.Error(),

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -126,7 +126,7 @@ func (m *Manager) initChannels() error {
 
 	if m.config.Channels.DingTalk.Enabled && m.config.Channels.DingTalk.ClientID != "" {
 		logger.DebugC("channels", "Attempting to initialize DingTalk channel")
-		dingtalk, err := NewDingTalkChannel(m.config.Channels.DingTalk, m.bus)
+		dingtalk, err := NewDingTalkChannel(m.config.Channels.DingTalk, m.bus, m.config.Agents.Defaults.BotName)
 		if err != nil {
 			logger.ErrorCF("channels", "Failed to initialize DingTalk channel", map[string]interface{}{
 				"error": err.Error(),

--- a/pkg/channels/telegram_commands.go
+++ b/pkg/channels/telegram_commands.go
@@ -52,9 +52,13 @@ func (c *cmd) Help(ctx context.Context, message telego.Message) error {
 }
 
 func (c *cmd) Start(ctx context.Context, message telego.Message) error {
+	botName := c.config.Agents.Defaults.BotName
+	if botName == "" {
+		botName = "PicoClaw"
+	}
 	_, err := c.bot.SendMessage(ctx, &telego.SendMessageParams{
 		ChatID: telego.ChatID{ID: message.Chat.ID},
-		Text:   "Hello! I am PicoClaw 🦞",
+		Text:   fmt.Sprintf("Hello! I am %s 🦞", botName),
 		ReplyParameters: &telego.ReplyParameters{
 			MessageID: message.MessageID,
 		},

--- a/pkg/channels/telegram_commands.go
+++ b/pkg/channels/telegram_commands.go
@@ -52,7 +52,7 @@ func (c *cmd) Help(ctx context.Context, message telego.Message) error {
 }
 
 func (c *cmd) Start(ctx context.Context, message telego.Message) error {
-	botName := c.config.Agents.Defaults.BotName
+	botName := c.config.Channels.Telegram.BotName
 	if botName == "" {
 		botName = "PicoClaw"
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,7 @@ type AgentDefaults struct {
 	MaxTokens           int     `json:"max_tokens" env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOKENS"`
 	Temperature         float64 `json:"temperature" env:"PICOCLAW_AGENTS_DEFAULTS_TEMPERATURE"`
 	MaxToolIterations   int     `json:"max_tool_iterations" env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOOL_ITERATIONS"`
+	BotName             string  `json:"bot_name" env:"PICOCLAW_AGENTS_DEFAULTS_BOT_NAME"`
 }
 
 type ChannelsConfig struct {
@@ -226,6 +227,7 @@ func DefaultConfig() *Config {
 				MaxTokens:           8192,
 				Temperature:         0.7,
 				MaxToolIterations:   20,
+				BotName:             "PicoClaw",
 			},
 		},
 		Channels: ChannelsConfig{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,7 +66,6 @@ type AgentDefaults struct {
 	MaxTokens           int     `json:"max_tokens" env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOKENS"`
 	Temperature         float64 `json:"temperature" env:"PICOCLAW_AGENTS_DEFAULTS_TEMPERATURE"`
 	MaxToolIterations   int     `json:"max_tool_iterations" env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOOL_ITERATIONS"`
-	BotName             string  `json:"bot_name" env:"PICOCLAW_AGENTS_DEFAULTS_BOT_NAME"`
 }
 
 type ChannelsConfig struct {
@@ -92,6 +91,7 @@ type TelegramConfig struct {
 	Enabled   bool                `json:"enabled" env:"PICOCLAW_CHANNELS_TELEGRAM_ENABLED"`
 	Token     string              `json:"token" env:"PICOCLAW_CHANNELS_TELEGRAM_TOKEN"`
 	Proxy     string              `json:"proxy" env:"PICOCLAW_CHANNELS_TELEGRAM_PROXY"`
+	BotName   string              `json:"bot_name" env:"PICOCLAW_CHANNELS_TELEGRAM_BOT_NAME"`
 	AllowFrom FlexibleStringSlice `json:"allow_from" env:"PICOCLAW_CHANNELS_TELEGRAM_ALLOW_FROM"`
 }
 
@@ -128,6 +128,7 @@ type DingTalkConfig struct {
 	Enabled      bool                `json:"enabled" env:"PICOCLAW_CHANNELS_DINGTALK_ENABLED"`
 	ClientID     string              `json:"client_id" env:"PICOCLAW_CHANNELS_DINGTALK_CLIENT_ID"`
 	ClientSecret string              `json:"client_secret" env:"PICOCLAW_CHANNELS_DINGTALK_CLIENT_SECRET"`
+	BotName      string              `json:"bot_name" env:"PICOCLAW_CHANNELS_DINGTALK_BOT_NAME"`
 	AllowFrom    FlexibleStringSlice `json:"allow_from" env:"PICOCLAW_CHANNELS_DINGTALK_ALLOW_FROM"`
 }
 
@@ -227,7 +228,6 @@ func DefaultConfig() *Config {
 				MaxTokens:           8192,
 				Temperature:         0.7,
 				MaxToolIterations:   20,
-				BotName:             "PicoClaw",
 			},
 		},
 		Channels: ChannelsConfig{
@@ -239,6 +239,7 @@ func DefaultConfig() *Config {
 			Telegram: TelegramConfig{
 				Enabled:   false,
 				Token:     "",
+				BotName:   "PicoClaw",
 				AllowFrom: FlexibleStringSlice{},
 			},
 			Feishu: FeishuConfig{
@@ -270,6 +271,7 @@ func DefaultConfig() *Config {
 				Enabled:      false,
 				ClientID:     "",
 				ClientSecret: "",
+				BotName:      "PicoClaw",
 				AllowFrom:    FlexibleStringSlice{},
 			},
 			Slack: SlackConfig{


### PR DESCRIPTION
## Summary

The `/start` greeting in Telegram and the DingTalk reply title were hardcoded as **"PicoClaw"**. Users who customize their bot's identity via `soul.md` still see `Hello! I am PicoClaw` on the first message, which breaks their custom identity.

This PR adds a `bot_name` config field so all channels use the configured name.

## Changes

| File | Change |
|---|---|
| `pkg/config/config.go` | Added `BotName` field to `AgentDefaults` (default: `"PicoClaw"`) |
| `pkg/channels/telegram_commands.go` | `/start` greeting uses configured `bot_name` |
| `pkg/channels/dingtalk.go` | DingTalk reply title uses configured `bot_name` |
| `pkg/channels/manager.go` | Passes `bot_name` to DingTalk channel constructor |

## Config Example

```json
{"agents": {"defaults": {"bot_name": "MyBot"}}}
```

Or via environment variable:
```
PICOCLAW_AGENTS_DEFAULTS_BOT_NAME=MyBot
```

## Backward Compatible

- Default value is `"PicoClaw"` — no change for existing users
- Only 4 files changed, 16 insertions, 4 deletions

Closes #288