### PR TITLE
fix: pass compound senderID to HandleMessage for Telegram allowlist

### DIFF
--- a/pkg/channels/telegram.go
+++ b/pkg/channels/telegram.go
@@ -355,7 +355,7 @@ func (c *TelegramChannel) handleMessage(ctx context.Context, message *telego.Mes
 		"is_group":   fmt.Sprintf("%t", message.Chat.Type != "private"),
 	}
 
-	c.HandleMessage(fmt.Sprintf("%d", user.ID), fmt.Sprintf("%d", chatID), content, mediaPaths, metadata)
+	c.HandleMessage(senderID, fmt.Sprintf("%d", chatID), content, mediaPaths, metadata)
 	return nil
 }
 


### PR DESCRIPTION
Fixes Issue #310 - Telegram messages stuck on Thinking

## Root Cause
In pkg/channels/telegram.go:358, HandleMessage was called with only the numeric user ID (e.g., "123456789"). However, the allowlist check in BaseChannel.HandleMessage expects the compound format ("123456789|myusername") to match @username entries.

When the allowlist contained @myusername, the numeric-only ID failed the match and the message was silently dropped after showing "Thinking...".

## Fix
Use the pre-computed compound senderID instead of just the numeric ID:
- Before: c.HandleMessage(fmt.Sprintf("%d", user.ID), ...)
- After: c.HandleMessage(senderID, ...)

## Changes
- pkg/channels/telegram.go: 1 line changed

## Testing
- All pkg/channels tests pass (6 tests)
- Build compiles successfully