### PR TITLE
fix(gemini): Implement Gemini 3 thought_signature handling for stateful reasoning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,19 @@
 # ============================================================
 FROM golang:1.26.0-alpine AS builder
 
-RUN apk add --no-cache git make
+# Install build dependencies
+RUN apk add --no-cache git make gcc musl-dev
 
 WORKDIR /src
 
-# Cache dependencies
+# Cache dependencies for faster subsequent builds
 COPY go.mod go.sum ./
 RUN go mod download
 
-# Copy source and build
+# Copy your local source code (where you'll add the Thought Signature fix)
 COPY . .
+
+# Compile the binary
 RUN make build
 
 # ============================================================
@@ -20,17 +23,19 @@ RUN make build
 # ============================================================
 FROM alpine:3.23
 
+# Install runtime essentials
 RUN apk add --no-cache ca-certificates tzdata curl
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget -q --spider http://localhost:18790/health || exit 1
 
-# Copy binary
+# Copy the compiled binary from the builder stage
 COPY --from=builder /src/build/picoclaw /usr/local/bin/picoclaw
 
-# Create picoclaw home directory
+# Create necessary directories and initialize
 RUN /usr/local/bin/picoclaw onboard
 
+# Set the binary as the entrypoint
 ENTRYPOINT ["picoclaw"]
 CMD ["gateway"]

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -621,13 +621,19 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.M
 		}
 		for _, tc := range response.ToolCalls {
 			argumentsJSON, _ := json.Marshal(tc.Arguments)
+			// Copy ExtraContent to ensure thought_signature is persisted
+			extraContent := tc.ExtraContent
+			
 			assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, providers.ToolCall{
 				ID:   tc.ID,
 				Type: "function",
 				Function: &providers.FunctionCall{
-					Name:      tc.Name,
-					Arguments: string(argumentsJSON),
+					Name:             tc.Name,
+					Arguments:        string(argumentsJSON),
 				},
+				ExtraContent: extraContent,
+				// We also set internal ThoughtSignature, but ExtraContent is what matters for serialization
+				ThoughtSignature: tc.ThoughtSignature, 
 			})
 		}
 		messages = append(messages, assistantMsg)

--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -3,16 +3,27 @@ package providers
 import "context"
 
 type ToolCall struct {
-	ID        string                 `json:"id"`
-	Type      string                 `json:"type,omitempty"`
-	Function  *FunctionCall          `json:"function,omitempty"`
-	Name      string                 `json:"name,omitempty"`
-	Arguments map[string]interface{} `json:"arguments,omitempty"`
+	ID               string                 `json:"id"`
+	Type             string                 `json:"type,omitempty"`
+	Function         *FunctionCall          `json:"function,omitempty"`
+	Name             string                 `json:"name,omitempty"`
+	Arguments        map[string]interface{} `json:"arguments,omitempty"`
+	ThoughtSignature string                 `json:"-"` // Internal use only
+	ExtraContent     *ExtraContent          `json:"extra_content,omitempty"`
+}
+
+type ExtraContent struct {
+	Google *GoogleExtra `json:"google,omitempty"`
+}
+
+type GoogleExtra struct {
+	ThoughtSignature string `json:"thought_signature,omitempty"`
 }
 
 type FunctionCall struct {
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"`
+	Name             string `json:"name"`
+	Arguments        string `json:"arguments"`
+	ThoughtSignature string `json:"-"` // Internal use only
 }
 
 type LLMResponse struct {


### PR DESCRIPTION
### Description
This PR addresses a critical compatibility issue with Gemini 3 models (specifically `gemini-3-flash-preview` and `gemini-3-pro-preview`) where tool calls would fail with a 400 `INVALID_ARGUMENT` error due to missing `thought_signature`.

According to Google's [Stateful Reasoning documentation](https://ai.google.dev/gemini-api/docs/thought-signatures), Gemini 3 generates encrypted `thought_signature` tokens during reasoning steps involving tools. These signatures must be persisted and returned in the subsequent conversation turn's `extra_content` field to maintain the reasoning chain. Failure to include them causes the API to reject the request.

### Changes
- **[pkg/providers/types.go](cci:7://file:///home/andrewq/picoclaw-dev/pkg/providers/types.go:0:0-0:0)**: 
  - Added [ExtraContent](cci:2://file:///home/andrewq/picoclaw-dev/pkg/providers/types.go:14:0-16:1) and [GoogleExtra](cci:2://file:///home/andrewq/picoclaw-dev/pkg/providers/types.go:18:0-20:1) structs to support the `extra_content` JSON field.
  - Added internal [ThoughtSignature](cci:1://file:///home/andrewq/picoclaw-dev/pkg/providers/gemini_integration_test.go:9:0-90:1) fields to [ToolCall](cci:2://file:///home/andrewq/picoclaw-dev/pkg/providers/types.go:4:0-12:1) and [FunctionCall](cci:2://file:///home/andrewq/picoclaw-dev/pkg/providers/types.go:22:0-26:1) to track this data internally.
- **[pkg/providers/http_provider.go](cci:7://file:///home/andrewq/picoclaw-dev/pkg/providers/http_provider.go:0:0-0:0)**: 
  - Updated [parseResponse](cci:1://file:///home/andrewq/picoclaw-dev/pkg/providers/http_provider.go:127:0-217:1) to extract the `thought_signature` from the `extra_content.google` field in the API response.
  - Ensured the [ExtraContent](cci:2://file:///home/andrewq/picoclaw-dev/pkg/providers/types.go:14:0-16:1) is correctly populated in the [ToolCall](cci:2://file:///home/andrewq/picoclaw-dev/pkg/providers/types.go:4:0-12:1) object.
- **[pkg/agent/loop.go](cci:7://file:///home/andrewq/picoclaw-dev/pkg/agent/loop.go:0:0-0:0)**: 
  - Updated the main agent loop to persist [ExtraContent](cci:2://file:///home/andrewq/picoclaw-dev/pkg/providers/types.go:14:0-16:1) when constructing the assistant's message history. This ensures the signature is included in the context window for the next turn.

### Verification
- **Test Environment**: Verified locally using `gemini-3-flash-preview`.
- **Scenario**: Executed multi-step tool calls (e.g., `list_dir`).
- **Result**: 
  - Before fix: API returned 400 `Function call is missing a thought_signature`.
  - After fix: Tool calls execute successfully, and the model maintains context across multiple turns without error.

### Related Issues
Fixes 400 error with Gemini 3 models.