### PR TITLE
fix: resolve Groq STT key from model_list when providers.groq is absent

### DIFF
--- a/cmd/picoclaw/cmd_gateway.go
+++ b/cmd/picoclaw/cmd_gateway.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/sipeed/picoclaw/pkg/agent"
@@ -121,8 +122,17 @@ func gatewayCmd() {
 	agentLoop.SetChannelManager(channelManager)
 
 	var transcriber *voice.GroqTranscriber
-	if cfg.Providers.Groq.APIKey != "" {
-		transcriber = voice.NewGroqTranscriber(cfg.Providers.Groq.APIKey)
+	groqAPIKey := cfg.Providers.Groq.APIKey
+	if groqAPIKey == "" {
+		for _, mc := range cfg.ModelList {
+			if strings.HasPrefix(mc.Model, "groq/") && mc.APIKey != "" {
+				groqAPIKey = mc.APIKey
+				break
+			}
+		}
+	}
+	if groqAPIKey != "" {
+		transcriber = voice.NewGroqTranscriber(groqAPIKey)
 		logger.InfoC("voice", "Groq voice transcription enabled")
 	}
 


### PR DESCRIPTION
## 📝 Description

After migrating from the legacy `providers` config to the new `model_list` format, voice transcription silently breaks on Telegram, Discord, and Slack. Voice messages fall back to a plain `[voice]` placeholder because the Groq API key is read exclusively from `cfg.Providers.Groq.APIKey`, which is empty post-migration.

This fix adds fallback logic to scan `model_list` for any entry with a `groq/`-prefixed model and uses its `api_key` if the legacy field is absent. The legacy `providers.groq.api_key` still takes precedence, so backward compatibility is fully preserved.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Closes #601

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/601
- **Reasoning:** The STT initialisation in `cmd_gateway.go` only checked `cfg.Providers.Groq.APIKey`. Users who fully migrated to `model_list` had no way to provide a Groq key through the legacy field, causing the transcriber to never be initialised.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Alpine Linux 3.23 (Docker)
- **Model/Provider:** Groq (whisper-large-v3)
- **Channels:** Telegram, Discord, Slack

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Gateway startup log after fix:
```
INFO [voice] Groq voice transcription enabled
```
Voice messages are now correctly transcribed instead of falling back to `[voice]`.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.