### PR TITLE
feat: ContextWindow vs MaxTokens fix + Token-oriented compaction

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -88,6 +88,12 @@ func NewAgentInstance(
 		temperature = *defaults.Temperature
 	}
 
+	// Resolve ContextWindow: use from config if set, otherwise use maxTokens as fallback
+	contextWindow := defaults.ContextWindow
+	if contextWindow == 0 {
+		contextWindow = maxTokens
+	}
+
 	// Resolve fallback candidates
 	modelCfg := providers.ModelConfig{
 		Primary:   model,
@@ -104,7 +110,7 @@ func NewAgentInstance(
 		MaxIterations:  maxIter,
 		MaxTokens:      maxTokens,
 		Temperature:    temperature,
-		ContextWindow:  maxTokens,
+		ContextWindow:  contextWindow,
 		Provider:       provider,
 		Sessions:       sessionsManager,
 		ContextBuilder: contextBuilder,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -167,16 +167,24 @@ type SessionConfig struct {
 }
 
 type AgentDefaults struct {
-	Workspace           string   `json:"workspace"                       env:"PICOCLAW_AGENTS_DEFAULTS_WORKSPACE"`
-	RestrictToWorkspace bool     `json:"restrict_to_workspace"           env:"PICOCLAW_AGENTS_DEFAULTS_RESTRICT_TO_WORKSPACE"`
-	Provider            string   `json:"provider"                        env:"PICOCLAW_AGENTS_DEFAULTS_PROVIDER"`
-	Model               string   `json:"model"                           env:"PICOCLAW_AGENTS_DEFAULTS_MODEL"`
-	ModelFallbacks      []string `json:"model_fallbacks,omitempty"`
-	ImageModel          string   `json:"image_model,omitempty"           env:"PICOCLAW_AGENTS_DEFAULTS_IMAGE_MODEL"`
-	ImageModelFallbacks []string `json:"image_model_fallbacks,omitempty"`
-	MaxTokens           int      `json:"max_tokens"                      env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOKENS"`
-	Temperature         *float64 `json:"temperature,omitempty"           env:"PICOCLAW_AGENTS_DEFAULTS_TEMPERATURE"`
-	MaxToolIterations   int      `json:"max_tool_iterations"             env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOOL_ITERATIONS"`
+	Workspace           string         `json:"workspace"                       env:"PICOCLAW_AGENTS_DEFAULTS_WORKSPACE"`
+	RestrictToWorkspace bool           `json:"restrict_to_workspace"           env:"PICOCLAW_AGENTS_DEFAULTS_RESTRICT_TO_WORKSPACE"`
+	Provider            string         `json:"provider"                        env:"PICOCLAW_AGENTS_DEFAULTS_PROVIDER"`
+	Model               string         `json:"model"                           env:"PICOCLAW_AGENTS_DEFAULTS_MODEL"`
+	ModelFallbacks      []string       `json:"model_fallbacks,omitempty"`
+	ImageModel          string         `json:"image_model,omitempty"           env:"PICOCLAW_AGENTS_DEFAULTS_IMAGE_MODEL"`
+	ImageModelFallbacks []string       `json:"image_model_fallbacks,omitempty"`
+	MaxTokens           int            `json:"max_tokens"                      env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOKENS"`
+	ContextWindow       int            `json:"context_window,omitempty"        env:"PICOCLAW_AGENTS_DEFAULTS_CONTEXT_WINDOW"`
+	Temperature         *float64       `json:"temperature,omitempty"           env:"PICOCLAW_AGENTS_DEFAULTS_TEMPERATURE"`
+	MaxToolIterations   int            `json:"max_tool_iterations"             env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOOL_ITERATIONS"`
+	Compaction          CompactionConfig `json:"compaction,omitempty"`
+}
+
+type CompactionConfig struct {
+	ReserveTokens      int `json:"reserve_tokens,omitempty"      env:"PICOCLAW_AGENTS_DEFAULTS_COMPACTION_RESERVE_TOKENS"`
+	ReserveTokensFloor int `json:"reserve_tokens_floor,omitempty" env:"PICOCLAW_AGENTS_DEFAULTS_COMPACTION_RESERVE_TOKENS_FLOOR"`
+	KeepRecentTokens   int `json:"keep_recent_tokens,omitempty"   env:"PICOCLAW_AGENTS_DEFAULTS_COMPACTION_KEEP_RECENT_TOKENS"`
 }
 
 type ChannelsConfig struct {


### PR DESCRIPTION
## Summary

This PR addresses Issue #653 and implements token-oriented compaction similar to OpenClaw.

### Changes

1. **Separate ContextWindow from MaxTokens**
   - Added  field to 
   - Previously,  incorrectly copied 
   - For GLM-4.7: can now set  and 

2. **Token-oriented Compaction**
   - Removed hardcoded message count threshold (`>20 messages`)
   - Added `CompactionConfig` for flexible settings:
     - `reserve_tokens`: tokens to reserve (default 20000)
     - `reserve_tokens_floor`: minimum reserve (default 20000)
     - `keep_recent_tokens`: recent tokens to keep (default 20000)
   - New trigger: `tokenEstimate > ContextWindow - reserveTokensFloor`
   - For 200k context window: triggers at ~180k tokens (90% threshold, was 75%)

3. **New summarizeSessionWithTokenLimit method**
   - Keeps last N tokens instead of fixed message count
   - More accurate for large context windows

### Example Config

```yaml
agents:
  defaults:
    model: "glm-4.7"
    context_window: 200000
    max_tokens: 4096
    compaction:
      reserve_tokens_floor: 20000
      keep_recent_tokens: 20000
```

### Related
- Issue #653 (context_window bug)