### PR TITLE
fix: correct documentation misalignment across translations and guides

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -212,19 +212,24 @@ picoclaw onboard
 
 ```json
 {
+  "model_list": [
+    {
+      "model_name": "gpt4",
+      "model": "openai/gpt-5.2",
+      "api_key": "sk-your-openai-key",
+      "api_base": "https://api.openai.com/v1"
+    }
+  ],
   "agents": {
     "defaults": {
-      "workspace": "~/.picoclaw/workspace",
-      "model": "glm-4.7",
-      "max_tokens": 8192,
-      "temperature": 0.7,
-      "max_tool_iterations": 20
+      "model": "gpt4"
     }
   },
-  "providers": {
-    "openrouter": {
-      "api_key": "xxx",
-      "api_base": "https://openrouter.ai/api/v1"
+  "channels": {
+    "telegram": {
+      "enabled": true,
+      "token": "VOTRE_TOKEN_BOT",
+      "allow_from": ["VOTRE_USER_ID"]
     }
   },
   "tools": {
@@ -290,7 +295,7 @@ Discutez avec votre PicoClaw via Telegram, Discord, DingTalk, LINE ou WeCom
     "telegram": {
       "enabled": true,
       "token": "VOTRE_TOKEN_BOT",
-      "allowFrom": ["VOTRE_USER_ID"]
+      "allow_from": ["VOTRE_USER_ID"]
     }
   }
 }
@@ -333,7 +338,7 @@ picoclaw gateway
     "discord": {
       "enabled": true,
       "token": "VOTRE_TOKEN_BOT",
-      "allowFrom": ["VOTRE_USER_ID"]
+      "allow_from": ["VOTRE_USER_ID"]
     }
   }
 }
@@ -765,6 +770,8 @@ Le sous-agent a accès aux outils (message, web_search, etc.) et peut communique
 | `anthropic` (À tester)   | LLM (Claude direct)                      | [console.anthropic.com](https://console.anthropic.com) |
 | `openai` (À tester)      | LLM (GPT direct)                         | [platform.openai.com](https://platform.openai.com)     |
 | `deepseek` (À tester)    | LLM (DeepSeek direct)                    | [platform.deepseek.com](https://platform.deepseek.com) |
+| `qwen`                   | LLM (Alibaba Qwen)                      | [dashscope.aliyuncs.com](https://dashscope.aliyuncs.com/compatible-mode/v1) |
+| `cerebras`               | LLM (Cerebras)                           | [cerebras.ai](https://api.cerebras.ai/v1)              |
 | `groq`                   | LLM + **Transcription vocale** (Whisper) | [console.groq.com](https://console.groq.com)           |
 
 <details>
@@ -1087,7 +1094,7 @@ Ajoutez la clé dans `~/.picoclaw/config.json` si vous utilisez Brave :
   "tools": {
     "web": {
       "brave": {
-        "enabled": true,
+        "enabled": false,
         "api_key": "VOTRE_CLE_API_BRAVE",
         "max_results": 5
       },

--- a/README.ja.md
+++ b/README.ja.md
@@ -174,35 +174,25 @@ picoclaw onboard
 
 ```json
 {
+  "model_list": [
+    {
+      "model_name": "gpt4",
+      "model": "openai/gpt-5.2",
+      "api_key": "sk-your-openai-key",
+      "api_base": "https://api.openai.com/v1"
+    }
+  ],
   "agents": {
     "defaults": {
-      "workspace": "~/.picoclaw/workspace",
-      "model": "glm-4.7",
-      "max_tokens": 8192,
-      "temperature": 0.7,
-      "max_tool_iterations": 20
+      "model": "gpt4"
     }
   },
-  "providers": {
-    "openrouter": {
-      "api_key": "xxx",
-      "api_base": "https://openrouter.ai/api/v1"
+  "channels": {
+    "telegram": {
+      "enabled": true,
+      "token": "YOUR_TELEGRAM_BOT_TOKEN",
+      "allow_from": []
     }
-  },
-  "tools": {
-    "web": {
-      "search": {
-        "api_key": "YOUR_BRAVE_API_KEY",
-        "max_results": 5
-      }
-    },
-    "cron": {
-      "exec_timeout_minutes": 5
-    }
-  },
-  "heartbeat": {
-    "enabled": true,
-    "interval": 30
   }
 }
 ```
@@ -214,7 +204,7 @@ picoclaw onboard
 
 > **注意**: 完全な設定テンプレートは `config.example.json` を参照してください。
 
-**3. チャット**
+**4. チャット**
 
 ```bash
 picoclaw agent -m "What is 2+2?"
@@ -764,10 +754,10 @@ HEARTBEAT_OK 応答         ユーザーが直接結果を受け取る
   },
   "providers": {
     "openrouter": {
-      "apiKey": "sk-or-v1-xxx"
+      "api_key": "sk-or-v1-xxx"
     },
     "groq": {
-      "apiKey": "gsk_xxx"
+      "api_key": "gsk_xxx"
     }
   },
   "channels": {
@@ -786,17 +776,17 @@ HEARTBEAT_OK 応答         ユーザーが直接結果を受け取る
     },
     "feishu": {
       "enabled": false,
-      "appId": "cli_xxx",
-      "appSecret": "xxx",
-      "encryptKey": "",
-      "verificationToken": "",
+      "app_id": "cli_xxx",
+      "app_secret": "xxx",
+      "encrypt_key": "",
+      "verification_token": "",
       "allow_from": []
     }
   },
   "tools": {
     "web": {
       "search": {
-        "apiKey": "BSA..."
+        "api_key": "BSA..."
       }
     },
     "cron": {
@@ -1001,8 +991,13 @@ Web 検索を有効にするには：
    {
      "tools": {
        "web": {
-         "search": {
+         "brave": {
+           "enabled": true,
            "api_key": "YOUR_BRAVE_API_KEY",
+           "max_results": 5
+         },
+         "duckduckgo": {
+           "enabled": true,
            "max_results": 5
          }
        }

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ picoclaw gateway
 }
 ```
 
-> Set `allow_from` to empty to allow all users, or specify QQ numbers to restrict access.
+> Set `allow_from` to empty to allow all users, or specify DingTalk user IDs to restrict access.
 
 **3. Run**
 
@@ -867,15 +867,15 @@ This design also enables **multi-agent support** with flexible provider selectio
 }
 ```
 
-**Anthropic (with OAuth)**
+**Anthropic (with API key)**
 ```json
 {
   "model_name": "claude-sonnet-4.6",
   "model": "anthropic/claude-sonnet-4.6",
-  "auth_method": "oauth"
+  "api_key": "sk-ant-your-key"
 }
 ```
-> Run `picoclaw auth login --provider anthropic` to set up OAuth credentials.
+> Run `picoclaw auth login --provider anthropic` to paste your API token.
 
 **Ollama (local)**
 ```json

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -213,19 +213,17 @@ picoclaw onboard
 
 ```json
 {
+  "model_list": [
+    {
+      "model_name": "gpt4",
+      "model": "openai/gpt-5.2",
+      "api_key": "sk-your-openai-key",
+      "api_base": "https://api.openai.com/v1"
+    }
+  ],
   "agents": {
     "defaults": {
-      "workspace": "~/.picoclaw/workspace",
-      "model": "glm-4.7",
-      "max_tokens": 8192,
-      "temperature": 0.7,
-      "max_tool_iterations": 20
-    }
-  },
-  "providers": {
-    "openrouter": {
-      "api_key": "xxx",
-      "api_base": "https://openrouter.ai/api/v1"
+      "model": "gpt4"
     }
   },
   "tools": {
@@ -291,7 +289,7 @@ Converse com seu PicoClaw via Telegram, Discord, DingTalk, LINE ou WeCom.
     "telegram": {
       "enabled": true,
       "token": "YOUR_BOT_TOKEN",
-      "allowFrom": ["YOUR_USER_ID"]
+      "allow_from": ["YOUR_USER_ID"]
     }
   }
 }
@@ -334,7 +332,7 @@ picoclaw gateway
     "discord": {
       "enabled": true,
       "token": "YOUR_BOT_TOKEN",
-      "allowFrom": ["YOUR_USER_ID"]
+      "allow_from": ["YOUR_USER_ID"]
     }
   }
 }
@@ -766,6 +764,8 @@ O subagente tem acesso às ferramentas (message, web_search, etc.) e pode se com
 | `anthropic` (Em teste) | LLM (Claude direto) | [console.anthropic.com](https://console.anthropic.com) |
 | `openai` (Em teste) | LLM (GPT direto) | [platform.openai.com](https://platform.openai.com) |
 | `deepseek` (Em teste) | LLM (DeepSeek direto) | [platform.deepseek.com](https://platform.deepseek.com) |
+| `qwen` | Alibaba Qwen | [dashscope.console.aliyun.com](https://dashscope.console.aliyun.com) |
+| `cerebras` | Cerebras | [cerebras.ai](https://cerebras.ai) |
 | `groq` | LLM + **Transcrição de voz** (Whisper) | [console.groq.com](https://console.groq.com) |
 
 <details>
@@ -1088,7 +1088,7 @@ Adicione a key em `~/.picoclaw/config.json` se usar o Brave:
   "tools": {
     "web": {
       "brave": {
-        "enabled": true,
+        "enabled": false,
         "api_key": "YOUR_BRAVE_API_KEY",
         "max_results": 5
       },
@@ -1119,3 +1119,4 @@ Isso acontece quando outra instância do bot está em execução. Certifique-se 
 | **Zhipu** | 200K tokens/mês | Melhor para usuários chineses |
 | **Brave Search** | 2000 consultas/mês | Funcionalidade de busca web |
 | **Groq** | Plano gratuito disponível | Inferência ultra-rápida (Llama, Mixtral) |
+| **Cerebras** | Plano gratuito disponível | Inferência ultra-rápida (Llama 3.3 70B) |

--- a/README.vi.md
+++ b/README.vi.md
@@ -193,32 +193,24 @@ picoclaw onboard
 
 ```json
 {
+  "model_list": [
+    {
+      "model_name": "gpt4",
+      "model": "openai/gpt-5.2",
+      "api_key": "sk-your-openai-key",
+      "api_base": "https://api.openai.com/v1"
+    }
+  ],
   "agents": {
     "defaults": {
-      "workspace": "~/.picoclaw/workspace",
-      "model": "glm-4.7",
-      "max_tokens": 8192,
-      "temperature": 0.7,
-      "max_tool_iterations": 20
+      "model": "gpt4"
     }
   },
-  "providers": {
-    "openrouter": {
-      "api_key": "xxx",
-      "api_base": "https://openrouter.ai/api/v1"
-    }
-  },
-  "tools": {
-    "web": {
-      "brave": {
-        "enabled": false,
-        "api_key": "YOUR_BRAVE_API_KEY",
-        "max_results": 5
-      },
-      "duckduckgo": {
-        "enabled": true,
-        "max_results": 5
-      }
+  "channels": {
+    "telegram": {
+      "enabled": true,
+      "token": "YOUR_TELEGRAM_BOT_TOKEN",
+      "allow_from": []
     }
   }
 }
@@ -747,6 +739,8 @@ Subagent có quyền truy cập các công cụ (message, web_search, v.v.) và 
 | `openai` (Đang thử nghiệm) | LLM (GPT trực tiếp) | [platform.openai.com](https://platform.openai.com) |
 | `deepseek` (Đang thử nghiệm) | LLM (DeepSeek trực tiếp) | [platform.deepseek.com](https://platform.deepseek.com) |
 | `groq` | LLM + **Chuyển giọng nói** (Whisper) | [console.groq.com](https://console.groq.com) |
+| `qwen` | LLM (Qwen trực tiếp) | [dashscope.console.aliyun.com](https://dashscope.console.aliyun.com) |
+| `cerebras` | LLM (Cerebras trực tiếp) | [cerebras.ai](https://cerebras.ai) |
 
 <details>
 <summary><b>Cấu hình Zhipu</b></summary>
@@ -1065,7 +1059,7 @@ Thêm key vào `~/.picoclaw/config.json` nếu dùng Brave:
   "tools": {
     "web": {
       "brave": {
-        "enabled": true,
+        "enabled": false,
         "api_key": "YOUR_BRAVE_API_KEY",
         "max_results": 5
       },

--- a/README.zh.md
+++ b/README.zh.md
@@ -238,8 +238,13 @@ picoclaw onboard
   ],
   "tools": {
     "web": {
-      "search": {
+      "brave": {
+        "enabled": false,
         "api_key": "YOUR_BRAVE_API_KEY",
+        "max_results": 5
+      },
+      "duckduckgo": {
+        "enabled": true,
         "max_results": 5
       }
     },
@@ -345,7 +350,8 @@ picoclaw gateway
     "discord": {
       "enabled": true,
       "token": "YOUR_BOT_TOKEN",
-      "allow_from": ["YOUR_USER_ID"]
+      "allow_from": ["YOUR_USER_ID"],
+      "mention_only": false
     }
   }
 }
@@ -525,7 +531,7 @@ picoclaw gateway
 
 只需通过 CLI 或任何集成的聊天应用发送一条消息，即可将 PicoClaw 连接到 Agent 社交网络。
 
-**阅读 `https://clawdchat.ai/skill.md` 并按照说明加入 [ClawdChat.ai**](https://clawdchat.ai)
+**阅读 `https://clawdchat.ai/skill.md` 并按照说明加入 [ClawdChat.ai](https://clawdchat.ai)
 
 ## ⚙️ 配置详解
 
@@ -857,8 +863,8 @@ Agent 读取 HEARTBEAT.md
     "zhipu": {
       "api_key": "Your API Key",
       "api_base": "https://open.bigmodel.cn/api/paas/v4"
-    },
-  },
+    }
+  }
 }
 
 ```
@@ -921,8 +927,14 @@ picoclaw agent -m "你好"
   },
   "tools": {
     "web": {
-      "search": {
-        "api_key": "BSA..."
+      "brave": {
+        "enabled": false,
+        "api_key": "YOUR_BRAVE_API_KEY",
+        "max_results": 5
+      },
+      "duckduckgo": {
+        "enabled": true,
+        "max_results": 5
       }
     },
     "cron": {
@@ -989,8 +1001,13 @@ Discord:  [https://discord.gg/V4sAZ9XWpN](https://discord.gg/V4sAZ9XWpN)
 {
   "tools": {
     "web": {
-      "search": {
+      "brave": {
+        "enabled": false,
         "api_key": "YOUR_BRAVE_API_KEY",
+        "max_results": 5
+      },
+      "duckduckgo": {
+        "enabled": true,
         "max_results": 5
       }
     }

--- a/docs/ANTIGRAVITY_USAGE.md
+++ b/docs/ANTIGRAVITY_USAGE.md
@@ -47,14 +47,12 @@ picoclaw agent -m "Hello" --model claude-opus-4-6-thinking
 
 If you are deploying via Coolify or Docker, follow these steps to test:
 
-1.  **Branch**: Use the `feat/antigravity-provider` branch.
-2.  **Environment Variables**:
-    *   `PICOCLAW_AGENTS_DEFAULTS_PROVIDER=antigravity`
-    *   `PICOCLAW_AGENTS_DEFAULTS_MODEL=gemini-3-flash`
-3.  **Authentication persistence**: 
+1.  **Environment Variables**:
+    *   `PICOCLAW_AGENTS_DEFAULTS_MODEL=gemini-flash`
+2.  **Authentication persistence**: 
     If you've logged in locally, you can copy your credentials to the server:
     ```bash
-    scp ~/.picoclaw/auth-profiles.json user@your-server:~/.picoclaw/
+    scp ~/.picoclaw/auth.json user@your-server:~/.picoclaw/
     ```
     *Alternatively*, run the `auth login` command once on the server if you have terminal access.
 

--- a/docs/design/provider-refactoring-tests.md
+++ b/docs/design/provider-refactoring-tests.md
@@ -1,7 +1,5 @@
 # Provider Architecture Refactoring - Test Suite Summary
 
-> PRD: `tasks/prd-provider-refactoring.md`
-
 This document summarizes the complete test suite designed for the Provider architecture refactoring.
 
 ## Test File Structure
@@ -12,10 +10,8 @@ pkg/
 │   ├── model_config_test.go      # US-001, US-002: ModelConfig struct and GetModelConfig tests
 │   └── migration_test.go         # US-003: Backward compatibility and migration tests
 ├── providers/
-│   ├── registry_test.go          # US-006: Load balancing tests
-│   ├── integration_test.go       # E2E integration tests
-│   └── factory/
-│       └── factory_test.go       # US-004, US-005: Provider factory tests
+│   ├── factory_test.go           # US-004, US-005: Provider factory tests
+│   └── factory_provider_test.go  # Factory provider integration tests
 ```
 
 ---
@@ -122,7 +118,6 @@ go test ./pkg/... -race
 # Run specific package tests
 go test ./pkg/config -v
 go test ./pkg/providers -v
-go test ./pkg/providers/factory -v
 
 # Run E2E tests
 go test ./pkg/providers -run TestE2E -v

--- a/docs/migration/model-list-migration.md
+++ b/docs/migration/model-list-migration.md
@@ -85,6 +85,7 @@ The `model` field uses a protocol prefix format: `[protocol/]model-identifier`
 | `openai/` | OpenAI API (default) | `openai/gpt-5.2` |
 | `anthropic/` | Anthropic API | `anthropic/claude-opus-4` |
 | `antigravity/` | Google via Antigravity OAuth | `antigravity/gemini-2.0-flash` |
+| `gemini/` | Google Gemini API | `gemini/gemini-2.0-flash-exp` |
 | `claude-cli/` | Claude CLI (local) | `claude-cli/claude-sonnet-4.6` |
 | `codex-cli/` | Codex CLI (local) | `codex-cli/codex-4` |
 | `github-copilot/` | GitHub Copilot | `github-copilot/gpt-4o` |
@@ -93,6 +94,13 @@ The `model` field uses a protocol prefix format: `[protocol/]model-identifier`
 | `deepseek/` | DeepSeek API | `deepseek/deepseek-chat` |
 | `cerebras/` | Cerebras API | `cerebras/llama-3.3-70b` |
 | `qwen/` | Alibaba Qwen | `qwen/qwen-max` |
+| `zhipu/` | Zhipu AI | `zhipu/glm-4` |
+| `nvidia/` | NVIDIA NIM | `nvidia/llama-3.1-nemotron-70b` |
+| `ollama/` | Ollama (local) | `ollama/llama3` |
+| `vllm/` | vLLM (local) | `vllm/my-model` |
+| `moonshot/` | Moonshot AI | `moonshot/moonshot-v1-8k` |
+| `shengsuanyun/` | ShengSuanYun | `shengsuanyun/deepseek-v3` |
+| `volcengine/` | Volcengine | `volcengine/doubao-pro-32k` |
 
 **Note**: If no prefix is specified, `openai/` is used as the default.
 

--- a/docs/picoclaw_community_roadmap_260216.md
+++ b/docs/picoclaw_community_roadmap_260216.md
@@ -71,14 +71,14 @@ Interested in a specific feature? You can "claim" these tasks and start building
   * Support for OneBot, additional platforms
   * attachments (images, audio, video, files).
 * **Skills:** 
-  * Implementing `find_skill` to discover tools via [openclaw/skills](https://github.com/openclaw/skills) and other platforms.
+  * Implementing `find_skill` to discover tools via [ClawhHub](https://clawhub.ai) and other platforms.
 * **Operations:** * MCP Support.
   * Android operations (e.g., botdrop).
   * Browser automation via CDP or ActionBook.
 
 
 * **Multi-Agent Ecosystem:**
-  * **Basic Model-Agnet** S
+  * **Basic Model-Agent**
   * **Model Routing:** Small models for easy tasks, large models for hard ones (to save tokens).
   * **Swarm Mode.**
   * **AIEOS Integration.**

--- a/docs/tools_configuration.md
+++ b/docs/tools_configuration.md
@@ -9,8 +9,8 @@ PicoClaw's tools configuration is located in the `tools` field of `config.json`.
   "tools": {
     "web": { ... },
     "exec": { ... },
-    "approval": { ... },
-    "cron": { ... }
+    "cron": { ... },
+    "skills": { ... }
   }
 }
 ```
@@ -83,24 +83,11 @@ By default, PicoClaw blocks the following dangerous commands:
       "custom_deny_patterns": [
         "\\brm\\s+-r\\b",
         "\\bkillall\\s+python"
-      ],
+      ]
     }
   }
 }
 ```
-
-## Approval Tool
-
-The approval tool controls permissions for dangerous operations.
-
-| Config | Type | Default | Description |
-|--------|------|---------|-------------|
-| `enabled` | bool | true | Enable approval functionality |
-| `write_file` | bool | true | Require approval for file writes |
-| `edit_file` | bool | true | Require approval for file edits |
-| `append_file` | bool | true | Require approval for file appends |
-| `exec` | bool | true | Require approval for command execution |
-| `timeout_minutes` | int | 5 | Approval timeout in minutes |
 
 ## Cron Tool
 
@@ -109,6 +96,40 @@ The cron tool is used for scheduling periodic tasks.
 | Config | Type | Default | Description |
 |--------|------|---------|-------------|
 | `exec_timeout_minutes` | int | 5 | Execution timeout in minutes, 0 means no limit |
+
+## Skills Tool
+
+The skills tool configures skill discovery and installation via registries like ClawHub.
+
+### Registries
+
+| Config | Type | Default | Description |
+|--------|------|---------|-------------|
+| `registries.clawhub.enabled` | bool | true | Enable ClawHub registry |
+| `registries.clawhub.base_url` | string | `https://clawhub.ai` | ClawHub base URL |
+| `registries.clawhub.search_path` | string | `/api/v1/search` | Search API path |
+| `registries.clawhub.skills_path` | string | `/api/v1/skills` | Skills API path |
+| `registries.clawhub.download_path` | string | `/api/v1/download` | Download API path |
+
+### Configuration Example
+
+```json
+{
+  "tools": {
+    "skills": {
+      "registries": {
+        "clawhub": {
+          "enabled": true,
+          "base_url": "https://clawhub.ai",
+          "search_path": "/api/v1/search",
+          "skills_path": "/api/v1/skills",
+          "download_path": "/api/v1/download"
+        }
+      }
+    }
+  }
+}
+```
 
 ## Environment Variables
 


### PR DESCRIPTION
Fixes inconsistencies between the main README, translated READMEs, and docs/ guides.

- Translated READMEs (fr, pt-br, vi, ja) used deprecated `providers` config format instead of `model_list`
- fr and pt-br had `allowFrom` (camelCase) instead of `allow_from`
- ja had camelCase keys (`apiKey`, `appId`, etc.) in its full config example
- zh and ja used the old flat `web.search` config instead of `brave`/`duckduckgo`
- ANTIGRAVITY_AUTH.md referenced OpenClaw project name, TypeScript plugin system, and wrong file paths throughout
- ANTIGRAVITY_USAGE.md had wrong auth file path and an outdated branch reference
- tools_configuration.md documented a non-existent `approval` tool and was missing `skills` tool docs
- DingTalk section in main README said "QQ numbers" (copy-paste from QQ section above)
- Anthropic vendor example showed `auth_method: "oauth"` but code uses paste-token auth
- Migration guide was missing several supported protocol prefixes
- Minor typos in community roadmap

No code changes. All fixes are documentation-only.