### PR TITLE
agent: ensure today's daily note file exists before LLM read_file

### DIFF
--- a/pkg/agent/memory.go
+++ b/pkg/agent/memory.go
@@ -98,6 +98,21 @@ func (ms *MemoryStore) AppendToday(content string) error {
 	return os.WriteFile(todayFile, []byte(newContent), 0o644)
 }
 
+// EnsureTodayFile creates today's daily note file (and month directory) if missing,
+// so paths advertised in the system prompt (memory/YYYYMM/YYYYMMDD.md) exist when the LLM reads them.
+func (ms *MemoryStore) EnsureTodayFile() {
+	todayFile := ms.getTodayFile()
+	monthDir := filepath.Dir(todayFile)
+	if err := os.MkdirAll(monthDir, 0o755); err != nil {
+		return
+	}
+	if _, err := os.Stat(todayFile); err == nil {
+		return // already exists
+	}
+	header := fmt.Sprintf("# %s\n\n", time.Now().Format("2006-01-02"))
+	_ = os.WriteFile(todayFile, []byte(header), 0o644)
+}
+
 // GetRecentDailyNotes returns daily notes from the last N days.
 // Contents are joined with "---" separator.
 func (ms *MemoryStore) GetRecentDailyNotes(days int) string {
@@ -125,6 +140,7 @@ func (ms *MemoryStore) GetRecentDailyNotes(days int) string {
 // GetMemoryContext returns formatted memory context for the agent prompt.
 // Includes long-term memory and recent daily notes.
 func (ms *MemoryStore) GetMemoryContext() string {
+	ms.EnsureTodayFile() // so memory/YYYYMM/YYYYMMDD.md exists when LLM uses read_file
 	longTerm := ms.ReadLongTerm()
 	recentNotes := ms.GetRecentDailyNotes(3)
 


### PR DESCRIPTION
- Add EnsureTodayFile() to create memory/YYYYMM/YYYYMMDD.md with date header if missing
- Call it from GetMemoryContext() so path advertised in system prompt always exists
- Avoids read_file tool failure when agent (or cron) tries to read today's note

## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [ ] My code/docs follow the style of this project.
- [ ] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.