### PR TITLE
refactor(voice): introduce Transcriber interface for pluggable STT

### DIFF
--- a/pkg/channels/discord.go
+++ b/pkg/channels/discord.go
@@ -24,7 +24,7 @@ type DiscordChannel struct {
 	*BaseChannel
 	session     *discordgo.Session
 	config      config.DiscordConfig
-	transcriber *voice.GroqTranscriber
+	transcriber voice.Transcriber
 	ctx         context.Context
 }
 
@@ -45,7 +45,7 @@ func NewDiscordChannel(cfg config.DiscordConfig, bus *bus.MessageBus) (*DiscordC
 	}, nil
 }
 
-func (c *DiscordChannel) SetTranscriber(transcriber *voice.GroqTranscriber) {
+func (c *DiscordChannel) SetTranscriber(transcriber voice.Transcriber) {
 	c.transcriber = transcriber
 }
 

--- a/pkg/channels/slack.go
+++ b/pkg/channels/slack.go
@@ -25,7 +25,7 @@ type SlackChannel struct {
 	api          *slack.Client
 	socketClient *socketmode.Client
 	botUserID    string
-	transcriber  *voice.GroqTranscriber
+	transcriber  voice.Transcriber
 	ctx          context.Context
 	cancel       context.CancelFunc
 	pendingAcks  sync.Map
@@ -58,7 +58,7 @@ func NewSlackChannel(cfg config.SlackConfig, messageBus *bus.MessageBus) (*Slack
 	}, nil
 }
 
-func (c *SlackChannel) SetTranscriber(transcriber *voice.GroqTranscriber) {
+func (c *SlackChannel) SetTranscriber(transcriber voice.Transcriber) {
 	c.transcriber = transcriber
 }
 

--- a/pkg/channels/telegram.go
+++ b/pkg/channels/telegram.go
@@ -30,7 +30,7 @@ type TelegramChannel struct {
 	commands     TelegramCommander
 	config       *config.Config
 	chatIDs      map[string]int64
-	transcriber  *voice.GroqTranscriber
+	transcriber  voice.Transcriber
 	placeholders sync.Map // chatID -> messageID
 	stopThinking sync.Map // chatID -> thinkingCancel
 }
@@ -80,7 +80,7 @@ func NewTelegramChannel(cfg *config.Config, bus *bus.MessageBus) (*TelegramChann
 	}, nil
 }
 
-func (c *TelegramChannel) SetTranscriber(transcriber *voice.GroqTranscriber) {
+func (c *TelegramChannel) SetTranscriber(transcriber voice.Transcriber) {
 	c.transcriber = transcriber
 }
 

--- a/pkg/voice/transcriber.go
+++ b/pkg/voice/transcriber.go
@@ -16,6 +16,15 @@ import (
 	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
+// Transcriber is the interface for speech-to-text providers.
+// Any STT backend (Groq, Whisper, etc.) must implement this.
+type Transcriber interface {
+	// Transcribe converts the audio file at audioFilePath to text.
+	Transcribe(ctx context.Context, audioFilePath string) (*TranscriptionResponse, error)
+	// IsAvailable returns true if the provider is configured and reachable.
+	IsAvailable() bool
+}
+
 type GroqTranscriber struct {
 	apiKey     string
 	apiBase    string


### PR DESCRIPTION
## Summary

Currently Discord, Slack, and Telegram all hardcode `*voice.GroqTranscriber` as their transcription dependency. This makes it impossible to swap in a different STT backend without modifying every channel file.

This PR adds a `Transcriber` interface to `pkg/voice/transcriber.go` and updates the three channels to depend on it instead of the concrete type.

## Changes

- `pkg/voice/transcriber.go`: add `Transcriber` interface (`Transcribe` + `IsAvailable`)
- `pkg/channels/discord.go`: `*voice.GroqTranscriber` → `voice.Transcriber`
- `pkg/channels/slack.go`: same
- `pkg/channels/telegram.go`: same

`GroqTranscriber` already satisfies the interface — **zero behaviour change**.

## Why

This unblocks adding alternative STT providers (e.g. local Whisper — see follow-up PR) without touching channel code. It also aligns with how the `Synthesizer` interface works for TTS.

## Tests

All existing tests pass (`go test ./...`).