### PR TITLE
fix: add generate dependency to test and vet Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,11 +129,11 @@ clean:
 	@echo "Clean complete"
 
 ## vet: Run go vet for static analysis
-vet:
+vet: generate
 	@$(GO) vet ./...
 
 ## test: Test Go code
-test:
+test: generate
 	@$(GO) test ./...
 
 ## fmt: Format Go code


### PR DESCRIPTION
## Summary

- `make test` and `make vet` fail on a fresh clone because `cmd/picoclaw/workspace` (needed by `//go:embed`) is gitignored and only created by `go generate`
- The `build` target already depends on `generate`, but `test` and `vet` did not

## Test plan

- `rm -rf cmd/picoclaw/workspace && make test` — passes (was FAIL before)
- `rm -rf cmd/picoclaw/workspace && make vet` — passes (was FAIL before)
- `make build` — still works as before