### PR TITLE
[feat] Add customer config path support 

### DIFF
--- a/cmd/picoclaw/cmd_agent.go
+++ b/cmd/picoclaw/cmd_agent.go
@@ -24,6 +24,7 @@ func agentCmd() {
 	message := ""
 	sessionKey := "cli:default"
 	modelOverride := ""
+	configPath := ""
 
 	args := os.Args[2:]
 	for i := 0; i < len(args); i++ {
@@ -46,10 +47,24 @@ func agentCmd() {
 				modelOverride = args[i+1]
 				i++
 			}
+		case "-c", "--config":
+			if i+1 < len(args) {
+				configPath = args[i+1]
+				i++
+			} else {
+				fmt.Println("Error: -c/--config requires a file path")
+				os.Exit(1)
+			}
+		default:
+			if strings.HasPrefix(args[i], "--config=") {
+				configPath = strings.TrimPrefix(args[i], "--config=")
+			} else if strings.HasPrefix(args[i], "-c=") {
+				configPath = strings.TrimPrefix(args[i], "-c=")
+			}
 		}
 	}
 
-	cfg, err := loadConfig()
+	cfg, err := loadConfigFromPath(configPath)
 	if err != nil {
 		fmt.Printf("Error loading config: %v\n", err)
 		os.Exit(1)

--- a/cmd/picoclaw/cmd_gateway.go
+++ b/cmd/picoclaw/cmd_gateway.go
@@ -29,17 +29,31 @@ import (
 )
 
 func gatewayCmd() {
-	// Check for --debug flag
+	configPath := ""
 	args := os.Args[2:]
-	for _, arg := range args {
-		if arg == "--debug" || arg == "-d" {
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--debug" || args[i] == "-d" {
 			logger.SetLevel(logger.DEBUG)
 			fmt.Println("🔍 Debug mode enabled")
-			break
+			continue
+		}
+		if args[i] == "-c" || args[i] == "--config" {
+			if i+1 < len(args) {
+				configPath = args[i+1]
+				i++
+				continue
+			}
+			fmt.Println("Error: -c/--config requires a file path")
+			os.Exit(1)
+		}
+		if strings.HasPrefix(args[i], "--config=") {
+			configPath = strings.TrimPrefix(args[i], "--config=")
+		} else if strings.HasPrefix(args[i], "-c=") {
+			configPath = strings.TrimPrefix(args[i], "-c=")
 		}
 	}
 
-	cfg, err := loadConfig()
+	cfg, err := loadConfigFromPath(configPath)
 	if err != nil {
 		fmt.Printf("Error loading config: %v\n", err)
 		os.Exit(1)

--- a/cmd/picoclaw/main.go
+++ b/cmd/picoclaw/main.go
@@ -195,5 +195,12 @@ func getConfigPath() string {
 }
 
 func loadConfig() (*config.Config, error) {
-	return config.LoadConfig(getConfigPath())
+	return loadConfigFromPath("")
+}
+
+func loadConfigFromPath(path string) (*config.Config, error) {
+	if path == "" {
+		path = getConfigPath()
+	}
+	return config.LoadConfig(path)
 }


### PR DESCRIPTION
## 📝 Description

Add customer config path support for command `agent` and `gateway`

It support :

```
./picoclaw-linux-amd64 agent  -c ./config.json -m "hi,who are you ?"
```
And 
```
./picoclaw-linux-amd64 gateway -c ./config.json
```
Allows users to set their configs via command , which will makes it easier to host multi-picoclaw-agent on one compute env . 

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

NA

## 📚 Technical Context (Skip for Docs)

NA

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Ubuntu 22.04 amd64
- **Model/Provider:** deepseak-chat 
- **Channels:** Telegram


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>
NA

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.