### PR TITLE
feat: add reasoning_effort support for Codex provider

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -28,7 +28,8 @@ type AgentInstance struct {
 	Tools          *tools.ToolRegistry
 	Subagents      *config.SubagentsConfig
 	SkillsFilter   []string
-	Candidates     []providers.FallbackCandidate
+	Candidates      []providers.FallbackCandidate
+	ReasoningEffort string
 }
 
 // NewAgentInstance creates an agent instance from config.
@@ -84,20 +85,21 @@ func NewAgentInstance(
 	candidates := providers.ResolveCandidates(modelCfg, defaults.Provider)
 
 	return &AgentInstance{
-		ID:             agentID,
-		Name:           agentName,
-		Model:          model,
-		Fallbacks:      fallbacks,
-		Workspace:      workspace,
-		MaxIterations:  maxIter,
-		ContextWindow:  defaults.MaxTokens,
-		Provider:       provider,
-		Sessions:       sessionsManager,
-		ContextBuilder: contextBuilder,
-		Tools:          toolsRegistry,
-		Subagents:      subagents,
-		SkillsFilter:   skillsFilter,
-		Candidates:     candidates,
+		ID:              agentID,
+		Name:            agentName,
+		Model:           model,
+		Fallbacks:       fallbacks,
+		Workspace:       workspace,
+		MaxIterations:   maxIter,
+		ContextWindow:   defaults.MaxTokens,
+		Provider:        provider,
+		Sessions:        sessionsManager,
+		ContextBuilder:  contextBuilder,
+		Tools:           toolsRegistry,
+		Subagents:       subagents,
+		SkillsFilter:    skillsFilter,
+		Candidates:      candidates,
+		ReasoningEffort: defaults.ReasoningEffort,
 	}
 }
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -472,6 +472,7 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, agent *AgentInstance, 
 				"tools_count":       len(providerToolDefs),
 				"max_tokens":        8192,
 				"temperature":       0.7,
+				"reasoning_effort":  agent.ReasoningEffort,
 				"system_prompt_len": len(messages[0].Content),
 			})
 
@@ -492,8 +493,9 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, agent *AgentInstance, 
 				fbResult, fbErr := al.fallback.Execute(ctx, agent.Candidates,
 					func(ctx context.Context, provider, model string) (*providers.LLMResponse, error) {
 						return agent.Provider.Chat(ctx, messages, providerToolDefs, model, map[string]interface{}{
-							"max_tokens":  8192,
-							"temperature": 0.7,
+							"max_tokens":       8192,
+							"temperature":      0.7,
+							"reasoning_effort": agent.ReasoningEffort,
 						})
 					},
 				)
@@ -508,8 +510,9 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, agent *AgentInstance, 
 				return fbResult.Response, nil
 			}
 			return agent.Provider.Chat(ctx, messages, providerToolDefs, agent.Model, map[string]interface{}{
-				"max_tokens":  8192,
-				"temperature": 0.7,
+				"max_tokens":       8192,
+				"temperature":      0.7,
+				"reasoning_effort": agent.ReasoningEffort,
 			})
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,6 +149,7 @@ type AgentDefaults struct {
 	MaxTokens           int      `json:"max_tokens" env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOKENS"`
 	Temperature         float64  `json:"temperature" env:"PICOCLAW_AGENTS_DEFAULTS_TEMPERATURE"`
 	MaxToolIterations   int      `json:"max_tool_iterations" env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOOL_ITERATIONS"`
+	ReasoningEffort     string   `json:"reasoning_effort,omitempty" env:"PICOCLAW_AGENTS_DEFAULTS_REASONING_EFFORT"`
 }
 
 type ChannelsConfig struct {

--- a/pkg/providers/codex_provider.go
+++ b/pkg/providers/codex_provider.go
@@ -268,6 +268,12 @@ func buildCodexParams(messages []Message, tools []ToolDefinition, model string, 
 		params.Instructions = openai.Opt(defaultCodexInstructions)
 	}
 
+	if re, ok := options["reasoning_effort"].(string); ok && re != "" {
+		params.Reasoning = responses.ReasoningParam{
+			Effort: responses.ReasoningEffort(re),
+		}
+	}
+
 	if len(tools) > 0 || enableWebSearch {
 		params.Tools = translateToolsForCodex(tools, enableWebSearch)
 	}


### PR DESCRIPTION
## 📝 Description

Add support for controlling OpenAI reasoning effort when using the Codex provider. The `reasoning_effort` field can be set in `agents.defaults` config or via the `PICOCLAW_AGENTS_DEFAULTS_REASONING_EFFORT` environment variable. Valid levels: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/openai/codex (Codex CLI uses `"reasoning": {"effort": "<level>"}`)
- **Reasoning:** The openai-go v3.22.0 SDK already exposes `ReasoningParam` with an `Effort` field on `ResponseNewParams`. This PR threads the config value through the agent loop options map into `buildCodexParams`, where it is applied to the request. Non-Codex providers ignore the option.

## 🧪 Test Environment
- **Hardware:** DigitalOcean VPS (amd64)
- **OS:** Debian 12
- **Model/Provider:** Codex (`gpt-5.3-codex` via `openai` provider)
- **Channels:** CLI (`picoclaw agent`)

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.