### PR TITLE
fix issue with tool calling using gemini 3.0 pro perview

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -622,8 +622,9 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.M
 		for _, tc := range response.ToolCalls {
 			argumentsJSON, _ := json.Marshal(tc.Arguments)
 			assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, providers.ToolCall{
-				ID:   tc.ID,
-				Type: "function",
+				ID:           tc.ID,
+				Type:         "function",
+				ExtraContent: tc.ExtraContent,
 				Function: &providers.FunctionCall{
 					Name:      tc.Name,
 					Arguments: string(argumentsJSON),

--- a/pkg/providers/http_provider.go
+++ b/pkg/providers/http_provider.go
@@ -129,8 +129,13 @@ func (p *HTTPProvider) parseResponse(body []byte) (*LLMResponse, error) {
 			Message struct {
 				Content   string `json:"content"`
 				ToolCalls []struct {
-					ID       string `json:"id"`
-					Type     string `json:"type"`
+					ID           string `json:"id"`
+					Type         string `json:"type"`
+					ExtraContent struct {
+						Google struct {
+							ThoughtSignature string `json:"thought_signature,omitempty"`
+						} `json:"google,omitempty"`
+					} `json:"extra_content,omitempty"`
 					Function *struct {
 						Name      string `json:"name"`
 						Arguments string `json:"arguments"`
@@ -179,7 +184,12 @@ func (p *HTTPProvider) parseResponse(body []byte) (*LLMResponse, error) {
 		}
 
 		toolCalls = append(toolCalls, ToolCall{
-			ID:        tc.ID,
+			ID: tc.ID,
+			ExtraContent: ExtraContent{
+				Google: GoogleExtraContent{
+					ThoughtSignature: tc.ExtraContent.Google.ThoughtSignature,
+				},
+			},
 			Name:      name,
 			Arguments: arguments,
 		})

--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -1,13 +1,24 @@
 package providers
 
-import "context"
+import (
+	"context"
+)
 
 type ToolCall struct {
-	ID        string                 `json:"id"`
-	Type      string                 `json:"type,omitempty"`
-	Function  *FunctionCall          `json:"function,omitempty"`
-	Name      string                 `json:"name,omitempty"`
-	Arguments map[string]interface{} `json:"arguments,omitempty"`
+	ID           string                 `json:"id"`
+	Type         string                 `json:"type,omitempty"`
+	ExtraContent ExtraContent           `json:"extra_content,omitempty"`
+	Function     *FunctionCall          `json:"function,omitempty"`
+	Name         string                 `json:"name,omitempty"`
+	Arguments    map[string]interface{} `json:"arguments,omitempty"`
+}
+
+type ExtraContent struct {
+	Google GoogleExtraContent `json:"google,omitempty"`
+}
+
+type GoogleExtraContent struct {
+	ThoughtSignature string `json:"thought_signature,omitempty"`
 }
 
 type FunctionCall struct {

--- a/pkg/tools/types.go
+++ b/pkg/tools/types.go
@@ -10,11 +10,20 @@ type Message struct {
 }
 
 type ToolCall struct {
-	ID        string                 `json:"id"`
-	Type      string                 `json:"type"`
-	Function  *FunctionCall          `json:"function,omitempty"`
-	Name      string                 `json:"name,omitempty"`
-	Arguments map[string]interface{} `json:"arguments,omitempty"`
+	ID           string                 `json:"id"`
+	Type         string                 `json:"type"`
+	ExtraContent ExtraContent           `json:"extra_content,omitempty"`
+	Function     *FunctionCall          `json:"function,omitempty"`
+	Name         string                 `json:"name,omitempty"`
+	Arguments    map[string]interface{} `json:"arguments,omitempty"`
+}
+
+type ExtraContent struct {
+	Google GoogleExtraContent `json:"google,omitempty"`
+}
+
+type GoogleExtraContent struct {
+	ThoughtSignature string `json:"thought_signature,omitempty"`
 }
 
 type FunctionCall struct {


### PR DESCRIPTION
issue where gemini 3.0 pro preview would error because google's thought_signature was missing

response I would get
```
Error processing message: LLM call failed after retries: API request failed:
  Status: 400
  Body:   [{
  "error": {
    "code": 400,
    "message": "Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly, and missing thought_signature may lead to degraded model performance. Additional data, function call default_api:read_file , position 20. Please refer to https://ai.google.dev/gemini-api/docs/thought-signatures for more details.",
    "status": "INVALID_ARGUMENT"
  }
}
```