### PR TITLE
fix: include extracted text in web_fetch ForLLM response

### DIFF
--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -476,8 +476,10 @@ func (t *WebFetchTool) Execute(ctx context.Context, args map[string]interface{})
 
 	resultJSON, _ := json.MarshalIndent(result, "", "  ")
 
+	forLLM := fmt.Sprintf("Fetched %d bytes from %s (extractor: %s, truncated: %v)\n\n%s", len(text), urlStr, extractor, truncated, text)
+
 	return &ToolResult{
-		ForLLM:  fmt.Sprintf("Fetched %d bytes from %s (extractor: %s, truncated: %v)", len(text), urlStr, extractor, truncated),
+		ForLLM:  forLLM,
 		ForUser: string(resultJSON),
 	}
 }


### PR DESCRIPTION
## 📝 Description
`web_fetch` tool's `ForLLM` field only returned a metadata summary (`"Fetched N bytes from URL"`), the LLM never saw the actual page content. This caused the agent to loop calling `web_fetch` on the same URL until `max_tool_iterations` was hit.

Fix: append the extracted text to `ForLLM` so the LLM can read and reason about fetched web content.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## 🔗 Linked Issue
Fixes #388

## 📚 Technical Context (Skip for Docs)
* **Reference:** `pkg/tools/web.go` — `WebFetchTool.Execute()`
* **Reasoning:** `ForLLM` is the content the LLM sees after a tool call. When it only contains metadata, the LLM retries the same fetch endlessly. The fix appends the extracted `text` variable to `ForLLM`.

## 🧪 Test Environment & Hardware
- **Hardware:** MacBook Pro (Apple Silicon)
- **OS:** macOS Darwin 24.4.0
- **Model/Provider:** Claude Opus 4.6
- **Channels:** Discord

## 📸 Proof of Work (Optional for Docs)
<details>
<summary>Click to view Logs/Screenshots</summary>

**Before fix** — agent loops `web_fetch` on the same URL (iteration 9→13), each returning only 81 bytes (metadata summary). LLM never sees page content:

```
2026/02/18 05:32:32 [INFO] agent: Tool call: web_fetch({"maxChars":4000,"url":"https://catellect.com"}) {tool=web_fetch, iteration=9}
2026/02/18 05:32:32 [INFO] tool: Tool execution completed {duration_ms=283, result_length=81, tool=web_fetch}
2026/02/18 05:32:34 [INFO] agent: Tool call: web_fetch({"maxChars":4000,"url":"https://catellect.com"}) {tool=web_fetch, iteration=10}
2026/02/18 05:32:34 [INFO] tool: Tool execution completed {result_length=81, tool=web_fetch, duration_ms=332}
2026/02/18 05:32:36 [INFO] agent: Tool call: web_fetch({"maxChars":4000,"url":"https://catellect.com"}) {tool=web_fetch, iteration=11}
2026/02/18 05:32:36 [INFO] tool: Tool execution completed {tool=web_fetch, duration_ms=291, result_length=81}
2026/02/18 05:32:37 [INFO] agent: Tool call: web_fetch({"maxChars":4000,"url":"https://catellect.com"}) {tool=web_fetch, iteration=12}
2026/02/18 05:32:38 [INFO] tool: Tool execution completed {tool=web_fetch, duration_ms=293, result_length=81}
2026/02/18 05:32:39 [INFO] agent: Tool call: web_fetch({"maxChars":4000,"url":"https://catellect.com"}) {tool=web_fetch, iteration=13}
2026/02/18 05:32:39 [INFO] tool: Tool execution completed {tool=web_fetch, duration_ms=299, result_length=81}
```

`result_length=81` = only `"Fetched 2505 bytes from https://catellect.com (extractor: text, truncated: false)"` — the actual 2505-byte page content was extracted but never included in `ForLLM`.

**After fix** — `web_fetch` returns full content, agent proceeds normally without looping.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.