### PR TITLE
feat: add OpenCode Zen provider (opencode/ prefix)

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -33,6 +33,11 @@
       "api_key": "sk-your-deepseek-key"
     },
     {
+      "model_name": "opencode-zen",
+      "model": "opencode/claude-sonnet-4-5",
+      "api_key": "your-opencode-zen-api-key"
+    },
+    {
       "model_name": "loadbalanced-gpt4",
       "model": "openai/gpt-5.2",
       "api_key": "sk-key1",

--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -53,7 +53,7 @@ func ExtractProtocol(model string) (protocol, modelID string) {
 
 // CreateProviderFromConfig creates a provider based on the ModelConfig.
 // It uses the protocol prefix in the Model field to determine which provider to create.
-// Supported protocols: openai, anthropic, antigravity, claude-cli, codex-cli, github-copilot
+// Supported protocols: openai, anthropic, opencode, antigravity, claude-cli, codex-cli, github-copilot
 // Returns the provider, the model ID (without protocol prefix), and any error.
 func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, error) {
 	if cfg == nil {
@@ -88,7 +88,7 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 
 	case "openrouter", "groq", "zhipu", "gemini", "nvidia",
 		"ollama", "moonshot", "shengsuanyun", "deepseek", "cerebras",
-		"volcengine", "vllm", "qwen", "mistral":
+		"volcengine", "vllm", "qwen", "mistral", "opencode":
 		// All other OpenAI-compatible HTTP providers
 		if cfg.APIKey == "" && cfg.APIBase == "" {
 			return nil, "", fmt.Errorf("api_key or api_base is required for HTTP-based protocol %q", protocol)
@@ -188,6 +188,8 @@ func getDefaultAPIBase(protocol string) string {
 		return "http://localhost:8000/v1"
 	case "mistral":
 		return "https://api.mistral.ai/v1"
+	case "opencode":
+		return "https://opencode.ai/zen/v1"
 	default:
 		return ""
 	}

--- a/pkg/providers/factory_provider_test.go
+++ b/pkg/providers/factory_provider_test.go
@@ -108,6 +108,7 @@ func TestCreateProviderFromConfig_DefaultAPIBase(t *testing.T) {
 		{"vllm", "vllm"},
 		{"deepseek", "deepseek"},
 		{"ollama", "ollama"},
+		{"opencode", "opencode"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Closes #752

Adds [OpenCode Zen](https://opencode.ai/zen) as a new LLM provider. OpenCode Zen is a curated model gateway by the OpenCode team supporting 30+ models (GPT-5, Claude, Gemini, etc.) via a single API key.

- New protocol prefix: `opencode/`
- API base: `https://opencode.ai/zen/v1` (OpenAI-compatible)
- Zero new dependencies — reuses existing `HTTPProvider`

## Changes

- `pkg/providers/factory_provider.go` — add `opencode` case and default API base
- `pkg/providers/factory_provider_test.go` — add test coverage
- `config/config.example.json` — add example entry
- `README*.md` (6 languages) — update vendor table and add config snippet

## Test plan

- [x] `go test ./pkg/providers/ -run TestCreateProviderFromConfig` passes
- [ ] Manual test with a real OpenCode Zen API key