### PR TITLE
feat(tool) show tool usage via channel

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -203,6 +203,7 @@
     }
   },
   "tools": {
+    "enable_notifications": false,
     "web": {
       "brave": {
         "enabled": false,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -468,10 +468,11 @@ type ExecConfig struct {
 }
 
 type ToolsConfig struct {
-	Web    WebToolsConfig    `json:"web"`
-	Cron   CronToolsConfig   `json:"cron"`
-	Exec   ExecConfig        `json:"exec"`
-	Skills SkillsToolsConfig `json:"skills"`
+	EnableNotifications bool              `json:"enable_notifications" env:"PICOCLAW_TOOLS_ENABLE_NOTIFICATIONS"`
+	Web                 WebToolsConfig    `json:"web"`
+	Cron                CronToolsConfig   `json:"cron"`
+	Exec                ExecConfig        `json:"exec"`
+	Skills              SkillsToolsConfig `json:"skills"`
 }
 
 type SkillsToolsConfig struct {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -276,6 +276,7 @@ func DefaultConfig() *Config {
 			Port: 18790,
 		},
 		Tools: ToolsConfig{
+			EnableNotifications: false,
 			Web: WebToolsConfig{
 				Proxy: "",
 				Brave: BraveConfig{

--- a/pkg/tools/base.go
+++ b/pkg/tools/base.go
@@ -17,6 +17,12 @@ type ContextualTool interface {
 	SetContext(channel, chatID string)
 }
 
+// NotificationFormatter allows a tool to generate a custom
+// message to be shown to the user before execution.
+type NotificationFormatter interface {
+	FormatNotification(args map[string]any) string
+}
+
 // AsyncCallback is a function type that async tools use to notify completion.
 // When an async tool finishes its work, it calls this callback with the result.
 //

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
 type ExecTool struct {
@@ -132,6 +133,13 @@ func (t *ExecTool) Parameters() map[string]any {
 		},
 		"required": []string{"command"},
 	}
+}
+
+func (t *ExecTool) FormatNotification(args map[string]any) string {
+	if cmd, ok := args["command"].(string); ok {
+		return fmt.Sprintf("🛠️ Exec: `%s`", utils.Truncate(cmd, 500))
+	}
+	return "🛠️ Shell command execution in progress"
 }
 
 func (t *ExecTool) Execute(ctx context.Context, args map[string]any) *ToolResult {

--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -471,6 +471,13 @@ func (t *WebSearchTool) Parameters() map[string]any {
 	}
 }
 
+func (t *WebSearchTool) FormatNotification(args map[string]any) string {
+	if query, ok := args["query"].(string); ok {
+		return fmt.Sprintf("🛠️ Web search: \"%s\"", query)
+	}
+	return "🛠️ Web search in progress"
+}
+
 func (t *WebSearchTool) Execute(ctx context.Context, args map[string]any) *ToolResult {
 	query, ok := args["query"].(string)
 	if !ok {
@@ -651,6 +658,13 @@ func (t *WebFetchTool) Execute(ctx context.Context, args map[string]any) *ToolRe
 		),
 		ForUser: string(resultJSON),
 	}
+}
+
+func (t *WebFetchTool) FormatNotification(args map[string]any) string {
+	if u, ok := args["url"].(string); ok {
+		return fmt.Sprintf("🛠️ Fetching page: \"%s\"", u)
+	}
+	return "🛠️ Fetching web page in progress"
 }
 
 func (t *WebFetchTool) extractText(htmlContent string) string {


### PR DESCRIPTION
## 📝 Description

Introduced an (optional) real-time feedback mechanism to notify users when the agent is actively using a tool (e.g., executing a command or searching the web). This vastly improves the UX by showing that the agent is "thinking" and performing actions, rather than just hanging silently while processing.

**Key implementations:**

* Added a `NotificationFormatter` interface in the `tools` package. The core agent loop now checks if a tool implements this interface via type assertion.
* **Global Toggle:** Added `enable_notifications` boolean under the `tools` configuration (defaults to `false`) so users can silence these intermediate messages if they prefer a cleaner chat.

## 🗣️ Type of Change

* [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
* [x] ✨ New feature (non-breaking change which adds functionality)
* [ ] 📖 Documentation update
* [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation

* [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
* [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
* [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

## 📚 Technical Context (Skip for Docs)

* **Reference URL:** N/A
* **Reasoning:** 

## 🧪 Test Environment

* **Hardware:** PC / Server
* **OS:** Linux / macOS
* **Model/Provider:** OpenAI / Anthropic
* **Channels:** Telegram / CLI

## 📸 Evidence (Optional)

<img width="765" height="481" alt="image" src="https://github.com/user-attachments/assets/dc839fde-aab5-4b69-be8f-444368601584" />

---
**Configuration Example (`config.json`):**
Users can disable this feature globally:

```json
{
  "tools": {
    "enable_notifications": false
  }
}

```

## ☑️ Checklist

* [x] My code/docs follow the style of this project.
* [x] I have performed a self-review of my own changes.
* [ ] I have updated the documentation accordingly.
