### PR TITLE
docs: add free deployment guide for Railway, Render, Fly.io

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,58 @@
+# 🚀 Deploy PicoClaw for Free
+
+## Quick Deploy
+
+### Railway.app (Recommended)
+
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template)
+
+1. Click "Deploy on Railway"
+2. Set environment variables:
+   - `TELEGRAM_BOT_TOKEN` - Your bot token from @BotFather
+   - `ZHIPU_API_KEY` - Your GLM API key from Z.AI
+
+### Render.com
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+
+1. Click "Deploy to Render"
+2. Connect GitHub repo
+3. Set environment variables
+4. Deploy
+
+### Fly.io
+
+```bash
+# Install CLI
+brew install flyctl
+
+# Login
+fly auth login
+
+# Deploy
+fly launch
+fly deploy
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `TELEGRAM_BOT_TOKEN` | ✅ | Bot token from @BotFather |
+| `ZHIPU_API_KEY` | ✅ | GLM API key from Z.AI |
+| `WEB_SEARCH_ENABLED` | ❌ | Enable web search (default: true) |
+| `WEB_SEARCH_PROVIDER` | ❌ | duckduckgo or brave |
+
+## Files Created
+
+- `railway.toml` - Railway config
+- `fly.toml` - Fly.io config  
+- `render.yaml` - Render blueprint
+- `deploy.sh` - Quick deploy script
+
+## Run Deploy Script
+
+```bash
+cd /Users/adisusilayasa/picoclaw
+./deploy.sh
+```

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+echo "🦞 PicoClaw Deployment Helper"
+echo "=============================="
+echo ""
+echo "Choose deployment platform:"
+echo ""
+echo "1) Railway.app (Recommended - $5/month free credit)"
+echo "2) Render.com (Free - 750 hours/month)"
+echo "3) Fly.io (Free - 3 VMs)"
+echo "4) Show instructions only"
+echo ""
+read -p "Enter choice [1-4]: " choice
+
+case $choice in
+    1)
+        echo ""
+        echo "📦 Deploying to Railway..."
+        echo ""
+        
+        # Check if Railway CLI is installed
+        if ! command -v railway &> /dev/null; then
+            echo "Installing Railway CLI..."
+            npm install -g @railway/cli
+        fi
+        
+        # Login if needed
+        railway login
+        
+        # Initialize project
+        echo ""
+        echo "Run these commands:"
+        echo "  railway init"
+        echo "  railway variables set TELEGRAM_BOT_TOKEN=YOUR_TOKEN"
+        echo "  railway variables set ZHIPU_API_KEY=YOUR_KEY"
+        echo "  railway up"
+        ;;
+    2)
+        echo ""
+        echo "📦 Deploying to Render..."
+        echo ""
+        echo "Steps:"
+        echo "1. Go to https://render.com"
+        echo "2. Create account"
+        echo "3. New → Web Service"
+        echo "4. Connect GitHub repo"
+        echo "5. Select Docker environment"
+        echo "6. Add environment variables"
+        echo "7. Deploy"
+        ;;
+    3)
+        echo ""
+        echo "📦 Deploying to Fly.io..."
+        echo ""
+        
+        # Check if Fly CLI is installed
+        if ! command -v fly &> /dev/null; then
+            echo "Installing Fly CLI..."
+            brew install flyctl
+        fi
+        
+        echo "Run these commands:"
+        echo "  fly auth login"
+        echo "  fly secrets set TELEGRAM_BOT_TOKEN=YOUR_TOKEN"
+        echo "  fly secrets set ZHIPU_API_KEY=YOUR_KEY"
+        echo "  fly launch"
+        echo "  fly deploy"
+        ;;
+    4)
+        echo ""
+        echo "📖 See ~/.picoclaw/workspace/DEPLOYMENT.md for detailed instructions"
+        ;;
+    *)
+        echo "Invalid choice"
+        ;;
+esac

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,28 @@
+app = "picoclaw-claw"
+primary_region = "sin"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+  auto_stop_machines = false
+  auto_start_machines = false
+  min_machines_running = 1
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 256

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,8 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "./build/picoclaw gateway"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,20 @@
+services:
+  - type: web
+    name: picoclaw
+    runtime: docker
+    dockerContext: .
+    dockerfilePath: ./Dockerfile
+    plan: free
+    envVars:
+      - key: TELEGRAM_BOT_TOKEN
+        sync: false
+      - key: ZHIPU_API_KEY
+        sync: false
+      - key: WEB_SEARCH_ENABLED
+        value: true
+      - key: WEB_SEARCH_PROVIDER
+        value: duckduckgo
+    disk:
+      name: picoclaw-data
+      mountPath: /root/.picoclaw
+      sizeGB: 1


### PR DESCRIPTION
## 📝 Description

Add deployment configurations and guide for deploying PicoClaw to free cloud platforms: Railway.app, Render.com, and Fly.io.

Many users want to run PicoClaw 24/7 without paying for a VPS. This PR provides ready-to-use deployment configs for popular free-tier platforms.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Addresses common question: "How to deploy PicoClaw for free?"

## Files Added

| File | Purpose |
|------|---------|
| `railway.toml` | Railway.app deployment config |
| `fly.toml` | Fly.io deployment config |
| `render.yaml` | Render.com blueprint |
| `deploy.sh` | Quick deployment helper script |
| `DEPLOY.md` | Detailed deployment instructions |

## Platform Comparison

| Platform | Free Tier | Difficulty |
|----------|-----------|------------|
| Railway.app | $5/month credit | ⭐ Easy |
| Render.com | 750 hours/month | ⭐ Easy |
| Fly.io | 3 VMs free | ⭐⭐ Medium |

## Why Not Vercel?

Vercel uses serverless functions with 10-60 second timeouts. PicoClaw requires continuous polling for Telegram, making Vercel unsuitable. The recommended platforms support long-running processes.

## 🧪 Test Environment
- **Hardware:** MacBook Pro
- **OS:** macOS
- **Model/Provider:** GLM-4.7 (Z.AI)
- **Channels:** Telegram

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.