### PR TITLE
fix: change message sending from text to markdown format in WeComAppC…

### DIFF
--- a/pkg/channels/wecom_app.go
+++ b/pkg/channels/wecom_app.go
@@ -223,7 +223,7 @@ func (c *WeComAppChannel) Send(ctx context.Context, msg bus.OutboundMessage) err
 		"preview": utils.Truncate(msg.Content, 100),
 	})
 
-	return c.sendTextMessage(ctx, accessToken, msg.ChatID, msg.Content)
+	return c.sendMarkdownMessage(ctx, accessToken, msg.ChatID, msg.Content)
 }
 
 // handleWebhook handles incoming webhook requests from WeCom


### PR DESCRIPTION
## 📝 Description

In `WeComAppChannel`'s `Send` method, changed message sending from plain text (`sendTextMessage`) to Markdown format (`sendMarkdownMessage`).

AI responses typically contain Markdown syntax (bold, lists, code blocks, etc.). Sending them as plain text caused raw Markdown symbols to appear in WeCom instead of rendered content. This fix ensures messages are displayed with proper rich-text formatting.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://developer.work.weixin.qq.com/document/path/90236
- **Reasoning:** WeCom App messages support Markdown format (`msgtype: "markdown"`). Since AI responses are already in Markdown, sending them via `sendTextMessage` (`msgtype: "text"`) caused raw symbols to render as plain text. Switching to `sendMarkdownMessage` ensures proper formatting is applied on the client side.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Linux
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** WeCom App

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.