### PR TITLE
fix: exclude prompt_cache_key for Gemini API requests

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -115,8 +115,12 @@ func (p *Provider) Chat(
 	// with the same key and reuse prefix KV cache across calls.
 	// The key is typically the agent ID — stable per agent, shared across requests.
 	// See: https://platform.openai.com/docs/guides/prompt-caching
+	// Prompt caching is only supported by OpenAI-native endpoints.
+	// Gemini and other providers reject unknown fields, so skip for non-OpenAI APIs.
 	if cacheKey, ok := options["prompt_cache_key"].(string); ok && cacheKey != "" {
-		requestBody["prompt_cache_key"] = cacheKey
+		if !strings.Contains(p.apiBase, "generativelanguage.googleapis.com") {
+			requestBody["prompt_cache_key"] = cacheKey
+		}
 	}
 
 	jsonData, err := json.Marshal(requestBody)


### PR DESCRIPTION
## Problem

Gemini's OpenAI-compatible endpoint (`generativelanguage.googleapis.com`) rejects unknown fields in the request body. The `prompt_cache_key` field (added in #617) causes a 400 error:

```
Invalid JSON payload received. Unknown name "prompt_cache_key": Cannot find field.
```

## Solution

Only include `prompt_cache_key` in the request body for OpenAI-native endpoints. Skip it when the API base URL contains `generativelanguage.googleapis.com`.

## Testing

- Verified Gemini 2.5 Flash no longer returns 400 errors
- OpenAI endpoints continue to receive `prompt_cache_key` as before