### PR TITLE
fix: support custom model protocols (e.g., zai-org/GLM-4.7)

### DIFF
--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
 // createClaudeAuthProvider creates a Claude provider using OAuth credentials from auth store.
@@ -53,8 +54,8 @@ func ExtractProtocol(model string) (protocol, modelID string) {
 
 // CreateProviderFromConfig creates a provider based on the ModelConfig.
 // It uses the protocol prefix in the Model field to determine which provider to create.
-// Supported protocols: openai, litellm, anthropic, antigravity, claude-cli, codex-cli, github-copilot
-// Returns the provider, the model ID (without protocol prefix), and any error.
+// Supported protocols: openai, litellm, anthropic, antigravity, claude-cli, codex-cli, github-copilot, and any OpenAI-compatible HTTP provider.
+// Returns the provider, the model ID (full model string for unknown protocols, otherwise without protocol prefix), and any error.
 func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, error) {
 	if cfg == nil {
 		return nil, "", fmt.Errorf("config is nil")
@@ -169,7 +170,16 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 		return provider, modelID, nil
 
 	default:
-		return nil, "", fmt.Errorf("unknown protocol %q in model %q", protocol, cfg.Model)
+		// Treat unknown protocols as OpenAI-compatible
+		logger.WarnF("unknown protocol, falling back to OpenAI-compatible HTTP provider", map[string]any{"protocol": protocol, "model": cfg.Model})
+		if cfg.APIKey == "" && cfg.APIBase == "" {
+			return nil, "", fmt.Errorf("api_key or api_base is required for HTTP-based protocol %q", protocol)
+		}
+		apiBase := cfg.APIBase
+		if apiBase == "" {
+			apiBase = getDefaultAPIBase("openai")
+		}
+		return NewHTTPProviderWithMaxTokensFieldAndRequestTimeout(cfg.APIKey, apiBase, cfg.Proxy, cfg.MaxTokensField, cfg.RequestTimeout), cfg.Model, nil
 	}
 }
 

--- a/pkg/providers/factory_provider_test.go
+++ b/pkg/providers/factory_provider_test.go
@@ -254,9 +254,46 @@ func TestCreateProviderFromConfig_UnknownProtocol(t *testing.T) {
 		APIKey:    "test-key",
 	}
 
+	provider, modelID, err := CreateProviderFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("CreateProviderFromConfig() unexpected error: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("CreateProviderFromConfig() returned nil provider for unknown protocol with APIKey")
+	}
+	if modelID != cfg.Model {
+		t.Fatalf("CreateProviderFromConfig() expected modelID=%q, got %q", cfg.Model, modelID)
+	}
+}
+
+func TestCreateProviderFromConfig_UnknownProtocolWithAPIBase(t *testing.T) {
+	cfg := &config.ModelConfig{
+		ModelName: "test-unknown",
+		Model:     "unknown-protocol/model",
+		APIBase:   "http://localhost:8080/v1",
+	}
+
+	provider, modelID, err := CreateProviderFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("CreateProviderFromConfig() unexpected error: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("CreateProviderFromConfig() returned nil provider")
+	}
+	if modelID != cfg.Model {
+		t.Fatalf("CreateProviderFromConfig() expected modelID=%q, got %q", cfg.Model, modelID)
+	}
+}
+
+func TestCreateProviderFromConfig_UnknownProtocolNoAuth(t *testing.T) {
+	cfg := &config.ModelConfig{
+		ModelName: "test-unknown",
+		Model:     "unknown-protocol/model",
+	}
+
 	_, _, err := CreateProviderFromConfig(cfg)
 	if err == nil {
-		t.Fatal("CreateProviderFromConfig() expected error for unknown protocol")
+		t.Fatal("CreateProviderFromConfig() expected error for unknown protocol without api_key or api_base")
 	}
 }
 


### PR DESCRIPTION
## Problem

When using custom models with unknown protocols (e.g., \`zai-org/GLM-4.7\`), the system returns an error:

\`\`\`
Error creating provider: failed to create provider for model "zai-org/GLM-4.7": unknown protocol "zai-org" in model "zai-org/GLM-4.7"
\`\`\`

## Root Cause

In \`pkg/providers/factory_provider.go\`, the \`ExtractProtocol()\` function splits the model string by the first \`/\` character. For \`"zai-org/GLM-4.7"\`, this results in:
- \`protocol="zai-org"\`
- \`modelID="GLM-4.7"\`

Since \`"zai-org"\` is not in the list of supported protocols, the system returns an error.

## Solution

Added a \`default\` case in \`CreateProviderFromConfig()\` that treats unknown protocols as OpenAI-compatible HTTP providers instead of returning an error:

\`\`\`go
default:
    // Treat unknown protocols as OpenAI-compatible
    logger.WarnF("unknown protocol, falling back to OpenAI-compatible HTTP provider",
        map[string]any{"protocol": protocol, "model": cfg.Model})
    if cfg.APIKey == "" && cfg.APIBase == "" {
        return nil, "", fmt.Errorf("api_key or api_base is required for HTTP-based protocol %q", protocol)
    }
    apiBase := cfg.APIBase
    if apiBase == "" {
        apiBase = getDefaultAPIBase("openai")
    }
    return NewHTTPProviderWithMaxTokensFieldAndRequestTimeout(
        cfg.APIKey, apiBase, cfg.Proxy, cfg.MaxTokensField, cfg.RequestTimeout,
    ), cfg.Model, nil
\`\`\`

Key points:
- Returns \`cfg.Model\` (full model name) instead of just \`modelID\`, so \`"zai-org/GLM-4.7"\` is sent to the API as-is
- Uses \`NewHTTPProviderWithMaxTokensFieldAndRequestTimeout\` — consistent with all other HTTP provider cases
- Logs a structured warning via \`WarnF\` so operators can see the fallback

## Configuration

\`\`\`json
{
  "model_name": "zai-org/GLM-4.7",
  "model": "zai-org/GLM-4.7",
  "api_base": "https://your-custom-api-endpoint.com/v1",
  "api_key": "..."
}
\`\`\`

## Testing

Added unit tests covering all three scenarios:

| Test | Scenario |
|------|----------|
| \`TestCreateProviderFromConfig_UnknownProtocol\` | Unknown protocol + \`api_key\` → fallback succeeds, returns full \`cfg.Model\` as model ID |
| \`TestCreateProviderFromConfig_UnknownProtocolWithAPIBase\` | Unknown protocol + \`api_base\` only (no key) → fallback succeeds (unauthenticated local endpoint) |
| \`TestCreateProviderFromConfig_UnknownProtocolNoAuth\` | Unknown protocol + no credentials → returns error |

## Backward Compatibility

- All existing protocol configurations continue to work unchanged
- Unknown protocols now fall back gracefully instead of hard-erroring

Fixes #661