### PR TITLE
Fix: calling URLs with curl

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -278,6 +278,10 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 		}
 	}
 
+	if strings.HasPrefix(cmd, "curl -s") && strings.Contains(cmd, "https://") {
+		return ""
+	}
+
 	if t.restrictToWorkspace {
 		if strings.Contains(cmd, "..\\") || strings.Contains(cmd, "../") {
 			return "Command blocked by safety guard (path traversal detected)"


### PR DESCRIPTION
## 📝 Description
Calling URLs via curl results in the error: “Command blocked by safety guard (path outside working dir)”. This commit fixes the problem.

## 🗣️ Type of Change
- [X] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [X] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## ☑️ Checklist
- [X] My code/docs follow the style of this project.
- [X] I have performed a self-review of my own changes.
- [] I have updated the documentation accordingly.