### PR TITLE
fix(tools): add proxy support to web_fetch HTTP transport

### DIFF
--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -413,6 +413,7 @@ func (t *WebFetchTool) Execute(ctx context.Context, args map[string]interface{})
 	client := &http.Client{
 		Timeout: 60 * time.Second,
 		Transport: &http.Transport{
+			Proxy:               http.ProxyFromEnvironment,
 			MaxIdleConns:        10,
 			IdleConnTimeout:     30 * time.Second,
 			DisableCompression:  false,


### PR DESCRIPTION
## Description

The `web_fetch` tool's custom `http.Transport` was missing the `Proxy` field, causing it to silently ignore `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` environment variables. This is a one-line fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## AI-Generated Code Disclosure

- [x] Mostly Human (Human draft, AI assisted)

## Related Issue

Closes #413

## Root Cause

When constructing an `http.Transport{}` manually, the `Proxy` field defaults to `nil` (no proxy). This is different from `http.DefaultTransport`, which sets `Proxy: http.ProxyFromEnvironment`.

The search providers (Brave, DuckDuckGo, Perplexity) use `&http.Client{Timeout: ...}` with a nil `Transport`, so they correctly inherit `http.DefaultTransport` and respect proxy env vars. But `WebFetchTool.Execute()` constructs a custom transport (for connection pooling and TLS tuning) that was missing the proxy field.

```go
// Before — no proxy support:
Transport: &http.Transport{
    MaxIdleConns:        10,
    IdleConnTimeout:     30 * time.Second,
    DisableCompression:  false,
    TLSHandshakeTimeout: 15 * time.Second,
},

// After — respects HTTP_PROXY/HTTPS_PROXY:
Transport: &http.Transport{
    Proxy:               http.ProxyFromEnvironment,
    MaxIdleConns:        10,
    IdleConnTimeout:     30 * time.Second,
    DisableCompression:  false,
    TLSHandshakeTimeout: 15 * time.Second,
},
```

## Note on PR #422

PR #422 attempts to fix this same issue but targets the wrong code path — it adds `Transport: http.DefaultTransport` to the Brave search provider, which is a no-op since nil Transport already uses DefaultTransport. See my review on #422 for details.

## Test Environment

- **Hardware:** MacBook Air M4
- **OS:** macOS 15.4
- **Go version:** 1.25.7

## Evidence

All existing web tool tests pass:
```
--- PASS: TestWebTool_WebFetch_Success
--- PASS: TestWebTool_WebFetch_JSON
--- PASS: TestWebTool_WebFetch_HTMLExtraction
--- PASS: TestWebTool_WebFetch_Truncation
(10 tests total, all passing)
```

## Self-review checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes