### PR TITLE
feat(observability): add ToolObserver hook for structured tool tracing

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -208,6 +208,16 @@ func (al *AgentLoop) RegisterTool(tool tools.Tool) {
 	}
 }
 
+// SetToolObserver registers a ToolObserver on every agent's tool registry.
+// The observer is called after every tool execution with name, args, result, and duration.
+func (al *AgentLoop) SetToolObserver(obs tools.ToolObserver) {
+	for _, agentID := range al.registry.ListAgentIDs() {
+		if agent, ok := al.registry.GetAgent(agentID); ok {
+			agent.Tools.SetObserver(obs)
+		}
+	}
+}
+
 func (al *AgentLoop) SetChannelManager(cm *channels.Manager) {
 	al.channelManager = cm
 }


### PR DESCRIPTION
## Summary

Adds a lightweight observer pattern to `ToolRegistry` that fires after every tool execution. This enables external observability integrations (W&B Weave, OpenTelemetry, custom metrics) without modifying individual tools.

## Changes

### `pkg/tools/registry.go`
- Add `ToolObserver` func type: `func(name string, args map[string]interface{}, result *ToolResult, durationMs int64)`
- Add `observer` field to `ToolRegistry`
- Add `SetObserver()` method
- Fire observer in `ExecuteWithContext` after every tool call

### `pkg/agent/loop.go`
- Add `SetToolObserver()` to `AgentLoop` — propagates observer to all agent tool registries

### `cmd/picoclaw/main.go`
- Wire observer in `agentCmd` when `PICOCLAW_WEAVE_OBSERVE=1`
- Emits `WEAVE_TOOL_EVENT:` JSON lines to stderr for downstream consumption

## Design

The observer is a **zero-cost abstraction** when not set — a single nil check before the call. No allocations, no goroutines.

The `WEAVE_TOOL_EVENT:` line format emitted to stderr:
```
WEAVE_TOOL_EVENT:{"tool":"exec","duration_ms":42,"is_error":false,"args":{...}}
```

This is intentionally transport-agnostic — any process reading the agent's stderr can parse these lines. The W&B Weave integration reads them from the agent subprocess and logs structured traces per run, but the hook itself has no Weave dependency.

## Usage

```go
// Custom observer — log to any backend
agentLoop.SetToolObserver(func(name string, args map[string]interface{}, result *tools.ToolResult, durationMs int64) {
    myTracer.RecordToolCall(name, durationMs, result.IsError)
})
```

Or via env var for the built-in stderr emitter:
```bash
PICOCLAW_WEAVE_OBSERVE=1 picoclaw agent -m "your prompt"
```
