### PR TITLE
fix: enhance count argument handling in WebSearchTool to support string input

### DIFF
--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -473,9 +475,22 @@ func (t *WebSearchTool) Execute(ctx context.Context, args map[string]any) *ToolR
 	}
 
 	count := t.maxResults
-	if c, ok := args["count"].(float64); ok {
-		if int(c) > 0 && int(c) <= 10 {
-			count = int(c)
+	switch v := args["count"].(type) {
+	case float64:
+		rounded := int(math.Round(v))
+		if math.Abs(v-float64(rounded)) > 1e-9 {
+			return ErrorResult(fmt.Sprintf("count must be an integer, got %v", v))
+		}
+		if rounded > 0 && rounded <= 10 {
+			count = rounded
+		}
+	case int:
+		if v > 0 && v <= 10 {
+			count = v
+		}
+	case string:
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 10 {
+			count = n
 		}
 	}
 


### PR DESCRIPTION
This pull request updates the handling of the `count` argument in the `WebSearchTool.Execute` method to make it more robust. The main improvement is that the method can now accept both numeric and string values for the `count` parameter, converting strings to integers when possible.

**Improvements to argument handling:**

* Enhanced the parsing of the `count` argument in `WebSearchTool.Execute` to accept both `float64` and string types, converting string values to integers using `strconv.Atoi` and validating the range (1–10).
* Added the `strconv` package import in `pkg/tools/web.go` to support string-to-integer conversion.