### PR TITLE
fix: add missing nvidia case in explicit provider switch

### DIFF
--- a/pkg/providers/http_provider.go
+++ b/pkg/providers/http_provider.go
@@ -322,7 +322,15 @@ func CreateProvider(cfg *config.Config) (LLMProvider, error) {
 				apiBase = "localhost:4321"
 			}
 			return NewGitHubCopilotProvider(apiBase, cfg.Providers.GitHubCopilot.ConnectMode, model)
-
+		case "nvidia":
+			if cfg.Providers.Nvidia.APIKey != "" {
+				apiKey = cfg.Providers.Nvidia.APIKey
+				apiBase = cfg.Providers.Nvidia.APIBase
+				proxy = cfg.Providers.Nvidia.Proxy
+				if apiBase == "" {
+					apiBase = "https://integrate.api.nvidia.com/v1"
+				}
+			}
 		}
 
 	}


### PR DESCRIPTION
## Summary

- The `nvidia` provider is defined in `ProvidersConfig` and handled in the model-name fallback detection, but was missing from the explicit provider switch in `CreateProvider()`
- Setting `PICOCLAW_AGENTS_DEFAULTS_PROVIDER=nvidia` silently falls through to the fallback, which only matches if the model name contains "nvidia" — models like `meta/llama-3.1-405b-instruct` on NVIDIA's API are never matched
- Adds `case "nvidia":` to resolve API key, base URL, and proxy from `cfg.Providers.Nvidia`, consistent with all other providers

## Test plan

- [ ] Set `provider: "nvidia"` and a non-nvidia model name (e.g. `meta/llama-3.1-405b-instruct`)
- [ ] Verify the agent connects and responds successfully
- [ ] Verify existing model-name fallback still works when no explicit provider is set