### PR TITLE
fix: support custom model protocols (e.g., zai-org/GLM-4.7)

### DIFF
--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -151,7 +151,15 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 		return provider, modelID, nil
 
 	default:
-		return nil, "", fmt.Errorf("unknown protocol %q in model %q", protocol, cfg.Model)
+		// Treat unknown protocols as OpenAI-compatible
+		if cfg.APIKey == "" && cfg.APIBase == "" {
+			return nil, "", fmt.Errorf("api_key or api_base is required for HTTP-based protocol %q", protocol)
+		}
+		apiBase := cfg.APIBase
+		if apiBase == "" {
+			apiBase = getDefaultAPIBase("openai")
+		}
+		return NewHTTPProviderWithMaxTokensField(cfg.APIKey, apiBase, cfg.Proxy, cfg.MaxTokensField), cfg.Model, nil
 	}
 }
 


### PR DESCRIPTION
## Problem

When using custom models with unknown protocols (e.g., `zai-org/GLM-4.7`), the system returns an error:

```
Error creating provider: failed to create provider for model "zai-org/GLM-4.7": unknown protocol "zai-org" in model "zai-org/GLM-4.7"
```

## Root Cause

In `pkg/providers/factory_provider.go`, the `ExtractProtocol()` function splits the model string by the first `/` character. For `"zai-org/GLM-4.7"`, this results in:
- `protocol="zai-org"`
- `modelID="GLM-4.7"`

Since `"zai-org"` is not in the list of supported protocols, the system returns an error.

## Solution

Modified the `default` case in `CreateProvider()` to treat unknown protocols as OpenAI-compatible:

```go
default:
	// Treat unknown protocols as OpenAI-compatible
	if cfg.APIKey == "" && cfg.APIBase == "" {
		return nil, "", fmt.Errorf("api_key or api_base is required for HTTP-based protocol %q", protocol)
	}
	apiBase := cfg.APIBase
	if apiBase == "" {
		apiBase = getDefaultAPIBase("openai")
	}
	return NewHTTPProviderWithMaxTokensField(cfg.APIKey, apiBase, cfg.Proxy, cfg.MaxTokensField), cfg.Model, nil
```

Key change: Returns `cfg.Model` (full model name including protocol) instead of just `modelID`, so the complete model name `"zai-org/GLM-4.7"` is sent to the API.

## Configuration

Set in `cfg/config.json`:

```json
{
  "model_name": "zai-org/GLM-4.7",
  "model": "zai-org/GLM-4.7",
  "api_base": "https://your-custom-api-endpoint.com/v1",
  "api_key": "..."
}
```

## Benefits

1. **Support for custom models**: Users can now use any custom model with an OpenAI-compatible API
2. **No code changes required**: Simply configure the model name and API base URL
3. **Backward compatible**: Existing configurations continue to work as before
4. **Flexible**: Works with any OpenAI-compatible API endpoint

## Testing

Tested with custom model `zai-org/GLM-4.7`:
- Application starts successfully
- Model is correctly recognized
- Requests are processed through the API

## Related Issue

Fixes #661
