### PR TITLE
fix: convert periods to dashes for OpenRouter model slugs

### DIFF
--- a/pkg/providers/http_provider.go
+++ b/pkg/providers/http_provider.go
@@ -61,6 +61,9 @@ func (p *HTTPProvider) Chat(ctx context.Context, messages []Message, tools []Too
 		}
 	}
 
+	// Convert periods to dashes for OpenRouter model slugs (e.g., glm-4.7 -> glm-4-7)
+	model = strings.ReplaceAll(model, ".", "-")
+
 	requestBody := map[string]interface{}{
 		"model":    model,
 		"messages": messages,


### PR DESCRIPTION
Fixes: glm-4.7 not working with OpenRouter

## Problem
OpenRouter uses dashes in model slugs (e.g., ) but users may configure with periods (). This causes "model not found" errors.

## Solution
Automatically convert periods to dashes when sending model names to OpenRouter:
-  -> 
-  -> 

## Changes
- : Add period-to-dash conversion before sending model to API

## Testing
- Build passes
- All provider tests pass