### PR TITLE
fix: align Docker Go version with go.mod and optimize logger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ============================================================
 # Stage 1: Build the picoclaw binary
 # ============================================================
-FROM golang:1.26.0-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git make
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -119,13 +119,15 @@ func logMessage(level LogLevel, component string, message string, fields map[str
 	if logger.file != nil {
 		jsonData, err := json.Marshal(entry)
 		if err == nil {
-			logger.file.WriteString(string(jsonData) + "\n")
+			logger.file.Write(append(jsonData, '\n'))
 		}
 	}
 
 	var fieldStr string
 	if len(fields) > 0 {
 		fieldStr = " " + formatFields(fields)
+	} else {
+		fieldStr = ""
 	}
 
 	logLine := fmt.Sprintf("[%s] [%s]%s %s%s",


### PR DESCRIPTION
## 📝 Description

This PR fixes build consistency issues and optimizes the logger for better memory efficiency on resource-constrained devices.

**Changes:**
- **Dockerfile**: Updated base image from `golang:1.26.0-alpine` to `golang:1.25-alpine` to match go.mod (go 1.25.7)
- **pkg/logger/logger.go**: Optimized file write operation by using `append(jsonData, '\n')` instead of `string(jsonData) + "\n"` to avoid unnecessary string allocation

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

None

## 📚 Technical Context
- **Reference URL:** N/A
- **Reasoning:** The Go version mismatch between Dockerfile and go.mod can cause build failures. The logger optimization reduces memory allocations, which is important for PicoClaw's goal of running on embedded devices with <10MB RAM.

## 🧪 Test Environment
- **Hardware:** PC/Docker
- **OS:** Alpine Linux (Docker)
- **Model/Provider:** N/A
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Build tested successfully with `docker build`. No functional changes to logging behavior - all log output remains identical.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.