### PR TITLE
fix(web_fetch): include fetched page content in ForLLM response

### DIFF
--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -477,7 +477,7 @@ func (t *WebFetchTool) Execute(ctx context.Context, args map[string]interface{})
 	resultJSON, _ := json.MarshalIndent(result, "", "  ")
 
 	return &ToolResult{
-		ForLLM:  fmt.Sprintf("Fetched %d bytes from %s (extractor: %s, truncated: %v)", len(text), urlStr, extractor, truncated),
+		ForLLM:  fmt.Sprintf("Fetched %d bytes from %s (extractor: %s, truncated: %v)\n\n%s", len(text), urlStr, extractor, truncated, text),
 		ForUser: string(resultJSON),
 	}
 }

--- a/pkg/tools/web_test.go
+++ b/pkg/tools/web_test.go
@@ -36,9 +36,14 @@ func TestWebTool_WebFetch_Success(t *testing.T) {
 		t.Errorf("Expected ForUser to contain 'Test Page', got: %s", result.ForUser)
 	}
 
-	// ForLLM should contain summary
-	if !strings.Contains(result.ForLLM, "bytes") && !strings.Contains(result.ForLLM, "extractor") {
-		t.Errorf("Expected ForLLM to contain summary, got: %s", result.ForLLM)
+	// ForLLM should contain summary metadata
+	if !strings.Contains(result.ForLLM, "bytes") || !strings.Contains(result.ForLLM, "extractor") {
+		t.Errorf("Expected ForLLM to contain summary metadata, got: %s", result.ForLLM)
+	}
+
+	// ForLLM should contain the actual fetched page content
+	if !strings.Contains(result.ForLLM, "Test Page") {
+		t.Errorf("Expected ForLLM to contain actual page content 'Test Page', got: %s", result.ForLLM)
 	}
 }
 
@@ -68,8 +73,13 @@ func TestWebTool_WebFetch_JSON(t *testing.T) {
 	}
 
 	// ForUser should contain formatted JSON
-	if !strings.Contains(result.ForUser, "key") && !strings.Contains(result.ForUser, "value") {
+	if !strings.Contains(result.ForUser, "key") || !strings.Contains(result.ForUser, "value") {
 		t.Errorf("Expected ForUser to contain JSON data, got: %s", result.ForUser)
+	}
+
+	// ForLLM should contain the actual JSON content, not just metadata
+	if !strings.Contains(result.ForLLM, "key") || !strings.Contains(result.ForLLM, "value") {
+		t.Errorf("Expected ForLLM to contain actual JSON content, got: %s", result.ForLLM)
 	}
 }
 
@@ -224,13 +234,18 @@ func TestWebTool_WebFetch_HTMLExtraction(t *testing.T) {
 	}
 
 	// ForUser should contain extracted text (without script/style tags)
-	if !strings.Contains(result.ForUser, "Title") && !strings.Contains(result.ForUser, "Content") {
+	if !strings.Contains(result.ForUser, "Title") || !strings.Contains(result.ForUser, "Content") {
 		t.Errorf("Expected ForUser to contain extracted text, got: %s", result.ForUser)
 	}
 
 	// Should NOT contain script or style tags
 	if strings.Contains(result.ForUser, "<script>") || strings.Contains(result.ForUser, "<style>") {
 		t.Errorf("Expected script/style tags to be removed, got: %s", result.ForUser)
+	}
+
+	// ForLLM should also contain the extracted text content
+	if !strings.Contains(result.ForLLM, "Title") || !strings.Contains(result.ForLLM, "Content") {
+		t.Errorf("Expected ForLLM to contain extracted text content, got: %s", result.ForLLM)
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

The `web_fetch` tool's `ForLLM` field only returned a metadata summary line (byte count, extractor type, truncation status), omitting the actual extracted page content. This meant the LLM could never read fetched web pages, causing it to loop calling `web_fetch` repeatedly until `max_tool_iterations` was hit.

The fix appends the extracted text content to the `ForLLM` response so the LLM can read and reason about fetched pages.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #388

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/388
- **Reasoning:** `ForLLM` is what the LLM sees as the tool result. Without the actual content, the tool provides no value and causes the LLM to loop indefinitely.

## 🧪 Test Environment
- **Hardware:** Mac (x86_64)
- **OS:** macOS
- **Model/Provider:** N/A (unit tests only, no API keys needed)
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

**Before (broken):** `ForLLM` returns only:
```
Fetched 5000 bytes from https://example.com (extractor: text, truncated: false)
```

**After (fixed):** `ForLLM` returns metadata + actual content:
```
Fetched 5000 bytes from https://example.com (extractor: text, truncated: false)

[actual page content here]
```

All tests pass: `make fmt`, `make vet`, `make test` ✓

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.

Made with [Cursor](https://cursor.com)