### PR TITLE
ci: enable gofumpt in CI

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -160,11 +160,11 @@ issues:
 
 formatters:
   enable:
+    - gofumpt
     - goimports
   # TODO: Disabled, because they are failing at the moment, we should fix them and enable (step by step)
   #    - gci
   #    - gofmt
-  #    - gofumpt
   #    - golines
   settings:
     gci:

--- a/cmd/picoclaw/cmd_agent.go
+++ b/cmd/picoclaw/cmd_agent.go
@@ -104,7 +104,6 @@ func interactiveMode(agentLoop *agent.AgentLoop, sessionKey string) {
 		InterruptPrompt: "^C",
 		EOFPrompt:       "exit",
 	})
-
 	if err != nil {
 		fmt.Printf("Error initializing readline: %v\n", err)
 		fmt.Println("Falling back to simple input mode...")

--- a/cmd/picoclaw/cmd_onboard.go
+++ b/cmd/picoclaw/cmd_onboard.go
@@ -55,7 +55,7 @@ func onboard() {
 
 func copyEmbeddedToTarget(targetDir string) error {
 	// Ensure target directory exists
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		return fmt.Errorf("Failed to create target directory: %w", err)
 	}
 
@@ -85,12 +85,12 @@ func copyEmbeddedToTarget(targetDir string) error {
 		targetPath := filepath.Join(targetDir, new_path)
 
 		// Ensure target file's directory exists
-		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 			return fmt.Errorf("Failed to create directory %s: %w", filepath.Dir(targetPath), err)
 		}
 
 		// Write file
-		if err := os.WriteFile(targetPath, data, 0644); err != nil {
+		if err := os.WriteFile(targetPath, data, 0o644); err != nil {
 			return fmt.Errorf("Failed to write file %s: %w", targetPath, err)
 		}
 

--- a/cmd/picoclaw/cmd_skills.go
+++ b/cmd/picoclaw/cmd_skills.go
@@ -126,7 +126,7 @@ func skillsInstallFromRegistry(cfg *config.Config, registryName, slug string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	if err := os.MkdirAll(filepath.Join(workspace, "skills"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspace, "skills"), 0o755); err != nil {
 		fmt.Printf("\u2717 Failed to create skills directory: %v\n", err)
 		os.Exit(1)
 	}
@@ -193,7 +193,7 @@ func skillsInstallBuiltinCmd(workspace string) {
 			continue
 		}
 
-		if err := os.MkdirAll(workspacePath, 0755); err != nil {
+		if err := os.MkdirAll(workspacePath, 0o755); err != nil {
 			fmt.Printf("✗ Failed to create directory for %s: %v\n", skillName, err)
 			continue
 		}

--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -41,7 +41,7 @@ func NewAgentInstance(
 	provider providers.LLMProvider,
 ) *AgentInstance {
 	workspace := resolveAgentWorkspace(agentCfg, defaults)
-	os.MkdirAll(workspace, 0755)
+	os.MkdirAll(workspace, 0o755)
 
 	model := resolveAgentModel(agentCfg, defaults)
 	fallbacks := resolveAgentFallbacks(agentCfg, defaults)

--- a/pkg/agent/memory.go
+++ b/pkg/agent/memory.go
@@ -29,7 +29,7 @@ func NewMemoryStore(workspace string) *MemoryStore {
 	memoryFile := filepath.Join(memoryDir, "MEMORY.md")
 
 	// Ensure memory directory exists
-	os.MkdirAll(memoryDir, 0755)
+	os.MkdirAll(memoryDir, 0o755)
 
 	return &MemoryStore{
 		workspace:  workspace,
@@ -57,7 +57,7 @@ func (ms *MemoryStore) ReadLongTerm() string {
 
 // WriteLongTerm writes content to the long-term memory file (MEMORY.md).
 func (ms *MemoryStore) WriteLongTerm(content string) error {
-	return os.WriteFile(ms.memoryFile, []byte(content), 0644)
+	return os.WriteFile(ms.memoryFile, []byte(content), 0o644)
 }
 
 // ReadToday reads today's daily note.
@@ -77,7 +77,7 @@ func (ms *MemoryStore) AppendToday(content string) error {
 
 	// Ensure month directory exists
 	monthDir := filepath.Dir(todayFile)
-	os.MkdirAll(monthDir, 0755)
+	os.MkdirAll(monthDir, 0o755)
 
 	var existingContent string
 	if data, err := os.ReadFile(todayFile); err == nil {
@@ -94,7 +94,7 @@ func (ms *MemoryStore) AppendToday(content string) error {
 		newContent = existingContent + "\n" + content
 	}
 
-	return os.WriteFile(todayFile, []byte(newContent), 0644)
+	return os.WriteFile(todayFile, []byte(newContent), 0o644)
 }
 
 // GetRecentDailyNotes returns daily notes from the last N days.

--- a/pkg/auth/store.go
+++ b/pkg/auth/store.go
@@ -64,7 +64,7 @@ func LoadStore() (*AuthStore, error) {
 func SaveStore(store *AuthStore) error {
 	path := authFilePath()
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 
@@ -72,7 +72,7 @@ func SaveStore(store *AuthStore) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0600)
+	return os.WriteFile(path, data, 0o600)
 }
 
 func GetCredential(provider string) (*AuthCredential, error) {

--- a/pkg/auth/store_test.go
+++ b/pkg/auth/store_test.go
@@ -108,7 +108,7 @@ func TestStoreFilePermissions(t *testing.T) {
 		t.Fatalf("Stat() error: %v", err)
 	}
 	perm := info.Mode().Perm()
-	if perm != 0600 {
+	if perm != 0o600 {
 		t.Errorf("file permissions = %o, want 0600", perm)
 	}
 }

--- a/pkg/channels/dingtalk.go
+++ b/pkg/channels/dingtalk.go
@@ -192,7 +192,6 @@ func (c *DingTalkChannel) SendDirectReply(ctx context.Context, sessionWebhook, c
 		titleBytes,
 		contentBytes,
 	)
-
 	if err != nil {
 		return fmt.Errorf("failed to send reply: %w", err)
 	}

--- a/pkg/channels/telegram.go
+++ b/pkg/channels/telegram.go
@@ -140,6 +140,7 @@ func (c *TelegramChannel) Start(ctx context.Context) error {
 
 	return nil
 }
+
 func (c *TelegramChannel) Stop(ctx context.Context) error {
 	logger.InfoC("telegram", "Stopping Telegram bot...")
 	c.setRunning(false)

--- a/pkg/channels/telegram_commands.go
+++ b/pkg/channels/telegram_commands.go
@@ -35,6 +35,7 @@ func commandArgs(text string) string {
 	}
 	return strings.TrimSpace(parts[1])
 }
+
 func (c *cmd) Help(ctx context.Context, message telego.Message) error {
 	msg := `/start - Start the bot
 /help - Show this help message
@@ -96,6 +97,7 @@ func (c *cmd) Show(ctx context.Context, message telego.Message) error {
 	})
 	return err
 }
+
 func (c *cmd) List(ctx context.Context, message telego.Message) error {
 	args := commandArgs(message.Text)
 	if args == "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -335,7 +335,7 @@ type ProviderConfig struct {
 	APIBase     string `json:"api_base" env:"PICOCLAW_PROVIDERS_{{.Name}}_API_BASE"`
 	Proxy       string `json:"proxy,omitempty" env:"PICOCLAW_PROVIDERS_{{.Name}}_PROXY"`
 	AuthMethod  string `json:"auth_method,omitempty" env:"PICOCLAW_PROVIDERS_{{.Name}}_AUTH_METHOD"`
-	ConnectMode string `json:"connect_mode,omitempty" env:"PICOCLAW_PROVIDERS_{{.Name}}_CONNECT_MODE"` //only for Github Copilot, `stdio` or `grpc`
+	ConnectMode string `json:"connect_mode,omitempty" env:"PICOCLAW_PROVIDERS_{{.Name}}_CONNECT_MODE"` // only for Github Copilot, `stdio` or `grpc`
 }
 
 type OpenAIProviderConfig struct {
@@ -489,11 +489,11 @@ func SaveConfig(path string, cfg *Config) error {
 	}
 
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 
-	return os.WriteFile(path, data, 0600)
+	return os.WriteFile(path, data, 0o600)
 }
 
 func (c *Config) WorkspacePath() string {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -319,7 +319,7 @@ func TestSaveConfig_FilePermissions(t *testing.T) {
 	}
 
 	perm := info.Mode().Perm()
-	if perm != 0600 {
+	if perm != 0o600 {
 		t.Errorf("config file has permission %04o, want 0600", perm)
 	}
 }

--- a/pkg/cron/service.go
+++ b/pkg/cron/service.go
@@ -331,7 +331,7 @@ func (cs *CronService) loadStore() error {
 
 func (cs *CronService) saveStoreUnsafe() error {
 	dir := filepath.Dir(cs.storePath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 
@@ -340,7 +340,7 @@ func (cs *CronService) saveStoreUnsafe() error {
 		return err
 	}
 
-	return os.WriteFile(cs.storePath, data, 0600)
+	return os.WriteFile(cs.storePath, data, 0o600)
 }
 
 func (cs *CronService) AddJob(name string, schedule CronSchedule, message string, deliver bool, channel, to string) (*CronJob, error) {

--- a/pkg/cron/service_test.go
+++ b/pkg/cron/service_test.go
@@ -28,7 +28,7 @@ func TestSaveStore_FilePermissions(t *testing.T) {
 	}
 
 	perm := info.Mode().Perm()
-	if perm != 0600 {
+	if perm != 0o600 {
 		t.Errorf("cron store has permission %04o, want 0600", perm)
 	}
 }

--- a/pkg/heartbeat/service.go
+++ b/pkg/heartbeat/service.go
@@ -275,7 +275,7 @@ This file contains tasks for the heartbeat service to check periodically.
 Add your heartbeat tasks below this line:
 `
 
-	if err := os.WriteFile(heartbeatPath, []byte(defaultContent), 0644); err != nil {
+	if err := os.WriteFile(heartbeatPath, []byte(defaultContent), 0o644); err != nil {
 		hs.logError("Failed to create default HEARTBEAT.md: %v", err)
 	} else {
 		hs.logInfo("Created default HEARTBEAT.md template")
@@ -354,7 +354,7 @@ func (hs *HeartbeatService) logError(format string, args ...any) {
 // log writes a message to the heartbeat log file
 func (hs *HeartbeatService) log(level, format string, args ...any) {
 	logFile := filepath.Join(hs.workspace, "heartbeat.log")
-	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return
 	}

--- a/pkg/heartbeat/service_test.go
+++ b/pkg/heartbeat/service_test.go
@@ -37,7 +37,7 @@ func TestExecuteHeartbeat_Async(t *testing.T) {
 	})
 
 	// Create HEARTBEAT.md
-	os.WriteFile(filepath.Join(tmpDir, "HEARTBEAT.md"), []byte("Test task"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "HEARTBEAT.md"), []byte("Test task"), 0o644)
 
 	// Execute heartbeat directly (internal method for testing)
 	hs.executeHeartbeat()
@@ -68,7 +68,7 @@ func TestExecuteHeartbeat_Error(t *testing.T) {
 	})
 
 	// Create HEARTBEAT.md
-	os.WriteFile(filepath.Join(tmpDir, "HEARTBEAT.md"), []byte("Test task"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "HEARTBEAT.md"), []byte("Test task"), 0o644)
 
 	hs.executeHeartbeat()
 
@@ -106,7 +106,7 @@ func TestExecuteHeartbeat_Silent(t *testing.T) {
 	})
 
 	// Create HEARTBEAT.md
-	os.WriteFile(filepath.Join(tmpDir, "HEARTBEAT.md"), []byte("Test task"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "HEARTBEAT.md"), []byte("Test task"), 0o644)
 
 	hs.executeHeartbeat()
 
@@ -174,7 +174,7 @@ func TestExecuteHeartbeat_NilResult(t *testing.T) {
 	})
 
 	// Create HEARTBEAT.md
-	os.WriteFile(filepath.Join(tmpDir, "HEARTBEAT.md"), []byte("Test task"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "HEARTBEAT.md"), []byte("Test task"), 0o644)
 
 	// Should not panic with nil result
 	hs.executeHeartbeat()

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -71,7 +71,7 @@ func EnableFileLogging(filePath string) error {
 	mu.Lock()
 	defer mu.Unlock()
 
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to open log file: %w", err)
 	}

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -161,7 +161,7 @@ func Execute(actions []Action, openclawHome, picoClawHome string) *Result {
 				fmt.Printf("  ✓ Converted config: %s\n", action.Destination)
 			}
 		case ActionCreateDir:
-			if err := os.MkdirAll(action.Destination, 0755); err != nil {
+			if err := os.MkdirAll(action.Destination, 0o755); err != nil {
 				result.Errors = append(result.Errors, err)
 			} else {
 				result.DirsCreated++
@@ -176,7 +176,7 @@ func Execute(actions []Action, openclawHome, picoClawHome string) *Result {
 			result.BackupsCreated++
 			fmt.Printf("  ✓ Backed up %s -> %s.bak\n", filepath.Base(action.Destination), filepath.Base(action.Destination))
 
-			if err := os.MkdirAll(filepath.Dir(action.Destination), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(action.Destination), 0o755); err != nil {
 				result.Errors = append(result.Errors, err)
 				continue
 			}
@@ -188,7 +188,7 @@ func Execute(actions []Action, openclawHome, picoClawHome string) *Result {
 				fmt.Printf("  ✓ Copied %s\n", relPath(action.Source, openclawHome))
 			}
 		case ActionCopy:
-			if err := os.MkdirAll(filepath.Dir(action.Destination), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(action.Destination), 0o755); err != nil {
 				result.Errors = append(result.Errors, err)
 				continue
 			}
@@ -226,7 +226,7 @@ func executeConfigMigration(srcConfigPath, dstConfigPath, picoClawHome string) e
 		incoming = MergeConfig(existing, incoming)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(dstConfigPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dstConfigPath), 0o755); err != nil {
 		return err
 	}
 	return config.SaveConfig(dstConfigPath, incoming)

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -108,7 +108,7 @@ func TestLoadOpenClawConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(configPath, data, 0644); err != nil {
+	if err := os.WriteFile(configPath, data, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -389,9 +389,9 @@ func TestPlanWorkspaceMigration(t *testing.T) {
 		srcDir := t.TempDir()
 		dstDir := t.TempDir()
 
-		os.WriteFile(filepath.Join(srcDir, "AGENTS.md"), []byte("# Agents"), 0644)
-		os.WriteFile(filepath.Join(srcDir, "SOUL.md"), []byte("# Soul"), 0644)
-		os.WriteFile(filepath.Join(srcDir, "USER.md"), []byte("# User"), 0644)
+		os.WriteFile(filepath.Join(srcDir, "AGENTS.md"), []byte("# Agents"), 0o644)
+		os.WriteFile(filepath.Join(srcDir, "SOUL.md"), []byte("# Soul"), 0o644)
+		os.WriteFile(filepath.Join(srcDir, "USER.md"), []byte("# User"), 0o644)
 
 		actions, err := PlanWorkspaceMigration(srcDir, dstDir, false)
 		if err != nil {
@@ -420,8 +420,8 @@ func TestPlanWorkspaceMigration(t *testing.T) {
 		srcDir := t.TempDir()
 		dstDir := t.TempDir()
 
-		os.WriteFile(filepath.Join(srcDir, "AGENTS.md"), []byte("# Agents from OpenClaw"), 0644)
-		os.WriteFile(filepath.Join(dstDir, "AGENTS.md"), []byte("# Existing Agents"), 0644)
+		os.WriteFile(filepath.Join(srcDir, "AGENTS.md"), []byte("# Agents from OpenClaw"), 0o644)
+		os.WriteFile(filepath.Join(dstDir, "AGENTS.md"), []byte("# Existing Agents"), 0o644)
 
 		actions, err := PlanWorkspaceMigration(srcDir, dstDir, false)
 		if err != nil {
@@ -443,8 +443,8 @@ func TestPlanWorkspaceMigration(t *testing.T) {
 		srcDir := t.TempDir()
 		dstDir := t.TempDir()
 
-		os.WriteFile(filepath.Join(srcDir, "AGENTS.md"), []byte("# Agents"), 0644)
-		os.WriteFile(filepath.Join(dstDir, "AGENTS.md"), []byte("# Existing"), 0644)
+		os.WriteFile(filepath.Join(srcDir, "AGENTS.md"), []byte("# Agents"), 0o644)
+		os.WriteFile(filepath.Join(dstDir, "AGENTS.md"), []byte("# Existing"), 0o644)
 
 		actions, err := PlanWorkspaceMigration(srcDir, dstDir, true)
 		if err != nil {
@@ -463,8 +463,8 @@ func TestPlanWorkspaceMigration(t *testing.T) {
 		dstDir := t.TempDir()
 
 		memDir := filepath.Join(srcDir, "memory")
-		os.MkdirAll(memDir, 0755)
-		os.WriteFile(filepath.Join(memDir, "MEMORY.md"), []byte("# Memory"), 0644)
+		os.MkdirAll(memDir, 0o755)
+		os.WriteFile(filepath.Join(memDir, "MEMORY.md"), []byte("# Memory"), 0o644)
 
 		actions, err := PlanWorkspaceMigration(srcDir, dstDir, false)
 		if err != nil {
@@ -494,8 +494,8 @@ func TestPlanWorkspaceMigration(t *testing.T) {
 		dstDir := t.TempDir()
 
 		skillDir := filepath.Join(srcDir, "skills", "weather")
-		os.MkdirAll(skillDir, 0755)
-		os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Weather"), 0644)
+		os.MkdirAll(skillDir, 0o755)
+		os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Weather"), 0o644)
 
 		actions, err := PlanWorkspaceMigration(srcDir, dstDir, false)
 		if err != nil {
@@ -518,7 +518,7 @@ func TestFindOpenClawConfig(t *testing.T) {
 	t.Run("finds openclaw.json", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "openclaw.json")
-		os.WriteFile(configPath, []byte("{}"), 0644)
+		os.WriteFile(configPath, []byte("{}"), 0o644)
 
 		found, err := findOpenClawConfig(tmpDir)
 		if err != nil {
@@ -532,7 +532,7 @@ func TestFindOpenClawConfig(t *testing.T) {
 	t.Run("falls back to config.json", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "config.json")
-		os.WriteFile(configPath, []byte("{}"), 0644)
+		os.WriteFile(configPath, []byte("{}"), 0o644)
 
 		found, err := findOpenClawConfig(tmpDir)
 		if err != nil {
@@ -546,8 +546,8 @@ func TestFindOpenClawConfig(t *testing.T) {
 	t.Run("prefers openclaw.json over config.json", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		openclawPath := filepath.Join(tmpDir, "openclaw.json")
-		os.WriteFile(openclawPath, []byte("{}"), 0644)
-		os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte("{}"), 0644)
+		os.WriteFile(openclawPath, []byte("{}"), 0o644)
+		os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte("{}"), 0o644)
 
 		found, err := findOpenClawConfig(tmpDir)
 		if err != nil {
@@ -593,9 +593,9 @@ func TestRunDryRun(t *testing.T) {
 	picoClawHome := t.TempDir()
 
 	wsDir := filepath.Join(openclawHome, "workspace")
-	os.MkdirAll(wsDir, 0755)
-	os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("# Soul"), 0644)
-	os.WriteFile(filepath.Join(wsDir, "AGENTS.md"), []byte("# Agents"), 0644)
+	os.MkdirAll(wsDir, 0o755)
+	os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("# Soul"), 0o644)
+	os.WriteFile(filepath.Join(wsDir, "AGENTS.md"), []byte("# Agents"), 0o644)
 
 	configData := map[string]interface{}{
 		"providers": map[string]interface{}{
@@ -605,7 +605,7 @@ func TestRunDryRun(t *testing.T) {
 		},
 	}
 	data, _ := json.Marshal(configData)
-	os.WriteFile(filepath.Join(openclawHome, "openclaw.json"), data, 0644)
+	os.WriteFile(filepath.Join(openclawHome, "openclaw.json"), data, 0o644)
 
 	opts := Options{
 		DryRun:       true,
@@ -634,14 +634,14 @@ func TestRunFullMigration(t *testing.T) {
 	picoClawHome := t.TempDir()
 
 	wsDir := filepath.Join(openclawHome, "workspace")
-	os.MkdirAll(wsDir, 0755)
-	os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("# Soul from OpenClaw"), 0644)
-	os.WriteFile(filepath.Join(wsDir, "AGENTS.md"), []byte("# Agents from OpenClaw"), 0644)
-	os.WriteFile(filepath.Join(wsDir, "USER.md"), []byte("# User from OpenClaw"), 0644)
+	os.MkdirAll(wsDir, 0o755)
+	os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("# Soul from OpenClaw"), 0o644)
+	os.WriteFile(filepath.Join(wsDir, "AGENTS.md"), []byte("# Agents from OpenClaw"), 0o644)
+	os.WriteFile(filepath.Join(wsDir, "USER.md"), []byte("# User from OpenClaw"), 0o644)
 
 	memDir := filepath.Join(wsDir, "memory")
-	os.MkdirAll(memDir, 0755)
-	os.WriteFile(filepath.Join(memDir, "MEMORY.md"), []byte("# Memory notes"), 0644)
+	os.MkdirAll(memDir, 0o755)
+	os.WriteFile(filepath.Join(memDir, "MEMORY.md"), []byte("# Memory notes"), 0o644)
 
 	configData := map[string]interface{}{
 		"providers": map[string]interface{}{
@@ -660,7 +660,7 @@ func TestRunFullMigration(t *testing.T) {
 		},
 	}
 	data, _ := json.Marshal(configData)
-	os.WriteFile(filepath.Join(openclawHome, "openclaw.json"), data, 0644)
+	os.WriteFile(filepath.Join(openclawHome, "openclaw.json"), data, 0o644)
 
 	opts := Options{
 		Force:        true,
@@ -754,7 +754,7 @@ func TestRunMutuallyExclusiveFlags(t *testing.T) {
 func TestBackupFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "test.md")
-	os.WriteFile(filePath, []byte("original content"), 0644)
+	os.WriteFile(filePath, []byte("original content"), 0o644)
 
 	if err := backupFile(filePath); err != nil {
 		t.Fatalf("backupFile: %v", err)
@@ -775,7 +775,7 @@ func TestCopyFile(t *testing.T) {
 	srcPath := filepath.Join(tmpDir, "src.md")
 	dstPath := filepath.Join(tmpDir, "dst.md")
 
-	os.WriteFile(srcPath, []byte("file content"), 0644)
+	os.WriteFile(srcPath, []byte("file content"), 0o644)
 
 	if err := copyFile(srcPath, dstPath); err != nil {
 		t.Fatalf("copyFile: %v", err)
@@ -795,8 +795,8 @@ func TestRunConfigOnly(t *testing.T) {
 	picoClawHome := t.TempDir()
 
 	wsDir := filepath.Join(openclawHome, "workspace")
-	os.MkdirAll(wsDir, 0755)
-	os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("# Soul"), 0644)
+	os.MkdirAll(wsDir, 0o755)
+	os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("# Soul"), 0o644)
 
 	configData := map[string]interface{}{
 		"providers": map[string]interface{}{
@@ -806,7 +806,7 @@ func TestRunConfigOnly(t *testing.T) {
 		},
 	}
 	data, _ := json.Marshal(configData)
-	os.WriteFile(filepath.Join(openclawHome, "openclaw.json"), data, 0644)
+	os.WriteFile(filepath.Join(openclawHome, "openclaw.json"), data, 0o644)
 
 	opts := Options{
 		Force:        true,
@@ -835,8 +835,8 @@ func TestRunWorkspaceOnly(t *testing.T) {
 	picoClawHome := t.TempDir()
 
 	wsDir := filepath.Join(openclawHome, "workspace")
-	os.MkdirAll(wsDir, 0755)
-	os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("# Soul"), 0644)
+	os.MkdirAll(wsDir, 0o755)
+	os.WriteFile(filepath.Join(wsDir, "SOUL.md"), []byte("# Soul"), 0o644)
 
 	configData := map[string]interface{}{
 		"providers": map[string]interface{}{
@@ -846,7 +846,7 @@ func TestRunWorkspaceOnly(t *testing.T) {
 		},
 	}
 	data, _ := json.Marshal(configData)
-	os.WriteFile(filepath.Join(openclawHome, "openclaw.json"), data, 0644)
+	os.WriteFile(filepath.Join(openclawHome, "openclaw.json"), data, 0o644)
 
 	opts := Options{
 		Force:         true,

--- a/pkg/providers/anthropic/provider.go
+++ b/pkg/providers/anthropic/provider.go
@@ -12,13 +12,15 @@ import (
 	"github.com/sipeed/picoclaw/pkg/providers/protocoltypes"
 )
 
-type ToolCall = protocoltypes.ToolCall
-type FunctionCall = protocoltypes.FunctionCall
-type LLMResponse = protocoltypes.LLMResponse
-type UsageInfo = protocoltypes.UsageInfo
-type Message = protocoltypes.Message
-type ToolDefinition = protocoltypes.ToolDefinition
-type ToolFunctionDefinition = protocoltypes.ToolFunctionDefinition
+type (
+	ToolCall               = protocoltypes.ToolCall
+	FunctionCall           = protocoltypes.FunctionCall
+	LLMResponse            = protocoltypes.LLMResponse
+	UsageInfo              = protocoltypes.UsageInfo
+	Message                = protocoltypes.Message
+	ToolDefinition         = protocoltypes.ToolDefinition
+	ToolFunctionDefinition = protocoltypes.ToolFunctionDefinition
+)
 
 const defaultBaseURL = "https://api.anthropic.com"
 

--- a/pkg/providers/claude_cli_provider_test.go
+++ b/pkg/providers/claude_cli_provider_test.go
@@ -30,12 +30,12 @@ func createMockCLI(t *testing.T, stdout, stderr string, exitCode int) string {
 	dir := t.TempDir()
 
 	if stdout != "" {
-		if err := os.WriteFile(filepath.Join(dir, "stdout.txt"), []byte(stdout), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "stdout.txt"), []byte(stdout), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
 	if stderr != "" {
-		if err := os.WriteFile(filepath.Join(dir, "stderr.txt"), []byte(stderr), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "stderr.txt"), []byte(stderr), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -51,7 +51,7 @@ func createMockCLI(t *testing.T, stdout, stderr string, exitCode int) string {
 	sb.WriteString(fmt.Sprintf("exit %d\n", exitCode))
 
 	script := filepath.Join(dir, "claude")
-	if err := os.WriteFile(script, []byte(sb.String()), 0755); err != nil {
+	if err := os.WriteFile(script, []byte(sb.String()), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return script
@@ -67,7 +67,7 @@ func createSlowMockCLI(t *testing.T, sleepSeconds int) string {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "claude")
 	content := fmt.Sprintf("#!/bin/sh\nsleep %d\necho '{\"type\":\"result\",\"result\":\"late\"}'\n", sleepSeconds)
-	if err := os.WriteFile(script, []byte(content), 0755); err != nil {
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return script
@@ -88,7 +88,7 @@ cat <<'EOFMOCK'
 {"type":"result","result":"ok","session_id":"test"}
 EOFMOCK
 `, argsFile)
-	if err := os.WriteFile(script, []byte(content), 0755); err != nil {
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return script
@@ -137,7 +137,6 @@ func TestChat_Success(t *testing.T) {
 	resp, err := p.Chat(context.Background(), []Message{
 		{Role: "user", Content: "Hello"},
 	}, nil, "", nil)
-
 	if err != nil {
 		t.Fatalf("Chat() error = %v", err)
 	}
@@ -193,7 +192,6 @@ func TestChat_WithToolCallsInResponse(t *testing.T) {
 	resp, err := p.Chat(context.Background(), []Message{
 		{Role: "user", Content: "What's the weather?"},
 	}, nil, "", nil)
-
 	if err != nil {
 		t.Fatalf("Chat() error = %v", err)
 	}
@@ -403,7 +401,6 @@ func TestChat_EmptyWorkspaceDoesNotSetDir(t *testing.T) {
 	resp, err := p.Chat(context.Background(), []Message{
 		{Role: "user", Content: "Hello"},
 	}, nil, "", nil)
-
 	if err != nil {
 		t.Fatalf("Chat() with empty workspace error = %v", err)
 	}

--- a/pkg/providers/codex_cli_credentials_test.go
+++ b/pkg/providers/codex_cli_credentials_test.go
@@ -18,7 +18,7 @@ func TestReadCodexCliCredentials_Valid(t *testing.T) {
 			"account_id": "org-test123"
 		}
 	}`
-	if err := os.WriteFile(authPath, []byte(authJSON), 0600); err != nil {
+	if err := os.WriteFile(authPath, []byte(authJSON), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -58,7 +58,7 @@ func TestReadCodexCliCredentials_EmptyToken(t *testing.T) {
 	authPath := filepath.Join(tmpDir, "auth.json")
 
 	authJSON := `{"tokens": {"access_token": "", "refresh_token": "r", "account_id": "a"}}`
-	if err := os.WriteFile(authPath, []byte(authJSON), 0600); err != nil {
+	if err := os.WriteFile(authPath, []byte(authJSON), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -74,7 +74,7 @@ func TestReadCodexCliCredentials_InvalidJSON(t *testing.T) {
 	tmpDir := t.TempDir()
 	authPath := filepath.Join(tmpDir, "auth.json")
 
-	if err := os.WriteFile(authPath, []byte("not json"), 0600); err != nil {
+	if err := os.WriteFile(authPath, []byte("not json"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -91,7 +91,7 @@ func TestReadCodexCliCredentials_NoAccountID(t *testing.T) {
 	authPath := filepath.Join(tmpDir, "auth.json")
 
 	authJSON := `{"tokens": {"access_token": "tok123", "refresh_token": "ref456"}}`
-	if err := os.WriteFile(authPath, []byte(authJSON), 0600); err != nil {
+	if err := os.WriteFile(authPath, []byte(authJSON), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -112,12 +112,12 @@ func TestReadCodexCliCredentials_NoAccountID(t *testing.T) {
 func TestReadCodexCliCredentials_CodexHomeEnv(t *testing.T) {
 	tmpDir := t.TempDir()
 	customDir := filepath.Join(tmpDir, "custom-codex")
-	if err := os.MkdirAll(customDir, 0755); err != nil {
+	if err := os.MkdirAll(customDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	authJSON := `{"tokens": {"access_token": "custom-token", "refresh_token": "r"}}`
-	if err := os.WriteFile(filepath.Join(customDir, "auth.json"), []byte(authJSON), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(customDir, "auth.json"), []byte(authJSON), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -137,7 +137,7 @@ func TestCreateCodexCliTokenSource_Valid(t *testing.T) {
 	authPath := filepath.Join(tmpDir, "auth.json")
 
 	authJSON := `{"tokens": {"access_token": "fresh-token", "refresh_token": "r", "account_id": "acc"}}`
-	if err := os.WriteFile(authPath, []byte(authJSON), 0600); err != nil {
+	if err := os.WriteFile(authPath, []byte(authJSON), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -161,7 +161,7 @@ func TestCreateCodexCliTokenSource_Expired(t *testing.T) {
 	authPath := filepath.Join(tmpDir, "auth.json")
 
 	authJSON := `{"tokens": {"access_token": "old-token", "refresh_token": "r"}}`
-	if err := os.WriteFile(authPath, []byte(authJSON), 0600); err != nil {
+	if err := os.WriteFile(authPath, []byte(authJSON), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/providers/codex_cli_provider_test.go
+++ b/pkg/providers/codex_cli_provider_test.go
@@ -409,7 +409,7 @@ func createMockCodexCLI(t *testing.T, events []string) string {
 		sb.WriteString(fmt.Sprintf("echo '%s'\n", event))
 	}
 
-	if err := os.WriteFile(scriptPath, []byte(sb.String()), 0755); err != nil {
+	if err := os.WriteFile(scriptPath, []byte(sb.String()), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return scriptPath
@@ -480,7 +480,7 @@ echo "$@" > "` + filepath.Join(tmpDir, "args.txt") + `"
 echo '{"type":"item.completed","item":{"id":"1","type":"agent_message","text":"ok"}}'
 echo '{"type":"turn.completed"}'`
 
-	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -522,7 +522,7 @@ func TestCodexCliProvider_MockCLI_ContextCancel(t *testing.T) {
 	scriptPath := filepath.Join(tmpDir, "codex")
 	script := "#!/bin/bash\nsleep 60"
 
-	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/providers/codex_provider.go
+++ b/pkg/providers/codex_provider.go
@@ -14,8 +14,10 @@ import (
 	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
-const codexDefaultModel = "gpt-5.2"
-const codexDefaultInstructions = "You are Codex, a coding assistant."
+const (
+	codexDefaultModel        = "gpt-5.2"
+	codexDefaultInstructions = "You are Codex, a coding assistant."
+)
 
 type CodexProvider struct {
 	client          *openai.Client

--- a/pkg/providers/github_copilot_provider.go
+++ b/pkg/providers/github_copilot_provider.go
@@ -17,7 +17,6 @@ type GitHubCopilotProvider struct {
 }
 
 func NewGitHubCopilotProvider(uri string, connectMode string, model string) (*GitHubCopilotProvider, error) {
-
 	var session *copilot.Session
 	if connectMode == "" {
 		connectMode = "grpc"
@@ -25,7 +24,7 @@ func NewGitHubCopilotProvider(uri string, connectMode string, model string) (*Gi
 	switch connectMode {
 
 	case "stdio":
-		//todo
+		// todo
 	case "grpc":
 		client := copilot.NewClient(&copilot.ClientOptions{
 			CLIUrl: uri,
@@ -73,10 +72,8 @@ func (p *GitHubCopilotProvider) Chat(ctx context.Context, messages []Message, to
 		FinishReason: "stop",
 		Content:      content,
 	}, nil
-
 }
 
 func (p *GitHubCopilotProvider) GetDefaultModel() string {
-
 	return "gpt-4.1"
 }

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -15,15 +15,17 @@ import (
 	"github.com/sipeed/picoclaw/pkg/providers/protocoltypes"
 )
 
-type ToolCall = protocoltypes.ToolCall
-type FunctionCall = protocoltypes.FunctionCall
-type LLMResponse = protocoltypes.LLMResponse
-type UsageInfo = protocoltypes.UsageInfo
-type Message = protocoltypes.Message
-type ToolDefinition = protocoltypes.ToolDefinition
-type ToolFunctionDefinition = protocoltypes.ToolFunctionDefinition
-type ExtraContent = protocoltypes.ExtraContent
-type GoogleExtra = protocoltypes.GoogleExtra
+type (
+	ToolCall               = protocoltypes.ToolCall
+	FunctionCall           = protocoltypes.FunctionCall
+	LLMResponse            = protocoltypes.LLMResponse
+	UsageInfo              = protocoltypes.UsageInfo
+	Message                = protocoltypes.Message
+	ToolDefinition         = protocoltypes.ToolDefinition
+	ToolFunctionDefinition = protocoltypes.ToolFunctionDefinition
+	ExtraContent           = protocoltypes.ExtraContent
+	GoogleExtra            = protocoltypes.GoogleExtra
+)
 
 type Provider struct {
 	apiKey         string

--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -7,15 +7,17 @@ import (
 	"github.com/sipeed/picoclaw/pkg/providers/protocoltypes"
 )
 
-type ToolCall = protocoltypes.ToolCall
-type FunctionCall = protocoltypes.FunctionCall
-type LLMResponse = protocoltypes.LLMResponse
-type UsageInfo = protocoltypes.UsageInfo
-type Message = protocoltypes.Message
-type ToolDefinition = protocoltypes.ToolDefinition
-type ToolFunctionDefinition = protocoltypes.ToolFunctionDefinition
-type ExtraContent = protocoltypes.ExtraContent
-type GoogleExtra = protocoltypes.GoogleExtra
+type (
+	ToolCall               = protocoltypes.ToolCall
+	FunctionCall           = protocoltypes.FunctionCall
+	LLMResponse            = protocoltypes.LLMResponse
+	UsageInfo              = protocoltypes.UsageInfo
+	Message                = protocoltypes.Message
+	ToolDefinition         = protocoltypes.ToolDefinition
+	ToolFunctionDefinition = protocoltypes.ToolFunctionDefinition
+	ExtraContent           = protocoltypes.ExtraContent
+	GoogleExtra            = protocoltypes.GoogleExtra
+)
 
 type LLMProvider interface {
 	Chat(ctx context.Context, messages []Message, tools []ToolDefinition, model string, options map[string]interface{}) (*LLMResponse, error)

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -32,7 +32,7 @@ func NewSessionManager(storage string) *SessionManager {
 	}
 
 	if storage != "" {
-		os.MkdirAll(storage, 0755)
+		os.MkdirAll(storage, 0o755)
 		sm.loadSessions()
 	}
 
@@ -214,7 +214,7 @@ func (sm *SessionManager) Save(key string) error {
 		_ = tmpFile.Close()
 		return err
 	}
-	if err := tmpFile.Chmod(0644); err != nil {
+	if err := tmpFile.Chmod(0o644); err != nil {
 		_ = tmpFile.Close()
 		return err
 	}

--- a/pkg/skills/clawhub_registry_test.go
+++ b/pkg/skills/clawhub_registry_test.go
@@ -162,7 +162,7 @@ func TestExtractZipPathTraversal(t *testing.T) {
 
 	// Write to temp file for extractZipFile.
 	tmpZip := filepath.Join(t.TempDir(), "bad.zip")
-	require.NoError(t, os.WriteFile(tmpZip, buf.Bytes(), 0644))
+	require.NoError(t, os.WriteFile(tmpZip, buf.Bytes(), 0o644))
 
 	tmpDir := t.TempDir()
 	err = utils.ExtractZipFile(tmpZip, tmpDir)
@@ -179,7 +179,7 @@ func TestExtractZipWithSubdirectories(t *testing.T) {
 
 	// Write to temp file for extractZipFile.
 	tmpZip := filepath.Join(t.TempDir(), "test.zip")
-	require.NoError(t, os.WriteFile(tmpZip, zipBuf, 0644))
+	require.NoError(t, os.WriteFile(tmpZip, zipBuf, 0o644))
 
 	tmpDir := t.TempDir()
 	targetDir := filepath.Join(tmpDir, "my-skill")

--- a/pkg/skills/installer.go
+++ b/pkg/skills/installer.go
@@ -59,12 +59,12 @@ func (si *SkillInstaller) InstallFromGitHub(ctx context.Context, repo string) er
 		return fmt.Errorf("failed to read response: %w", err)
 	}
 
-	if err := os.MkdirAll(skillDir, 0755); err != nil {
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create skill directory: %w", err)
 	}
 
 	skillPath := filepath.Join(skillDir, "SKILL.md")
-	if err := os.WriteFile(skillPath, body, 0644); err != nil {
+	if err := os.WriteFile(skillPath, body, 0o644); err != nil {
 		return fmt.Errorf("failed to write skill file: %w", err)
 	}
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -38,7 +38,7 @@ func NewManager(workspace string) *Manager {
 	oldStateFile := filepath.Join(workspace, "state.json")
 
 	// Create state directory if it doesn't exist
-	os.MkdirAll(stateDir, 0755)
+	os.MkdirAll(stateDir, 0o755)
 
 	sm := &Manager{
 		workspace: workspace,
@@ -139,7 +139,7 @@ func (sm *Manager) saveAtomic() error {
 	}
 
 	// Write to temp file
-	if err := os.WriteFile(tempFile, data, 0644); err != nil {
+	if err := os.WriteFile(tempFile, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write temp file: %w", err)
 	}
 

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -98,7 +98,7 @@ func TestAtomicity_NoCorruptionOnInterrupt(t *testing.T) {
 
 	// Simulate a crash scenario by manually creating a corrupted temp file
 	tempFile := filepath.Join(tmpDir, "state", "state.json.tmp")
-	err = os.WriteFile(tempFile, []byte("corrupted data"), 0644)
+	err = os.WriteFile(tempFile, []byte("corrupted data"), 0o644)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}

--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -320,7 +320,6 @@ func (t *CronTool) ExecuteJob(ctx context.Context, job *cron.CronJob) string {
 		channel,
 		chatID,
 	)
-
 	if err != nil {
 		return fmt.Sprintf("Error: %v", err)
 	}

--- a/pkg/tools/edit.go
+++ b/pkg/tools/edit.go
@@ -94,7 +94,7 @@ func (t *EditFileTool) Execute(ctx context.Context, args map[string]interface{})
 
 	newContent := strings.Replace(contentStr, oldText, newText, 1)
 
-	if err := os.WriteFile(resolvedPath, []byte(newContent), 0644); err != nil {
+	if err := os.WriteFile(resolvedPath, []byte(newContent), 0o644); err != nil {
 		return ErrorResult(fmt.Sprintf("failed to write file: %v", err))
 	}
 
@@ -151,7 +151,7 @@ func (t *AppendFileTool) Execute(ctx context.Context, args map[string]interface{
 		return ErrorResult(err.Error())
 	}
 
-	f, err := os.OpenFile(resolvedPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(resolvedPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return ErrorResult(fmt.Sprintf("failed to open file: %v", err))
 	}

--- a/pkg/tools/edit_test.go
+++ b/pkg/tools/edit_test.go
@@ -12,7 +12,7 @@ import (
 func TestEditTool_EditFile_Success(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.txt")
-	os.WriteFile(testFile, []byte("Hello World\nThis is a test"), 0644)
+	os.WriteFile(testFile, []byte("Hello World\nThis is a test"), 0o644)
 
 	tool := NewEditFileTool(tmpDir, true)
 	ctx := context.Background()
@@ -83,7 +83,7 @@ func TestEditTool_EditFile_NotFound(t *testing.T) {
 func TestEditTool_EditFile_OldTextNotFound(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.txt")
-	os.WriteFile(testFile, []byte("Hello World"), 0644)
+	os.WriteFile(testFile, []byte("Hello World"), 0o644)
 
 	tool := NewEditFileTool(tmpDir, true)
 	ctx := context.Background()
@@ -110,7 +110,7 @@ func TestEditTool_EditFile_OldTextNotFound(t *testing.T) {
 func TestEditTool_EditFile_MultipleMatches(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.txt")
-	os.WriteFile(testFile, []byte("test test test"), 0644)
+	os.WriteFile(testFile, []byte("test test test"), 0o644)
 
 	tool := NewEditFileTool(tmpDir, true)
 	ctx := context.Background()
@@ -138,7 +138,7 @@ func TestEditTool_EditFile_OutsideAllowedDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	otherDir := t.TempDir()
 	testFile := filepath.Join(otherDir, "test.txt")
-	os.WriteFile(testFile, []byte("content"), 0644)
+	os.WriteFile(testFile, []byte("content"), 0o644)
 
 	tool := NewEditFileTool(tmpDir, true) // Restrict to tmpDir
 	ctx := context.Background()
@@ -216,7 +216,7 @@ func TestEditTool_EditFile_MissingNewText(t *testing.T) {
 func TestEditTool_AppendFile_Success(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.txt")
-	os.WriteFile(testFile, []byte("Initial content"), 0644)
+	os.WriteFile(testFile, []byte("Initial content"), 0o644)
 
 	tool := NewAppendFileTool("", false)
 	ctx := context.Background()

--- a/pkg/tools/filesystem.go
+++ b/pkg/tools/filesystem.go
@@ -177,11 +177,11 @@ func (t *WriteFileTool) Execute(ctx context.Context, args map[string]interface{}
 	}
 
 	dir := filepath.Dir(resolvedPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return ErrorResult(fmt.Sprintf("failed to create directory: %v", err))
 	}
 
-	if err := os.WriteFile(resolvedPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(resolvedPath, []byte(content), 0o644); err != nil {
 		return ErrorResult(fmt.Sprintf("failed to write file: %v", err))
 	}
 

--- a/pkg/tools/filesystem_test.go
+++ b/pkg/tools/filesystem_test.go
@@ -12,7 +12,7 @@ import (
 func TestFilesystemTool_ReadFile_Success(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.txt")
-	os.WriteFile(testFile, []byte("test content"), 0644)
+	os.WriteFile(testFile, []byte("test content"), 0o644)
 
 	tool := &ReadFileTool{}
 	ctx := context.Background()
@@ -187,9 +187,9 @@ func TestFilesystemTool_WriteFile_MissingContent(t *testing.T) {
 // TestFilesystemTool_ListDir_Success verifies successful directory listing
 func TestFilesystemTool_ListDir_Success(t *testing.T) {
 	tmpDir := t.TempDir()
-	os.WriteFile(filepath.Join(tmpDir, "file1.txt"), []byte("content"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "file2.txt"), []byte("content"), 0644)
-	os.Mkdir(filepath.Join(tmpDir, "subdir"), 0755)
+	os.WriteFile(filepath.Join(tmpDir, "file1.txt"), []byte("content"), 0o644)
+	os.WriteFile(filepath.Join(tmpDir, "file2.txt"), []byte("content"), 0o644)
+	os.Mkdir(filepath.Join(tmpDir, "subdir"), 0o755)
 
 	tool := &ListDirTool{}
 	ctx := context.Background()
@@ -250,15 +250,14 @@ func TestFilesystemTool_ListDir_DefaultPath(t *testing.T) {
 
 // Block paths that look inside workspace but point outside via symlink.
 func TestFilesystemTool_ReadFile_RejectsSymlinkEscape(t *testing.T) {
-
 	root := t.TempDir()
 	workspace := filepath.Join(root, "workspace")
-	if err := os.MkdirAll(workspace, 0755); err != nil {
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
 		t.Fatalf("failed to create workspace: %v", err)
 	}
 
 	secret := filepath.Join(root, "secret.txt")
-	if err := os.WriteFile(secret, []byte("top secret"), 0644); err != nil {
+	if err := os.WriteFile(secret, []byte("top secret"), 0o644); err != nil {
 		t.Fatalf("failed to write secret file: %v", err)
 	}
 

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -91,7 +91,7 @@ func TestShellTool_WorkingDir(t *testing.T) {
 	// Create temp directory
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.txt")
-	os.WriteFile(testFile, []byte("test content"), 0644)
+	os.WriteFile(testFile, []byte("test content"), 0o644)
 
 	tool := NewExecTool("", false)
 

--- a/pkg/tools/skills_install.go
+++ b/pkg/tools/skills_install.go
@@ -108,7 +108,7 @@ func (t *InstallSkillTool) Execute(ctx context.Context, args map[string]interfac
 	}
 
 	// Ensure skills directory exists.
-	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		return ErrorResult(fmt.Sprintf("failed to create skills directory: %v", err))
 	}
 
@@ -195,5 +195,5 @@ func writeOriginMeta(targetDir, registryName, slug, version string) error {
 		return err
 	}
 
-	return os.WriteFile(filepath.Join(targetDir, ".skill-origin.json"), data, 0644)
+	return os.WriteFile(filepath.Join(targetDir, ".skill-origin.json"), data, 0o644)
 }

--- a/pkg/tools/skills_install_test.go
+++ b/pkg/tools/skills_install_test.go
@@ -53,7 +53,7 @@ func TestInstallSkillToolUnsafeSlug(t *testing.T) {
 func TestInstallSkillToolAlreadyExists(t *testing.T) {
 	workspace := t.TempDir()
 	skillDir := filepath.Join(workspace, "skills", "existing-skill")
-	require.NoError(t, os.MkdirAll(skillDir, 0755))
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
 
 	tool := NewInstallSkillTool(skills.NewRegistryManager(), workspace)
 	result := tool.Execute(context.Background(), map[string]interface{}{

--- a/pkg/utils/media.go
+++ b/pkg/utils/media.go
@@ -65,7 +65,7 @@ func DownloadFile(url, filename string, opts DownloadOptions) string {
 	}
 
 	mediaDir := filepath.Join(os.TempDir(), "picoclaw_media")
-	if err := os.MkdirAll(mediaDir, 0700); err != nil {
+	if err := os.MkdirAll(mediaDir, 0o700); err != nil {
 		logger.ErrorCF(opts.LoggerPrefix, "Failed to create media directory", map[string]interface{}{
 			"error": err.Error(),
 		})

--- a/pkg/utils/zip.go
+++ b/pkg/utils/zip.go
@@ -28,7 +28,7 @@ func ExtractZipFile(zipPath string, targetDir string) error {
 		"entries":    len(reader.File),
 	})
 
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create target dir: %w", err)
 	}
 
@@ -55,14 +55,14 @@ func ExtractZipFile(zipPath string, targetDir string) error {
 		}
 
 		if f.FileInfo().IsDir() {
-			if err := os.MkdirAll(destPath, 0755); err != nil {
+			if err := os.MkdirAll(destPath, 0o755); err != nil {
 				return err
 			}
 			continue
 		}
 
 		// Ensure parent directory exists.
-		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## 📝 Description

Enable gofumpt in CI. This is done by enabling the formatter then run `golangci-lint run --fix`.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.