### PR TITLE
refactor: use nil slices and preallocate where capacity is known

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -107,7 +107,7 @@ func (cb *ContextBuilder) buildToolsSection() string {
 }
 
 func (cb *ContextBuilder) BuildSystemPrompt() string {
-	parts := []string{}
+	var parts []string
 
 	// Core identity section
 	parts = append(parts, cb.getIdentity())
@@ -158,8 +158,6 @@ func (cb *ContextBuilder) LoadBootstrapFiles() string {
 }
 
 func (cb *ContextBuilder) BuildMessages(history []providers.Message, summary string, currentMessage string, media []string, channel, chatID string) []providers.Message {
-	messages := []providers.Message{}
-
 	systemPrompt := cb.BuildSystemPrompt()
 
 	// Add Current Session info if provided
@@ -199,6 +197,8 @@ func (cb *ContextBuilder) BuildMessages(history []providers.Message, summary str
 	}
 	//Diegox-17
 	// --- FIN DEL FIX ---
+
+	messages := make([]providers.Message, 0, len(history)+2)
 
 	messages = append(messages, providers.Message{
 		Role:    "system",

--- a/pkg/channels/line.go
+++ b/pkg/channels/line.go
@@ -307,7 +307,7 @@ func (c *LINEChannel) processEvent(event lineEvent) {
 
 	var content string
 	var mediaPaths []string
-	localFiles := []string{}
+	var localFiles []string
 
 	defer func() {
 		for _, file := range localFiles {

--- a/pkg/channels/slack.go
+++ b/pkg/channels/slack.go
@@ -232,7 +232,7 @@ func (c *SlackChannel) handleMessageEvent(ev *slackevents.MessageEvent) {
 	content = c.stripBotMention(content)
 
 	var mediaPaths []string
-	localFiles := []string{} // 跟踪需要清理的本地文件
+	var localFiles []string // 跟踪需要清理的本地文件
 
 	// 确保临时文件在函数返回时被清理
 	defer func() {

--- a/pkg/channels/telegram.go
+++ b/pkg/channels/telegram.go
@@ -212,9 +212,9 @@ func (c *TelegramChannel) handleMessage(ctx context.Context, message *telego.Mes
 	chatID := message.Chat.ID
 	c.chatIDs[senderID] = chatID
 
-	content := ""
-	mediaPaths := []string{}
-	localFiles := []string{} // 跟踪需要清理的本地文件
+	var content string
+	var mediaPaths []string
+	var localFiles []string // 跟踪需要清理的本地文件
 
 	// 确保临时文件在函数返回时被清理
 	defer func() {

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -283,7 +283,8 @@ func PrintPlan(actions []Action, warnings []string) {
 
 func PrintSummary(result *Result) {
 	fmt.Println()
-	parts := []string{}
+	var parts []string
+
 	if result.FilesCopied > 0 {
 		parts = append(parts, fmt.Sprintf("%d files copied", result.FilesCopied))
 	}


### PR DESCRIPTION
## 📝 Description

Minor slice cleanup for more idiomatic Go and slightly better performance:

- Replaced `s := []T{}` with `var s []T` where a nil slice is sufficient.
- Preallocated `messages` with known capacity to avoid extra reallocations.

No functional changes intended.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reasoning:** Make slice initialization more idiomatic and reduce unnecessary allocations.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Fedora

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Existing tests pass.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
