### PR TITLE
fix: support keyless Ollama and harden exec working_dir safety

### DIFF
--- a/pkg/providers/factory_test.go
+++ b/pkg/providers/factory_test.go
@@ -136,6 +136,24 @@ func TestResolveProviderSelection(t *testing.T) {
 			wantAPIBase: "http://localhost:11434/v1",
 		},
 		{
+			name: "explicit ollama provider allows empty key and uses default base",
+			setup: func(cfg *config.Config) {
+				cfg.Agents.Defaults.Provider = "ollama"
+				cfg.Agents.Defaults.Model = "qwen2.5:14b"
+			},
+			wantType:    providerTypeHTTPCompat,
+			wantAPIBase: "http://localhost:11434/v1",
+		},
+		{
+			name: "ollama model allows api base without key",
+			setup: func(cfg *config.Config) {
+				cfg.Agents.Defaults.Model = "ollama/qwen2.5:14b"
+				cfg.Providers.Ollama.APIBase = "http://localhost:11434/v1"
+			},
+			wantType:    providerTypeHTTPCompat,
+			wantAPIBase: "http://localhost:11434/v1",
+		},
+		{
 			name: "moonshot model keeps proxy and default base",
 			setup: func(cfg *config.Config) {
 				cfg.Agents.Defaults.Model = "moonshot/kimi-k2.5"


### PR DESCRIPTION
## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A (internal code-path fixes)
- **Reasoning:** Local Ollama setups usually do not require API keys, and `exec` directory/path restrictions should consistently enforce workspace boundaries.

## 🧪 Test Environment
- **Hardware:** MacBook Pro
- **OS:** macOS
- **Model/Provider:** Ollama / local provider config path
- **Channels:** N/A (core provider + tool behavior)


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>
Passed locally:

- `go test ./pkg/tools ./pkg/providers`
- `go test ./pkg/config ./pkg/agent ./pkg/migrate`

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.