### PR TITLE
feat: register Telegram command menu via SetMyCommands

### DIFF
--- a/pkg/channels/telegram.go
+++ b/pkg/channels/telegram.go
@@ -158,7 +158,7 @@ func (c *TelegramChannel) registerCommands(ctx context.Context) error {
 		{Command: "start", Description: "Start the bot"},
 		{Command: "help", Description: "Show this help message"},
 		{Command: "show", Description: "Show current configuration"},
-		{Command: "list", Description: "List available options (models or channels)"},
+		{Command: "list", Description: "List available options"},
 	}
 
 	return c.bot.SetMyCommands(ctx, &telego.SetMyCommandsParams{


### PR DESCRIPTION
## 📝 Description

The Telegram bot does not call `SetMyCommands`, so users don't see the command menu when pressing `/` in chat. This PR registers the existing handled commands (`/start`, `/help`, `/show`, `/list`) on startup so the menu is visible.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

<!-- No existing issue — this is a missing feature discovered during usage -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://core.telegram.org/bots/api#setmycommands
- **Reasoning:** `telego.BotCommand` and `telego.SetMyCommandsParams` already exist in telego v1.6.0 — no new dependencies needed. Only the 4 commands that have registered handlers are included. Registration failure logs a warning but does not block bot startup.

## 🧪 Test Environment
- **Hardware:** PC (AMD64)
- **OS:** Ubuntu 24.04 (Linux 6.8.0-87-generic)
- **Model/Provider:** N/A (channel-level change, no LLM interaction)
- **Channels:** Telegram

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

After deploying, pressing `/` in the Telegram chat shows the command menu with all 4 registered commands. `make build` and `go test ./pkg/channels/ -v` pass with no errors or warnings.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.