### PR TITLE
fix: prevent DefaultConfig template values from leaking into user model_list entries

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -499,6 +499,20 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, err
 	}
 
+	// Pre-scan the JSON to check how many model_list entries the user provided.
+	// Go's JSON decoder reuses existing slice backing-array elements rather than
+	// zero-initializing them, so fields absent from the user's JSON (e.g. api_base)
+	// would silently inherit values from the DefaultConfig template at the same
+	// index position. We only reset cfg.ModelList when the user actually provides
+	// entries; when count is 0 we keep DefaultConfig's built-in list as fallback.
+	var tmp Config
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return nil, err
+	}
+	if len(tmp.ModelList) > 0 {
+		cfg.ModelList = nil
+	}
+
 	if err := json.Unmarshal(data, cfg); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Fixes #721

When `DefaultConfig()` pre-populates `ModelList` with ~18 template entries, Go's JSON decoder reuses the existing slice backing-array elements rather than zero-initializing them. This means fields absent from the user's JSON (e.g. `api_base`) silently inherit the template value at the same index position — for example, `ModelList[0]` is the Zhipu `glm-4.7` entry with `APIBase: "https://open.bigmodel.cn/api/paas/v4"`, which leaks into any user-defined model at index 0 that omits `api_base`.

**Fix**: pre-scan the JSON into a zero-value `Config` to count user-provided `model_list` entries. Only reset `cfg.ModelList = nil` when the user provides >0 entries, ensuring clean zero-value initialization during the real unmarshal. When the user provides 0 entries, the `DefaultConfig` built-in list is preserved as a fallback.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| User `model_list` has 0 entries | DefaultConfig list used (correct) | DefaultConfig list used (correct) |
| User `model_list` has ≥1 entries, some fields omitted | Omitted fields leaked from DefaultConfig template | Omitted fields are zero-valued (correct) |

## Test plan

- [x] All existing `pkg/config` tests pass
- [x] Full project builds cleanly (`go build ./...`)
- Manual: set a single `model_list` entry with no `api_base` → confirm the model entry has empty `api_base` instead of the Zhipu template URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)