### PR TITLE
fix(telegram): use senderID and chatIDStr for message handling

### DIFF
--- a/pkg/channels/telegram.go
+++ b/pkg/channels/telegram.go
@@ -355,7 +355,7 @@ func (c *TelegramChannel) handleMessage(ctx context.Context, message *telego.Mes
 		"is_group":   fmt.Sprintf("%t", message.Chat.Type != "private"),
 	}
 
-	c.HandleMessage(fmt.Sprintf("%d", user.ID), fmt.Sprintf("%d", chatID), content, mediaPaths, metadata)
+	c.HandleMessage(senderID, chatIDStr, content, mediaPaths, metadata)
 	return nil
 }
 


### PR DESCRIPTION
## 📝 Description

`handleMessage` constructed a compound `senderID` (`"<id>|<username>"`) for the allowlist check but then passed only the numeric `fmt.Sprintf("%d", user.ID)` to `HandleMessage`. This meant downstream consumers (session key, metadata, logs) never saw the username component, and—more importantly—the `senderID` stored in the inbound message wouldn't match allowlist entries that use the `@username` form.

The same issue applied to `chatID`: a separate `chatIDStr` was already computed earlier in the function but `HandleMessage` was called with a redundant `fmt.Sprintf("%d", chatID)`.

This PR reuses the already-computed `senderID` and `chatIDStr` variables, fixing the mismatch and removing the duplicate formatting.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Linked Issue

#310 

## 📚 Technical Context (Skip for Docs)
* **Reasoning:** `senderID` was built as `fmt.Sprintf("%d|%s", user.ID, user.Username)` on L204 but `HandleMessage` on L358 was called with `fmt.Sprintf("%d", user.ID)`, discarding the username part. The fix is a one-line change reusing the existing locals.