### PR TITLE
fix: reject empty task in spawn tool

### DIFF
--- a/pkg/tools/spawn.go
+++ b/pkg/tools/spawn.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 type SpawnTool struct {
@@ -66,8 +67,8 @@ func (t *SpawnTool) SetAllowlistChecker(check func(targetAgentID string) bool) {
 
 func (t *SpawnTool) Execute(ctx context.Context, args map[string]any) *ToolResult {
 	task, ok := args["task"].(string)
-	if !ok {
-		return ErrorResult("task is required")
+	if !ok || strings.TrimSpace(task) == "" {
+		return ErrorResult("task is required and must be a non-empty string")
 	}
 
 	label, _ := args["label"].(string)

--- a/pkg/tools/spawn_test.go
+++ b/pkg/tools/spawn_test.go
@@ -1,0 +1,79 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestSpawnTool_Execute_EmptyTask(t *testing.T) {
+	provider := &MockLLMProvider{}
+	manager := NewSubagentManager(provider, "test-model", "/tmp/test", nil)
+	tool := NewSpawnTool(manager)
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{"empty string", map[string]any{"task": ""}},
+		{"whitespace only", map[string]any{"task": "   "}},
+		{"tabs and newlines", map[string]any{"task": "\t\n  "}},
+		{"missing task key", map[string]any{"label": "test"}},
+		{"wrong type", map[string]any{"task": 123}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tool.Execute(ctx, tt.args)
+			if result == nil {
+				t.Fatal("Result should not be nil")
+			}
+			if !result.IsError {
+				t.Error("Expected error for invalid task parameter")
+			}
+			if !strings.Contains(result.ForLLM, "task is required") {
+				t.Errorf("Error message should mention 'task is required', got: %s", result.ForLLM)
+			}
+		})
+	}
+}
+
+func TestSpawnTool_Execute_ValidTask(t *testing.T) {
+	provider := &MockLLMProvider{}
+	manager := NewSubagentManager(provider, "test-model", "/tmp/test", nil)
+	tool := NewSpawnTool(manager)
+
+	ctx := context.Background()
+	args := map[string]any{
+		"task":  "Write a haiku about coding",
+		"label": "haiku-task",
+	}
+
+	result := tool.Execute(ctx, args)
+	if result == nil {
+		t.Fatal("Result should not be nil")
+	}
+	if result.IsError {
+		t.Errorf("Expected success for valid task, got error: %s", result.ForLLM)
+	}
+	if !result.Async {
+		t.Error("SpawnTool should return async result")
+	}
+}
+
+func TestSpawnTool_Execute_NilManager(t *testing.T) {
+	tool := NewSpawnTool(nil)
+
+	ctx := context.Background()
+	args := map[string]any{"task": "test task"}
+
+	result := tool.Execute(ctx, args)
+	if !result.IsError {
+		t.Error("Expected error for nil manager")
+	}
+	if !strings.Contains(result.ForLLM, "Subagent manager not configured") {
+		t.Errorf("Error message should mention manager not configured, got: %s", result.ForLLM)
+	}
+}


### PR DESCRIPTION
## 📝 Description

The `spawn` tool accepts empty strings as valid `task` arguments (e.g. `spawn("")` or `spawn("   ")`), which causes a subagent to run with no meaningful work. The subagent completes with a garbage result, and the completion system message is routed back to the originating channel via `processSystemMessage()`, where the main agent processes it and may hallucinate an unrelated response that gets sent to end users.

**Root cause:** `Execute()` in `spawn.go` checks `args["task"].(string)` with a type assertion, but an empty string passes this check.

**Fix:** Add `strings.TrimSpace(task) == ""` validation to reject empty/whitespace-only task strings early, before a subagent is spawned.

## Reproduction

The bug is trivially reproducible on vanilla `upstream/main` by placing the included test file and running:

```
$ go test ./pkg/tools/ -run TestSpawnTool_Execute_EmptyTask -v

=== RUN   TestSpawnTool_Execute_EmptyTask/empty_string
    spawn_test.go:34: Expected error for invalid task parameter
    spawn_test.go:37: Error message should mention 'task is required', got: Spawned subagent for task:
=== RUN   TestSpawnTool_Execute_EmptyTask/whitespace_only
    spawn_test.go:34: Expected error for invalid task parameter
    spawn_test.go:37: Error message should mention 'task is required', got: Spawned subagent for task:
=== RUN   TestSpawnTool_Execute_EmptyTask/tabs_and_newlines
    spawn_test.go:34: Expected error for invalid task parameter
    spawn_test.go:37: Error message should mention 'task is required', got: Spawned subagent for task:
--- FAIL: TestSpawnTool_Execute_EmptyTask (0.00s)
```

Empty strings, whitespace-only strings, and tabs/newlines all pass validation and spawn a subagent.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Related: #545 (duplicate messages after subagent delegation — different root cause but same code path: `processSystemMessage` routes subagent completions to user-facing channels)

## 📚 Technical Context
- **Reference URL:** N/A
- **Reasoning:** When an LLM calls `spawn("")`, the subagent runs with an empty user message, completes with a meaningless result, and the completion system message is routed back to the originating channel. The main agent then processes this garbage and sends a hallucinated response to the user. This was observed in production on both Discord (#545) and Signal deployments. Validating the task parameter at the tool level prevents the entire chain from starting.

## 🧪 Test Environment
- **Hardware:** Raspberry Pi 5 (8GB), also reproduced on x86_64 laptop
- **OS:** RPi OS Lite (Debian 12), Ubuntu Linux
- **Model/Provider:** Gemini 2.5 Flash Lite via OpenRouter (production), test suite uses mock provider
- **Channels:** Signal (production observation), bug is channel-agnostic

## 📸 Evidence
<details>
<summary>Click to view Logs/Screenshots</summary>

**Test results on vanilla upstream/main (WITHOUT fix) — bug confirmed:**
```
=== RUN   TestSpawnTool_Execute_EmptyTask/empty_string
    spawn_test.go:34: Expected error for invalid task parameter
    spawn_test.go:37: Error message should mention 'task is required', got: Spawned subagent for task: 
=== RUN   TestSpawnTool_Execute_EmptyTask/whitespace_only
    spawn_test.go:34: Expected error for invalid task parameter
=== RUN   TestSpawnTool_Execute_EmptyTask/tabs_and_newlines
    spawn_test.go:34: Expected error for invalid task parameter
--- FAIL: TestSpawnTool_Execute_EmptyTask (0.00s)
FAIL
```

**Test results WITH fix — all pass:**
```
=== RUN   TestSpawnTool_Execute_EmptyTask
=== RUN   TestSpawnTool_Execute_EmptyTask/empty_string
=== RUN   TestSpawnTool_Execute_EmptyTask/whitespace_only
=== RUN   TestSpawnTool_Execute_EmptyTask/tabs_and_newlines
=== RUN   TestSpawnTool_Execute_EmptyTask/missing_task_key
=== RUN   TestSpawnTool_Execute_EmptyTask/wrong_type
--- PASS: TestSpawnTool_Execute_EmptyTask (0.00s)
=== RUN   TestSpawnTool_Execute_ValidTask
--- PASS: TestSpawnTool_Execute_ValidTask (0.00s)
=== RUN   TestSpawnTool_Execute_NilManager
--- PASS: TestSpawnTool_Execute_NilManager (0.00s)
PASS
ok  	github.com/sipeed/picoclaw/pkg/tools	0.008s
```

**Production log showing the downstream effect:**
```
[INFO] agent: Tool call: spawn({"task":""}) {agent_id=admin, tool=spawn, iteration=1}
[INFO] tool: Tool started (async) {tool=spawn, duration=0}
[INFO] agent: Async tool completed {tool=spawn, content_len=156}
[INFO] agent: Processing message from system:subagent:subagent-1: Task '' completed.
[INFO] agent: Response: I see you've completed your task. I've noted that in the memory. Let's move on.
       What is the current status of the do... {session_key=agent:admin:main}
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.