### PR TITLE
Feature: Add PR concurrency to reduce redundant runs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,10 @@ name: pr-check
 on:
   pull_request:
 
+concurrency:
+  group: pr-${{github.workflow}}-${{github.event.pull_request.number}}
+  cancel-in-progress: true
+
 jobs:
   fmt-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Introduce concurrency to the pr-check workflow. This PR adds concurrency to the PR workflow so that when new commits are pushed, older in-progress runs are canceled. No code changes, only CI behavior optimization. Because multiple pushes to a PR can queue or run redundant checks. Canceling superseded runs saves CI minutes and shortens feedback loops.