### PR TITLE
Add custom OpenAI-compatible provider support

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -263,6 +263,7 @@ type ProvidersConfig struct {
 	ShengSuanYun  ProviderConfig       `json:"shengsuanyun"`
 	DeepSeek      ProviderConfig       `json:"deepseek"`
 	GitHubCopilot ProviderConfig       `json:"github_copilot"`
+	Custom        ProviderConfig       `json:"custom"`
 }
 
 type ProviderConfig struct {
@@ -411,6 +412,7 @@ func DefaultConfig() *Config {
 			Nvidia:       ProviderConfig{},
 			Moonshot:     ProviderConfig{},
 			ShengSuanYun: ProviderConfig{},
+			Custom:       ProviderConfig{},
 		},
 		Gateway: GatewayConfig{
 			Host: "0.0.0.0",

--- a/pkg/providers/factory.go
+++ b/pkg/providers/factory.go
@@ -75,6 +75,12 @@ func resolveProviderSelection(cfg *config.Config) (providerSelection, error) {
 	// First, prefer explicit provider configuration.
 	if providerName != "" {
 		switch providerName {
+		case "custom":
+			if cfg.Providers.Custom.APIBase != "" {
+				sel.apiKey = cfg.Providers.Custom.APIKey
+				sel.apiBase = cfg.Providers.Custom.APIBase
+				sel.proxy = cfg.Providers.Custom.Proxy
+			}
 		case "groq":
 			if cfg.Providers.Groq.APIKey != "" {
 				sel.apiKey = cfg.Providers.Groq.APIKey
@@ -214,6 +220,10 @@ func resolveProviderSelection(cfg *config.Config) (providerSelection, error) {
 	// Fallback: infer provider from model and configured keys.
 	if sel.apiKey == "" && sel.apiBase == "" {
 		switch {
+		case cfg.Providers.Custom.APIBase != "":
+			sel.apiKey = cfg.Providers.Custom.APIKey
+			sel.apiBase = cfg.Providers.Custom.APIBase
+			sel.proxy = cfg.Providers.Custom.Proxy
 		case (strings.Contains(lowerModel, "kimi") || strings.Contains(lowerModel, "moonshot") || strings.HasPrefix(model, "moonshot/")) && cfg.Providers.Moonshot.APIKey != "":
 			sel.apiKey = cfg.Providers.Moonshot.APIKey
 			sel.apiBase = cfg.Providers.Moonshot.APIBase


### PR DESCRIPTION
### Changes
- **Configuration** (`pkg/config/config.go`)
  - Added `Custom` field to `ProvidersConfig` struct
  - Initialized `Custom` default value in `DefaultConfig()` function

- **Provider Factory** (`pkg/providers/factory.go`)
  - Added explicit `"custom"` provider configuration support in `resolveProviderSelection` function
  - Added custom provider auto-detection in fallback logic

### Usage
Add the following to your configuration file:

```json
{
  "agents": {
    "defaults": {
      "provider": "custom",
      "model": "your-model-name"
    }
  },
  "providers": {
    "custom": {
      "api_key": "your-api-key",
      "api_base": "https://api.your-provider.com/v1",
      "proxy": ""
    }
  }
}