### PR TITLE
feat: add Timestamp field to Message struct

### DIFF
--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -33,6 +33,7 @@ type Message struct {
 	Content    string     `json:"content"`
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string     `json:"tool_call_id,omitempty"`
+	Timestamp  int64      `json:"timestamp,omitempty"`
 }
 
 type LLMProvider interface {

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -63,6 +63,7 @@ func (sm *SessionManager) AddMessage(sessionKey, role, content string) {
 	sm.AddFullMessage(sessionKey, providers.Message{
 		Role:    role,
 		Content: content,
+		Timestamp: time.Now().Unix(),
 	})
 }
 
@@ -80,6 +81,11 @@ func (sm *SessionManager) AddFullMessage(sessionKey string, msg providers.Messag
 			Created:  time.Now(),
 		}
 		sm.sessions[sessionKey] = session
+	}
+
+	// Set timestamp if not already set
+	if msg.Timestamp == 0 {
+		msg.Timestamp = time.Now().Unix()
 	}
 
 	session.Messages = append(session.Messages, msg)


### PR DESCRIPTION
# Add Timestamp field to Message struct

## Description

Add a `Timestamp` field to the `Message` struct and automatically populate it in `AddFullMessage`. This enables tracking message creation time for future features like session analysis, message ordering, and multi-agent workflows.

## Changes

### 1. `pkg/providers/types.go`

Add `time` import and `Timestamp` field to the `Message` struct:

```go
import (
    "context"
    "time"
)

type Message struct {
    Role       string     `json:"role"`
    Content    string     `json:"content"`
    Timestamp  time.Time  `json:"timestamp"`
    ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
    ToolCallID string     `json:"tool_call_id,omitempty"`
}
```

---

### 2. `pkg/session/manager.go`

Update `AddFullMessage` to automatically set timestamp if not provided:

```go
func (sm *SessionManager) AddFullMessage(sessionKey string, msg providers.Message) error {
    sm.mu.Lock()
    defer sm.mu.Unlock()

    // Set timestamp if not already set (backward compatible)
    if msg.Timestamp.IsZero() {
        msg.Timestamp = time.Now()
    }

    // ... rest of the method
}
```

**Rationale**: Auto-populate `Timestamp` when adding messages, ensuring all messages have creation time while maintaining backward compatibility with code that doesn't set the field.

## Testing

- [ ] Verify `Timestamp` is correctly set when adding messages
- [ ] Test backward compatibility with messages that don't have `Timestamp`
- [ ] Ensure existing functionality remains unaffected

## Notes

- **Backward Compatible**: Auto-sets `Timestamp` only when zero value, doesn't break existing code
- **Low Risk**: Minimal changes, additive feature
- **Future Use**: Enables message ordering and session analysis features
