### PR TITLE
fix: inject current date into WebSearchTool description

### DIFF
--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -449,7 +449,7 @@ func (t *WebSearchTool) Name() string {
 }
 
 func (t *WebSearchTool) Description() string {
-	return "Search the web for current information. Returns titles, URLs, and snippets from search results."
+	return fmt.Sprintf("Search the web for current information. Returns titles, URLs, and snippets from search results. Today's date is %s. When constructing queries about recent events, use this date as reference.", time.Now().Format("2006-01-02"))
 }
 
 func (t *WebSearchTool) Parameters() map[string]any {


### PR DESCRIPTION
## Problem

`WebSearchTool.Description()` returned a static string with no date context. When the LLM constructed search queries for time-relative requests (e.g. "yesterday's AI news"), it defaulted to its training-cutoff year instead of the actual current date.

Root cause: while `pkg/agent/context.go` injects today's date into the system prompt, the tool description is evaluated independently at query-construction time — creating an attention gap.

## Solution

Following the suggestion by @nikolasdehor in #754: make `Description()` dynamic by embedding `time.Now().Format("2006-01-02")` via `fmt.Sprintf()`, so the LLM sees the correct date exactly where it decides what query to construct.

```go
func (t *WebSearchTool) Description() string {
    return fmt.Sprintf("Search the web for current information. Returns titles, URLs, and snippets from search results. Today's date is %s. When constructing queries about recent events, use this date as reference.", time.Now().Format("2006-01-02"))
}
```

## Test plan

- [ ] Verify that a query like "show me yesterday's news" produces a search using the correct current year/date, not the model's training cutoff year
- [ ] Confirm existing search functionality is unaffected

Closes #754