### PR TITLE
Allow vllm provider to work without API key

### DIFF
--- a/pkg/providers/factory.go
+++ b/pkg/providers/factory.go
@@ -295,7 +295,7 @@ func resolveProviderSelection(cfg *config.Config) (providerSelection, error) {
 	}
 
 	if sel.providerType == providerTypeHTTPCompat {
-		if sel.apiKey == "" && !strings.HasPrefix(model, "bedrock/") {
+		if sel.apiKey == "" && !strings.HasPrefix(model, "bedrock/") && providerName != "vllm" {
 			return providerSelection{}, fmt.Errorf("no API key configured for provider (model: %s)", model)
 		}
 		if sel.apiBase == "" {


### PR DESCRIPTION
## 📝 Description
Allow the `vllm` provider to work without an API key. This enables use of OpenAI-compatible endpoints that don't require authentication, such as opencode.ai/zen free models (kimi-k2.5-free, glm-5-free, etc.).

Single line change in `pkg/providers/http_provider.go`: added `&& providerName != "vllm"` to the API key validation check at line 441.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Linked Issue
N/A

## 📚 Technical Context (Skip for Docs)
* **Reference:** https://opencode.ai/zen
* **Reasoning:** The `HTTPProvider.Chat()` method already handles empty API keys correctly (skips the `Authorization` header at line 104), but the `CreateProvider()` validation at line 441 blocks empty keys for all providers except `bedrock`. The `vllm` provider is designed for self-hosted/custom endpoints and should also allow keyless access.

## 🧪 Test Environment & Hardware
- **Hardware:** Raspberry Pi (aarch64)
- **OS:** Debian (Linux ARM64)
- **Model/Provider:** kimi-k2.5-free, glm-5-free, gpt-5-nano via opencode.ai/zen/v1
- **Channels:** Telegram, CLI

## 📸 Proof of Work (Optional for Docs)
<details>
<summary>Click to view Logs/Screenshots</summary>

```
$ picoclaw agent -m "Hello! Who are you? Reply in one sentence."
2026/02/17 17:37:37 [INFO] agent: Agent initialized {skills_available=6, tools_count=13, skills_total=6}
2026/02/17 17:37:37 [INFO] agent: Processing message from cli:cron: Hello! Who are you? Reply in one sentence.
2026/02/17 17:37:39 [INFO] agent: LLM response without tool calls (direct answer) {iteration=1, content_chars=123}

🦞 Hello! I'm **picoclaw** 🦞, a lightweight AI assistant written in Go, here to help you with information, tasks, and more.
```

Config used:
```json
{
  "provider": "vllm",
  "model": "kimi-k2.5-free",
  "providers": {
    "vllm": {
      "api_key": "",
      "api_base": "https://opencode.ai/zen/v1"
    }
  }
}
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.