### PR TITLE
fix(docker): enable container-to-host connectivity for localhost services (e.g., Ollama)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
     container_name: picoclaw-agent
     profiles:
       - agent
+    # Uncomment to access host network; leave commented unless needed.
+    #extra_hosts:
+    #  - "host.docker.internal:host-gateway"
     volumes:
       - ./config/config.json:/home/picoclaw/.picoclaw/config.json:ro
       - picoclaw-workspace:/home/picoclaw/.picoclaw/workspace
@@ -29,6 +32,9 @@ services:
     restart: unless-stopped
     profiles:
       - gateway
+    # Uncomment to access host network; leave commented unless needed.
+    #extra_hosts:
+    #  - "host.docker.internal:host-gateway"
     volumes:
       # Configuration file
       - ./config/config.json:/home/picoclaw/.picoclaw/config.json:ro


### PR DESCRIPTION
## 📝 Description

Fixes Docker containers unable to access Ollama when running on the host machine.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue
#466, #75

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://forums.docker.com/t/how-to-reach-localhost-on-host-from-docker-container/113321/9
- **Reasoning:** By default, Docker isolates containers from the host network and other containers for security reasons.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Fedora 43
- **Model/Provider:** Ollama (localhost)
- **Channels:** -


## 📸 Evidence (Optional)

<img width="1027" height="883" alt="Screenshot From 2026-02-19 16-53-02" src="https://github.com/user-attachments/assets/ca57f063-a6ff-40d9-9bba-a47105391ed1" />


If Ollama is already running, it must be restarted with the correct host binding. I used:
```bash
pkill ollama
OLLAMA_HOST=0.0.0.0 ollama serve
```
On Fedora, Ollama must listen on 0.0.0.0 to be accessible from Docker. This is typically unnecessary on macOS or Windows.

I used whit config:
```
    "openai": {
      "api_key": "xxx",
      "api_base": "http://host.docker.internal:11434/v1"
    },
```
This setting must point to "api_base": "http://host.docker.internal:11434/v1".
An api_key must also be provided. The value itself is not important, but it cannot be empty because the client validates its presence.

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [NA] I have updated the documentation accordingly.

I don’t believe this needs a docs update yet, cloud setups work as expected. This is specific to local Ollama in Docker and seems like an isolated case. It may be worth documenting once an official Ollama provider is added.