### PR TITLE
fix: should use fmt.Printf instead of fmt.Print(fmt.Sprintf(...))

### DIFF
--- a/cmd/picoclaw/cmd_agent.go
+++ b/cmd/picoclaw/cmd_agent.go
@@ -148,7 +148,7 @@ func interactiveMode(agentLoop *agent.AgentLoop, sessionKey string) {
 func simpleInteractiveMode(agentLoop *agent.AgentLoop, sessionKey string) {
 	reader := bufio.NewReader(os.Stdin)
 	for {
-		fmt.Print(fmt.Sprintf("%s You: ", logo))
+		fmt.Printf("%s You: ", logo)
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			if err == io.EOF {


### PR DESCRIPTION
This PR replaces `fmt.Print(fmt.Sprintf(...))` with `fmt.Printf` for cleaner and more idiomatic Go code.

Using `fmt.Printf` avoids unnecessary string formatting and improves readability.

No functional changes were introduced.