### PR TITLE
fix: distinguish network timeouts from context window errors

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -9,6 +9,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -554,10 +555,35 @@ func (al *AgentLoop) runLLMIteration(
 			}
 
 			errMsg := strings.ToLower(err.Error())
-			isContextError := strings.Contains(errMsg, "token") ||
-				strings.Contains(errMsg, "context") ||
+
+			// Check if this is a network/HTTP timeout — not a context window error.
+			isTimeoutError := errors.Is(err, context.DeadlineExceeded) ||
+				strings.Contains(errMsg, "deadline exceeded") ||
+				strings.Contains(errMsg, "client.timeout") ||
+				strings.Contains(errMsg, "timed out") ||
+				strings.Contains(errMsg, "timeout exceeded")
+
+			// Detect real context window / token limit errors, excluding network timeouts.
+			isContextError := !isTimeoutError && (strings.Contains(errMsg, "context_length_exceeded") ||
+				strings.Contains(errMsg, "context window") ||
+				strings.Contains(errMsg, "maximum context length") ||
+				strings.Contains(errMsg, "token limit") ||
+				strings.Contains(errMsg, "too many tokens") ||
+				strings.Contains(errMsg, "max_tokens") ||
 				strings.Contains(errMsg, "invalidparameter") ||
-				strings.Contains(errMsg, "length")
+				strings.Contains(errMsg, "prompt is too long") ||
+				strings.Contains(errMsg, "request too large"))
+
+			if isTimeoutError && retry < maxRetries {
+				backoff := time.Duration(retry+1) * 5 * time.Second
+				logger.WarnCF("agent", "Timeout error, retrying after backoff", map[string]any{
+					"error":   err.Error(),
+					"retry":   retry,
+					"backoff": backoff.String(),
+				})
+				time.Sleep(backoff)
+				continue
+			}
 
 			if isContextError && retry < maxRetries {
 				logger.WarnCF("agent", "Context window error detected, attempting compression", map[string]any{


### PR DESCRIPTION
Fixes #683

## Summary

- HTTP timeouts (`context deadline exceeded`, `Client.Timeout exceeded`) were incorrectly classified as context window errors due to overly broad substring matching (`"context"`, `"token"`, `"length"`)
- This caused useless history compression and a misleading "Context window exceeded" message to users when the real problem was a network timeout (e.g. slow z.ai API response)
- Replaced broad checks with explicit timeout detection first, then specific context window error patterns (`context_length_exceeded`, `token limit`, `too many tokens`, `invalidparameter`, etc.)
- Timeout errors were not retried at all — now they retry up to 2 times with exponential backoff (5s, 10s)

## Test plan

- [x] Existing `TestAgentLoop_ContextExhaustionRetry` passes — real context window errors still trigger compression
- [x] Full test suite passes (`go test ./...`)
- [ ] Manual test: simulate z.ai timeout and verify no false "Context window exceeded" message
- [ ] Manual test: verify timeout retries with backoff in logs