### PR TITLE
fix: exec tool should not treat URLs as file paths

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -188,8 +188,12 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 			return ""
 		}
 
+		// Strip URLs before path checking so they don't get misidentified as file paths
+		urlPattern := regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9+.-]*://[^\s\"']+`)
+		stripped := urlPattern.ReplaceAllString(cmd, "")
+
 		pathPattern := regexp.MustCompile(`[A-Za-z]:\\[^\\\"']+|/[^\s\"']+`)
-		matches := pathPattern.FindAllString(cmd, -1)
+		matches := pathPattern.FindAllString(stripped, -1)
 
 		for _, raw := range matches {
 			p, err := filepath.Abs(raw)


### PR DESCRIPTION
## Summary

- Fix `guardCommand` in `pkg/tools/shell.go` misidentifying URLs as filesystem paths
- Commands like `curl https://example.com` were blocked with "path outside working dir" when `restrict_to_workspace` is enabled
- Strip URLs from command string before running path checks

Fixes #386

## Test plan

- [x] All existing shell tool tests pass (`TestShellTool_RestrictToWorkspace` etc.)
- [ ] Verify `exec` tool can run `curl https://example.com` with `restrict_to_workspace: true`
- [ ] Verify `exec` tool still blocks `cat /etc/passwd` with `restrict_to_workspace: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)