### PR TITLE
docs(config): add missing duckduckgo, exec, and qq sections to example config

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -59,6 +59,12 @@
       "token": "YOUR_DISCORD_BOT_TOKEN",
       "allow_from": []
     },
+    "qq": {
+      "enabled": false,
+      "app_id": "YOUR_QQ_APP_ID",
+      "app_secret": "YOUR_QQ_APP_SECRET",
+      "allow_from": []
+    },
     "maixcam": {
       "enabled": false,
       "host": "0.0.0.0",
@@ -172,6 +178,10 @@
         "api_key": "YOUR_BRAVE_API_KEY",
         "max_results": 5
       },
+      "duckduckgo": {
+        "enabled": true,
+        "max_results": 5
+      },
       "perplexity": {
         "enabled": false,
         "api_key": "pplx-xxx",
@@ -180,6 +190,10 @@
     },
     "cron": {
       "exec_timeout_minutes": 5
+    },
+    "exec": {
+      "enable_deny_patterns": false,
+      "custom_deny_patterns": []
     }
   },
   "heartbeat": {


### PR DESCRIPTION
## 📝 Description

`config.example.json` was missing three sections that exist in the Go config structs (`pkg/config/config.go`) and have defaults in `pkg/config/defaults.go`:

1. **`tools.web.duckduckgo`** — DuckDuckGo search is **enabled by default** in `defaults.go` and requires **no API key** (it's the only free web search provider). Users who copy the example config as their starting point silently lose web search because this section was omitted entirely.

2. **`tools.exec`** — The `ExecConfig` struct supports `enable_deny_patterns` and `custom_deny_patterns` for security hardening, but the example config didn't surface these options.

3. **`channels.qq`** — QQ was the only channel defined in `ChannelsConfig` that was missing from the example while all 9 other channels were present.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Addresses the **Documentation & DX** goal in ROADMAP.md (Section 5): "Creating clear, user-friendly documentation for both setup and development."

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** `pkg/config/defaults.go` lines 245-265 (DuckDuckGo default), `pkg/config/config.go` lines 392-421 (struct definitions)
- **Reasoning:** The example config should reflect all configurable sections so users can discover and customize them. The DuckDuckGo gap is especially impactful since it's the only free, no-API-key search option — aligned with PicoClaw's low-cost philosophy.

## 🧪 Test Environment
- **Hardware:** Mac (x86_64)
- **OS:** macOS
- **Verification:** JSON validated, `make fmt && make vet && make test` all pass

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.

Made with [Cursor](https://cursor.com)