### PR TITLE
feat(session): add configurable memory summarization thresholds

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -4,8 +4,11 @@
       "workspace": "~/.picoclaw/workspace",
       "restrict_to_workspace": true,
       "model": "gpt4",
+      "context_window": 8192,
       "max_tokens": 8192,
       "temperature": 0.7,
+      "summary_max_tokens": 1024,
+      "summary_temperature": 0.3,
       "max_tool_iterations": 20
     }
   },

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -977,8 +977,8 @@ func (al *AgentLoop) summarizeSession(agent *AgentInstance, sessionKey string) {
 			nil,
 			agent.Model,
 			map[string]any{
-				"max_tokens":  1024,
-				"temperature": 0.3,
+				"max_tokens":  agent.SummaryMaxTokens,
+				"temperature": agent.SummaryTemperature,
 			},
 		)
 		if err == nil {
@@ -1027,8 +1027,8 @@ func (al *AgentLoop) summarizeBatch(
 		nil,
 		agent.Model,
 		map[string]any{
-			"max_tokens":  1024,
-			"temperature": 0.3,
+			"max_tokens":  agent.SummaryMaxTokens,
+			"temperature": agent.SummaryTemperature,
 		},
 	)
 	if err != nil {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -28,6 +28,7 @@ func TestRecordLastChannel(t *testing.T) {
 			Defaults: config.AgentDefaults{
 				Workspace:         tmpDir,
 				Model:             "test-model",
+				ContextWindow:     4096,
 				MaxTokens:         4096,
 				MaxToolIterations: 10,
 			},
@@ -73,6 +74,7 @@ func TestRecordLastChatID(t *testing.T) {
 			Defaults: config.AgentDefaults{
 				Workspace:         tmpDir,
 				Model:             "test-model",
+				ContextWindow:     4096,
 				MaxTokens:         4096,
 				MaxToolIterations: 10,
 			},
@@ -118,6 +120,7 @@ func TestNewAgentLoop_StateInitialized(t *testing.T) {
 			Defaults: config.AgentDefaults{
 				Workspace:         tmpDir,
 				Model:             "test-model",
+				ContextWindow:     4096,
 				MaxTokens:         4096,
 				MaxToolIterations: 10,
 			},
@@ -154,6 +157,7 @@ func TestToolRegistry_ToolRegistration(t *testing.T) {
 			Defaults: config.AgentDefaults{
 				Workspace:         tmpDir,
 				Model:             "test-model",
+				ContextWindow:     4096,
 				MaxTokens:         4096,
 				MaxToolIterations: 10,
 			},
@@ -200,6 +204,7 @@ func TestToolContext_Updates(t *testing.T) {
 			Defaults: config.AgentDefaults{
 				Workspace:         tmpDir,
 				Model:             "test-model",
+				ContextWindow:     4096,
 				MaxTokens:         4096,
 				MaxToolIterations: 10,
 			},
@@ -231,6 +236,7 @@ func TestToolRegistry_GetDefinitions(t *testing.T) {
 			Defaults: config.AgentDefaults{
 				Workspace:         tmpDir,
 				Model:             "test-model",
+				ContextWindow:     4096,
 				MaxTokens:         4096,
 				MaxToolIterations: 10,
 			},
@@ -275,6 +281,7 @@ func TestAgentLoop_GetStartupInfo(t *testing.T) {
 			Defaults: config.AgentDefaults{
 				Workspace:         tmpDir,
 				Model:             "test-model",
+				ContextWindow:     4096,
 				MaxTokens:         4096,
 				MaxToolIterations: 10,
 			},
@@ -322,6 +329,7 @@ func TestAgentLoop_Stop(t *testing.T) {
 			Defaults: config.AgentDefaults{
 				Workspace:         tmpDir,
 				Model:             "test-model",
+				ContextWindow:     4096,
 				MaxTokens:         4096,
 				MaxToolIterations: 10,
 			},
@@ -450,6 +458,7 @@ func TestToolResult_SilentToolDoesNotSendUserMessage(t *testing.T) {
 			Defaults: config.AgentDefaults{
 				Workspace:         tmpDir,
 				Model:             "test-model",
+				ContextWindow:     4096,
 				MaxTokens:         4096,
 				MaxToolIterations: 10,
 			},
@@ -492,6 +501,7 @@ func TestToolResult_UserFacingToolDoesSendMessage(t *testing.T) {
 			Defaults: config.AgentDefaults{
 				Workspace:         tmpDir,
 				Model:             "test-model",
+				ContextWindow:     4096,
 				MaxTokens:         4096,
 				MaxToolIterations: 10,
 			},
@@ -563,6 +573,7 @@ func TestAgentLoop_ContextExhaustionRetry(t *testing.T) {
 			Defaults: config.AgentDefaults{
 				Workspace:         tmpDir,
 				Model:             "test-model",
+				ContextWindow:     4096,
 				MaxTokens:         4096,
 				MaxToolIterations: 10,
 			},

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -30,6 +30,7 @@ func testCfg(agents []config.AgentConfig) *config.Config {
 			Defaults: config.AgentDefaults{
 				Workspace:         "/tmp/picoclaw-test-registry",
 				Model:             "gpt-4",
+				ContextWindow:     8192,
 				MaxTokens:         8192,
 				MaxToolIterations: 10,
 			},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -178,8 +178,11 @@ type AgentDefaults struct {
 	ModelFallbacks      []string `json:"model_fallbacks,omitempty"`
 	ImageModel          string   `json:"image_model,omitempty"           env:"PICOCLAW_AGENTS_DEFAULTS_IMAGE_MODEL"`
 	ImageModelFallbacks []string `json:"image_model_fallbacks,omitempty"`
+	ContextWindow       int      `json:"context_window"                  env:"PICOCLAW_AGENTS_DEFAULTS_CONTEXT_WINDOW"`
 	MaxTokens           int      `json:"max_tokens"                      env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOKENS"`
 	Temperature         *float64 `json:"temperature,omitempty"           env:"PICOCLAW_AGENTS_DEFAULTS_TEMPERATURE"`
+	SummaryMaxTokens    int      `json:"summary_max_tokens"              env:"PICOCLAW_AGENTS_DEFAULTS_SUMMARY_MAX_TOKENS"`
+	SummaryTemperature  float64  `json:"summary_temperature"             env:"PICOCLAW_AGENTS_DEFAULTS_SUMMARY_TEMPERATURE"`
 	MaxToolIterations   int      `json:"max_tool_iterations"             env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOOL_ITERATIONS"`
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -215,6 +215,15 @@ func TestDefaultConfig_Model(t *testing.T) {
 	}
 }
 
+// TestDefaultConfig_ContextWindow verifies context_window has default value
+func TestDefaultConfig_ContextWindow(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Agents.Defaults.ContextWindow == 0 {
+		t.Error("ContextWindow should not be zero")
+	}
+}
+
 // TestDefaultConfig_MaxTokens verifies max tokens has default value
 func TestDefaultConfig_MaxTokens(t *testing.T) {
 	cfg := DefaultConfig()
@@ -336,6 +345,9 @@ func TestConfig_Complete(t *testing.T) {
 	}
 	if cfg.Agents.Defaults.Temperature != nil {
 		t.Error("Temperature should be nil when not provided")
+	}
+	if cfg.Agents.Defaults.ContextWindow == 0 {
+		t.Error("ContextWindow should not be zero")
 	}
 	if cfg.Agents.Defaults.MaxTokens == 0 {
 		t.Error("MaxTokens should not be zero")

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -14,7 +14,10 @@ func DefaultConfig() *Config {
 				RestrictToWorkspace: true,
 				Provider:            "",
 				Model:               "glm-4.7",
+				ContextWindow:       8192,
 				MaxTokens:           8192,
+				SummaryMaxTokens:    1024,
+				SummaryTemperature:  0.3,
 				Temperature:         nil, // nil means use provider default
 				MaxToolIterations:   20,
 			},

--- a/pkg/migrate/config.go
+++ b/pkg/migrate/config.go
@@ -75,11 +75,23 @@ func ConvertConfig(data map[string]any) (*config.Config, []string, error) {
 			if v, ok := getString(defaults, "model"); ok {
 				cfg.Agents.Defaults.Model = v
 			}
+			if v, ok := getFloat(defaults, "context_window"); ok {
+				cfg.Agents.Defaults.ContextWindow = int(v)
+			} else if v, ok := getFloat(defaults, "max_tokens"); ok {
+				// Backward compat: old configs used max_tokens for both; set context_window from it.
+				cfg.Agents.Defaults.ContextWindow = int(v)
+			}
 			if v, ok := getFloat(defaults, "max_tokens"); ok {
 				cfg.Agents.Defaults.MaxTokens = int(v)
 			}
 			if v, ok := getFloat(defaults, "temperature"); ok {
 				cfg.Agents.Defaults.Temperature = &v
+			}
+			if v, ok := getFloat(defaults, "summary_max_tokens"); ok {
+				cfg.Agents.Defaults.SummaryMaxTokens = int(v)
+			}
+			if v, ok := getFloat(defaults, "summary_temperature"); ok {
+				cfg.Agents.Defaults.SummaryTemperature = v
 			}
 			if v, ok := getFloat(defaults, "max_tool_iterations"); ok {
 				cfg.Agents.Defaults.MaxToolIterations = int(v)

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -272,6 +272,9 @@ func TestConvertConfig(t *testing.T) {
 		if cfg.Agents.Defaults.Model != "claude-3-opus" {
 			t.Errorf("Model = %q, want %q", cfg.Agents.Defaults.Model, "claude-3-opus")
 		}
+		if cfg.Agents.Defaults.ContextWindow != 4096 {
+			t.Errorf("ContextWindow = %d, want 4096 (backward compat from max_tokens)", cfg.Agents.Defaults.ContextWindow)
+		}
 		if cfg.Agents.Defaults.MaxTokens != 4096 {
 			t.Errorf("MaxTokens = %d, want %d", cfg.Agents.Defaults.MaxTokens, 4096)
 		}


### PR DESCRIPTION
## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

- Add memory_message_limit, memory_token_percent, memory_notify_user to SessionConfig
- Don't notify user by default; log only when memory_notify_user is false
- Add `context_window`, `summary_max_tokens`, `summary_temperature` to config
- Use `agent.MaxTokens` and `agent.Temperature` in LLM calls (replace hardcoded values)
- Backward compat: migrate derives `context_window` from `max_tokens` when absent

Ref: @harshbansal7 b226e68
 
## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->
Closes #420 


## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->PC
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->Ubuntu 22.04
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->GLM-4
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->Telegram


## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.