### PR TITLE
feat: add mentioned_only config for OneBot channel

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -112,6 +112,7 @@
       "access_token": "",
       "reconnect_interval": 5,
       "group_trigger_prefix": [],
+      "mentioned_only": true,
       "allow_from": []
     },
     "wecom": {

--- a/docs/channels/onebot/README.zh.md
+++ b/docs/channels/onebot/README.zh.md
@@ -17,12 +17,14 @@ OneBot 是一个面向 QQ 机器人的开放协议标准，为多种 QQ 机器�
 }
 ```
 
-| 字段         | 类型   | 必填 | 描述                             |
-| ------------ | ------ | ---- | -------------------------------- |
-| enabled      | bool   | 是   | 是否启用 OneBot 频道             |
-| ws_url       | string | 是   | OneBot 服务器的 WebSocket URL    |
-| access_token | string | 否   | 连接 OneBot 服务器的访问令牌     |
-| allow_from   | array  | 否   | 用户ID白名单，空表示允许所有用户 |
+| 字段               | 类型   | 必填 | 默认值 | 描述                                                                 |
+| ------------------ | ------ | ---- | ------ | -------------------------------------------------------------------- |
+| enabled            | bool   | 是   | -      | 是否启用 OneBot 频道                                                 |
+| ws_url             | string | 是   | -      | OneBot 服务器的 WebSocket URL                                        |
+| access_token       | string | 否   | -      | 连接 OneBot 服务器的访问令牌                                         |
+| mentioned_only     | bool   | 否   | true   | 为 true 时仅处理 @ 了机器人的群消息；为 false 时处理所有群消息（适用于官方机器人等仅推送已 @ 消息的实现） |
+| group_trigger_prefix | array  | 否   | []     | 群消息触发前缀，消息以此列表中某一项开头也会触发                     |
+| allow_from         | array  | 否   | []     | 用户ID白名单，空表示允许所有用户                                     |
 
 ## 设置流程
 

--- a/pkg/channels/onebot.go
+++ b/pkg/channels/onebot.go
@@ -887,7 +887,17 @@ func (c *OneBotChannel) handleMessage(raw *oneBotRawEvent) {
 			metadata["sender_name"] = sender.Nickname
 		}
 
-		triggered, strippedContent := c.checkGroupTrigger(content, isBotMentioned)
+		mentionedOnly := true
+		if c.config.MentionedOnly != nil {
+			mentionedOnly = *c.config.MentionedOnly
+		}
+		var triggered bool
+		var strippedContent string
+		if mentionedOnly {
+			triggered, strippedContent = c.checkGroupTrigger(content, isBotMentioned)
+		} else {
+			triggered, strippedContent = true, content
+		}
 		if !triggered {
 			logger.DebugCF("onebot", "Group message ignored (no trigger)", map[string]any{
 				"sender":       senderID,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -267,6 +267,7 @@ type OneBotConfig struct {
 	AccessToken        string              `json:"access_token"         env:"PICOCLAW_CHANNELS_ONEBOT_ACCESS_TOKEN"`
 	ReconnectInterval  int                 `json:"reconnect_interval"   env:"PICOCLAW_CHANNELS_ONEBOT_RECONNECT_INTERVAL"`
 	GroupTriggerPrefix []string            `json:"group_trigger_prefix" env:"PICOCLAW_CHANNELS_ONEBOT_GROUP_TRIGGER_PREFIX"`
+	MentionedOnly      *bool               `json:"mentioned_only"     env:"PICOCLAW_CHANNELS_ONEBOT_MENTIONED_ONLY"`
 	AllowFrom          FlexibleStringSlice `json:"allow_from"           env:"PICOCLAW_CHANNELS_ONEBOT_ALLOW_FROM"`
 }
 


### PR DESCRIPTION
- add `mentioned_only` for OneBot channel to control whether the message contains a mention of the bot (@bot_id) can be processed.
- update the documentation accordingly.

## 📝 Description

Adds a `mentioned_only` option for the OneBot channel to control whether only messages that @mention the bot are processed:
- **`mentioned_only: true` (default)**: Only process group messages that mention the bot, avoiding replies to every message and reducing spam.
- **`mentioned_only: false`**: Process all group messages (for implementations that only deliver messages that already @ the bot, e.g. some official bots).

Changes: OneBot channel logic (`pkg/channels/onebot.go`), config struct and example (`pkg/config/config.go`, `config/config.example.json`), and OneBot docs (`docs/channels/onebot/README.zh.md`).

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

AI Model: Cursor Auto and Claude Opus 4.6

## 🔗 Related Issue

Closes [#678](https://github.com/sipeed/picoclaw/issues/678) — [Feature] Add mentioned_only config option for OneBot channel

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** [OneBot Implementations](https://onebot.dev/ecosystem.html) (message format and @mentions)
- **Reasoning:** In group chats we need to choose between “reply only when @mentioned” and “reply to every message”. Defaulting to only @mentioned messages gives users explicit control regardless of how the OneBot client forwards messages (see [#678](https://github.com/sipeed/picoclaw/issues/678)); set to `false` when the implementation only delivers messages that already @ the bot.

## 🧪 Test Environment
- **Hardware:** PC (x86_64, Intel Core i7-13700H)
- **OS:** Ubuntu 24.04
- **Model/Provider:** OpenAI Compatible API(MiniMax API)
- **Channels:** OneBot (e.g. go-cqhttp, NapCat, Onebots)


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.