### PR TITLE
config: change default dm_scope to per-channel-peer

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -413,3 +413,12 @@ func TestLoadConfig_WebToolsProxy(t *testing.T) {
 		t.Fatalf("Tools.Web.Proxy = %q, want %q", cfg.Tools.Web.Proxy, "http://127.0.0.1:7890")
 	}
 }
+
+// TestDefaultConfig_DMScope verifies the default dm_scope value
+func TestDefaultConfig_DMScope(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Session.DMScope != "per-channel-peer" {
+		t.Errorf("Session.DMScope = %q, want 'per-channel-peer'", cfg.Session.DMScope)
+	}
+}

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -21,7 +21,7 @@ func DefaultConfig() *Config {
 		},
 		Bindings: []AgentBinding{},
 		Session: SessionConfig{
-			DMScope: "main",
+			DMScope: "per-channel-peer",
 		},
 		Channels: ChannelsConfig{
 			WhatsApp: WhatsAppConfig{


### PR DESCRIPTION
## 📝 Description

Change the default value of session.dm_scope from "main" to "per-channel-peer" to provide better conversation isolation by default. This prevents context leakage between different users and channels.
