### PR TITLE
fix: better session management for `github_copilot_provider`

### DIFF
--- a/cmd/picoclaw/cmd_gateway.go
+++ b/cmd/picoclaw/cmd_gateway.go
@@ -211,10 +211,10 @@ func gatewayCmd() {
 	<-sigChan
 
 	fmt.Println("\nShutting down...")
-	cancel()
-	if cp, ok := provider.(providers.SessionProvider); ok {
+	if cp, ok := provider.(providers.StatefulProvider); ok {
 		cp.Close()
 	}
+	cancel()
 	healthServer.Stop(context.Background())
 	deviceService.Stop()
 	heartbeatService.Stop()

--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -30,7 +30,7 @@ type LLMProvider interface {
 	GetDefaultModel() string
 }
 
-type SessionProvider interface {
+type StatefulProvider interface {
 	LLMProvider
 	Close()
 }

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -14,14 +14,14 @@ import (
 type mockRegistryTool struct {
 	name   string
 	desc   string
-	params map[string]any
+	params map[string]interface{}
 	result *ToolResult
 }
 
-func (m *mockRegistryTool) Name() string               { return m.name }
-func (m *mockRegistryTool) Description() string        { return m.desc }
-func (m *mockRegistryTool) Parameters() map[string]any { return m.params }
-func (m *mockRegistryTool) Execute(_ context.Context, _ map[string]any) *ToolResult {
+func (m *mockRegistryTool) Name() string                       { return m.name }
+func (m *mockRegistryTool) Description() string                { return m.desc }
+func (m *mockRegistryTool) Parameters() map[string]interface{} { return m.params }
+func (m *mockRegistryTool) Execute(_ context.Context, _ map[string]interface{}) *ToolResult {
 	return m.result
 }
 
@@ -51,7 +51,7 @@ func newMockTool(name, desc string) *mockRegistryTool {
 	return &mockRegistryTool{
 		name:   name,
 		desc:   desc,
-		params: map[string]any{"type": "object"},
+		params: map[string]interface{}{"type": "object"},
 		result: SilentResult("ok"),
 	}
 }
@@ -109,7 +109,7 @@ func TestToolRegistry_Execute_Success(t *testing.T) {
 	r.Register(&mockRegistryTool{
 		name:   "greet",
 		desc:   "says hello",
-		params: map[string]any{},
+		params: map[string]interface{}{},
 		result: SilentResult("hello"),
 	})
 
@@ -203,7 +203,7 @@ func TestToolRegistry_GetDefinitions(t *testing.T) {
 	if defs[0]["type"] != "function" {
 		t.Errorf("expected type 'function', got %v", defs[0]["type"])
 	}
-	fn, ok := defs[0]["function"].(map[string]any)
+	fn, ok := defs[0]["function"].(map[string]interface{})
 	if !ok {
 		t.Fatal("expected 'function' key to be a map")
 	}
@@ -217,7 +217,7 @@ func TestToolRegistry_GetDefinitions(t *testing.T) {
 
 func TestToolRegistry_ToProviderDefs(t *testing.T) {
 	r := NewToolRegistry()
-	params := map[string]any{"type": "object", "properties": map[string]any{}}
+	params := map[string]interface{}{"type": "object", "properties": map[string]interface{}{}}
 	r.Register(&mockRegistryTool{
 		name:   "beta",
 		desc:   "tool B",
@@ -310,7 +310,7 @@ func TestToolToSchema(t *testing.T) {
 	if schema["type"] != "function" {
 		t.Errorf("expected type 'function', got %v", schema["type"])
 	}
-	fn, ok := schema["function"].(map[string]any)
+	fn, ok := schema["function"].(map[string]interface{})
 	if !ok {
 		t.Fatal("expected 'function' to be a map")
 	}


### PR DESCRIPTION
## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** #204 
- **Reasoning:** As is, at the moment the github copilot provider is unusable due to the defer client.stop() which closes immediately the connection with the cli

## 🧪 Test Environment
- **Hardware:** Intel/AMD PC platform
- **OS:** Debian,Window
- **Model/Provider:** gpt-4.1
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.