### PR TITLE
fix: correct invalid model ID in config example JSON

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -3,7 +3,7 @@
     "defaults": {
       "workspace": "~/.picoclaw/workspace",
       "restrict_to_workspace": true,
-      "model": "glm-4.7",
+      "model": "z-ai/glm-4.7",
       "max_tokens": 8192,
       "temperature": 0.7,
       "max_tool_iterations": 20


### PR DESCRIPTION
For default model id,  update default model ID to "z-ai/glm-4.7" in config.example.json.  Tried on my local, It works.