### PR TITLE
feat: add Gemini CLI auth login support

### DIFF
--- a/cmd/picoclaw/main.go
+++ b/cmd/picoclaw/main.go
@@ -789,13 +789,14 @@ func authHelp() {
 	fmt.Println("  status      Show current auth status")
 	fmt.Println()
 	fmt.Println("Login options:")
-	fmt.Println("  --provider <name>    Provider to login with (openai, anthropic)")
+	fmt.Println("  --provider <name>    Provider to login with (openai, anthropic, gemini)")
 	fmt.Println("  --device-code        Use device code flow (for headless environments)")
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  picoclaw auth login --provider openai")
 	fmt.Println("  picoclaw auth login --provider openai --device-code")
 	fmt.Println("  picoclaw auth login --provider anthropic")
+	fmt.Println("  picoclaw auth login --provider gemini")
 	fmt.Println("  picoclaw auth logout --provider openai")
 	fmt.Println("  picoclaw auth status")
 }
@@ -819,18 +820,18 @@ func authLoginCmd() {
 
 	if provider == "" {
 		fmt.Println("Error: --provider is required")
-		fmt.Println("Supported providers: openai, anthropic")
+		fmt.Println("Supported providers: openai, anthropic, gemini")
 		return
 	}
 
 	switch provider {
 	case "openai":
 		authLoginOpenAI(useDeviceCode)
-	case "anthropic":
+	case "anthropic", "gemini":
 		authLoginPasteToken(provider)
 	default:
 		fmt.Printf("Unsupported provider: %s\n", provider)
-		fmt.Println("Supported providers: openai, anthropic")
+		fmt.Println("Supported providers: openai, anthropic, gemini")
 	}
 }
 
@@ -889,6 +890,8 @@ func authLoginPasteToken(provider string) {
 			appCfg.Providers.Anthropic.AuthMethod = "token"
 		case "openai":
 			appCfg.Providers.OpenAI.AuthMethod = "token"
+		case "gemini":
+			appCfg.Providers.Gemini.AuthMethod = "token"
 		}
 		if err := config.SaveConfig(getConfigPath(), appCfg); err != nil {
 			fmt.Printf("Warning: could not update config: %v\n", err)
@@ -925,6 +928,8 @@ func authLogoutCmd() {
 				appCfg.Providers.OpenAI.AuthMethod = ""
 			case "anthropic":
 				appCfg.Providers.Anthropic.AuthMethod = ""
+			case "gemini":
+				appCfg.Providers.Gemini.AuthMethod = ""
 			}
 			config.SaveConfig(getConfigPath(), appCfg)
 		}
@@ -940,6 +945,7 @@ func authLogoutCmd() {
 		if err == nil {
 			appCfg.Providers.OpenAI.AuthMethod = ""
 			appCfg.Providers.Anthropic.AuthMethod = ""
+			appCfg.Providers.Gemini.AuthMethod = ""
 			config.SaveConfig(getConfigPath(), appCfg)
 		}
 

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -37,6 +37,8 @@ func providerDisplayName(provider string) string {
 		return "console.anthropic.com"
 	case "openai":
 		return "platform.openai.com"
+	case "gemini":
+		return "aistudio.google.com/apikey"
 	default:
 		return provider
 	}


### PR DESCRIPTION
## Summary

Adds **Gemini (Google AI)** as a supported provider for CLI authentication, enabling users to securely store and use their Gemini API key.

## Usage

```bash
# Login (paste API key from aistudio.google.com/apikey)
picoclaw auth login --provider gemini

# Check status
picoclaw auth status

# Logout
picoclaw auth logout --provider gemini
```

The API key is stored securely in `~/.picoclaw/auth.json` and loaded automatically when the provider is configured with `auth_method: "token"`.

## Changes

| File | Change |
|---|---|
| `pkg/auth/token.go` | Added Gemini display name (`aistudio.google.com/apikey`) |
| `cmd/picoclaw/main.go` | Wired Gemini into login, logout, help commands |
| `pkg/providers/http_provider.go` | Load Gemini API key from auth store when `auth_method` is `token` (both explicit provider and model-name fallback) |

## How it works

1. User runs `picoclaw auth login --provider gemini`
2. Prompted to paste API key from Google AI Studio
3. Key is stored in `~/.picoclaw/auth.json`
4. Config is updated with `auth_method: "token"`
5. On next run, the Gemini provider loads the key from the auth store

## Backward Compatible

- Existing `api_key` in config continues to work (takes priority)
- Only 3 files changed, 38 insertions, 8 deletions

Closes #267