### PR TITLE
ci: add PR memory budget guardrail (20MB startup RSS)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,3 +56,18 @@ jobs:
       - name: Run go test
         run: go test ./...
 
+  memory-budget:
+    runs-on: ubuntu-latest
+    needs: fmt-check
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check startup memory budget
+        run: make memory-check
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build install uninstall clean help test
+.PHONY: all build install uninstall clean help test memory-check
 
 # Build variables
 BINARY_NAME=picoclaw
@@ -126,9 +126,13 @@ clean:
 vet:
 	@$(GO) vet ./...
 
-## fmt: Format Go code
+## test: Run unit tests
 test:
 	@$(GO) test ./...
+
+## memory-check: Validate startup memory stays under budget (default 20MB RSS)
+memory-check:
+	@bash ./scripts/memory_budget_check.sh
 
 ## fmt: Format Go code
 fmt:

--- a/scripts/memory_budget_check.sh
+++ b/scripts/memory_budget_check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BINARY_PATH="${PICOCLAW_BINARY_PATH:-${ROOT_DIR}/build/picoclaw}"
+BUDGET_KB="${PICOCLAW_MEMORY_BUDGET_KB:-20480}"
+
+if [[ ! -x "${BINARY_PATH}" ]]; then
+  echo "[memory-check] binary not found at ${BINARY_PATH}; building..."
+  make -C "${ROOT_DIR}" build >/dev/null
+fi
+
+tmp_time_out="$(mktemp)"
+trap 'rm -f "${tmp_time_out}"' EXIT
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  /usr/bin/time -l "${BINARY_PATH}" version >/dev/null 2>"${tmp_time_out}"
+  rss_bytes="$(awk '/maximum resident set size/{print $1}' "${tmp_time_out}" | tail -n1)"
+  rss_kb="$((rss_bytes / 1024))"
+else
+  /usr/bin/time -v "${BINARY_PATH}" version >/dev/null 2>"${tmp_time_out}"
+  rss_kb="$(awk -F: '/Maximum resident set size/{gsub(/^[ \t]+/, "", $2); print $2}' "${tmp_time_out}" | tail -n1)"
+fi
+
+if [[ -z "${rss_kb}" ]]; then
+  echo "[memory-check] failed to parse peak RSS from /usr/bin/time output"
+  cat "${tmp_time_out}"
+  exit 1
+fi
+
+echo "[memory-check] peak RSS: ${rss_kb} KiB (budget: ${BUDGET_KB} KiB)"
+
+if (( rss_kb > BUDGET_KB )); then
+  echo "[memory-check] FAILED: peak RSS exceeds budget"
+  exit 1
+fi
+
+echo "[memory-check] PASS"


### PR DESCRIPTION
## Summary
Implements an initial memory guardrail for roadmap issue #346 by adding an automated startup RSS budget check in PR CI.

### What changed
- Added `scripts/memory_budget_check.sh`:
  - Builds binary if missing
  - Measures peak RSS using `/usr/bin/time`
  - Supports Linux and macOS parsing
  - Fails when RSS exceeds budget (default: `20480 KiB`, i.e. 20MB)
- Added `make memory-check` target
- Added `memory-budget` job in `.github/workflows/pr.yml` so every PR runs the check

## Why
Issue #346 asks for:
- memory monitoring in PR flow
- a hard red line guardrail

This PR provides a concrete and low-friction first guardrail while keeping the threshold configurable via `PICOCLAW_MEMORY_BUDGET_KB`.

## Local validation
- `make memory-check`
  - Example output on my machine: `peak RSS: ~12.5MB`, `PASS`.

## Follow-ups
- Extend to multi-command profile matrix (e.g., gateway startup path)
- Persist trend metrics as CI artifacts for regression history

Closes #346
