### PR TITLE
fix(security): Symlink TOCTOU race condition

### DIFF
--- a/pkg/tools/filesystem.go
+++ b/pkg/tools/filesystem.go
@@ -43,6 +43,9 @@ func validatePath(path, workspace string, restrict bool) (string, error) {
 			if !isWithinWorkspace(resolved, workspaceReal) {
 				return "", fmt.Errorf("access denied: symlink resolves outside workspace")
 			}
+			// Return the resolved path to prevent TOCTOU race
+			// the caller operates on the validated target directly.
+			absPath = resolved
 		} else if os.IsNotExist(err) {
 			if parentResolved, err := resolveExistingAncestor(filepath.Dir(absPath)); err == nil {
 				if !isWithinWorkspace(parentResolved, workspaceReal) {


### PR DESCRIPTION
@Leeaandrob 

  validatePath() resolved symlinks for validation but returned the original unresolved path. An attacker could retarget the  symlink between check and use. Now returns the resolved path directly.                                                   
                                                                                                                             
  🗣️  Type of Change                                                                                                        

  - 🐞 Bug fix (non-breaking change which fixes an issue)

  🤖 AI Code Generation

  - 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

  🔗 Related Issue

  Security audit finding, no existing issue.

  📚 Technical Context (Skip for Docs)

  - Reference URL: N/A
  - Reasoning: TOCTOU race in pkg/tools/filesystem.go. EvalSymlinks result was checked but discarded . callers (ReadFileTool, WriteFileTool, ListDirTool) operated on the original symlink path. 

  🧪 Test Environment

  - Hardware: MacBook (Apple Silicon)
  - OS: macOS (Darwin 23.3.0)
  - Model/Provider: N/A
  - Channels: N/A

  📸 Evidence (Optional)

  One-line change: absPath = resolved after symlink validation passes.

  ☑️  Checklist

  - My code/docs follow the style of this project.
  - I have performed a self-review of my own changes.
  - I have updated the documentation accordingly.

