### PR TITLE
Allow vllm provider to work without API key

### DIFF
--- a/pkg/providers/factory.go
+++ b/pkg/providers/factory.go
@@ -295,7 +295,7 @@ func resolveProviderSelection(cfg *config.Config) (providerSelection, error) {
 	}
 
 	if sel.providerType == providerTypeHTTPCompat {
-		if sel.apiKey == "" && !strings.HasPrefix(model, "bedrock/") {
+		if sel.apiKey == "" && !strings.HasPrefix(model, "bedrock/") && providerName != "vllm" {
 			return providerSelection{}, fmt.Errorf("no API key configured for provider (model: %s)", model)
 		}
 		if sel.apiBase == "" {


### PR DESCRIPTION
Skip the API key requirement check when using the vllm provider, enabling use of OpenAI-compatible endpoints that don't require authentication (e.g. opencode.ai/zen free models).