### PR TITLE
Ignore system messages in Discord handler

### DIFF
--- a/pkg/channels/discord.go
+++ b/pkg/channels/discord.go
@@ -176,13 +176,15 @@ func (c *DiscordChannel) handleMessage(s *discordgo.Session, m *discordgo.Messag
 		return
 	}
 
-	// Ignore system messages (including thread creation messages)
-	// MessageTypeDefault (0) = regular user message
-	if m.Type != discordgo.MessageTypeDefault {
-		logger.DebugCF("discord", "Message ignored - system message", map[string]any{
-			"message_type": int(m.Type),
-		})
-		return
+	// Ignore system messages (thread creation, pins, boosts, etc.)
+	switch m.Type {
+	case discordgo.MessageTypeDefault, discordgo.MessageTypeReply:
+	    // These are real user messages, process them
+	default:
+	    logger.DebugCF("discord", "Message ignored - system message", map[string]any{
+	        "message_type": int(m.Type),
+	    })
+	    return
 	}
 
 	// Check allowlist first to avoid downloading attachments and transcribing for rejected users


### PR DESCRIPTION
Added check to ignore system messages in Discord bot.

## 📝 Description

When new thread in Discord channel is created, the bot will respond in channel to the thread name(👎), then also inside thread to the actual message(👍).
This change will prevent wasting tokens and making confusion.
<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC--> Any
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 --> Any
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 --> Any
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... --> Discord

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.