### PR TITLE
fix(openai_compat): exclude groq from prompt caching

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -154,9 +154,11 @@ func (p *Provider) Chat(
 	// The key is typically the agent ID — stable per agent, shared across requests.
 	// See: https://platform.openai.com/docs/guides/prompt-caching
 	// Prompt caching is only supported by OpenAI-native endpoints.
-	// Gemini and other providers reject unknown fields, so skip for non-OpenAI APIs.
+	// Gemini and Groq reject unknown fields, so skip for non-OpenAI APIs.
 	if cacheKey, ok := options["prompt_cache_key"].(string); ok && cacheKey != "" {
-		if !strings.Contains(p.apiBase, "generativelanguage.googleapis.com") {
+		apiBase := strings.ToLower(p.apiBase)
+		if !strings.Contains(apiBase, "generativelanguage.googleapis.com") &&
+			!strings.Contains(apiBase, "groq.com") {
 			requestBody["prompt_cache_key"] = cacheKey
 		}
 	}


### PR DESCRIPTION
## 📝 Description
We recently added prompt_cache_key for OpenAI-compatible providers. We need to exclude Groq, since it does not support prompt caching.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue
Fix for #748 

## 📚 Technical Context (Skip for Docs)
- **Reasoning:** We should consider refactoring this later, potentially using a mapping to handle prompt caching compatibility.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Fedora 43 (Docker)
- **Model/Provider:** groq/meta-llama/llama-4-scout-17b-16e-instruct


## 📸 Evidence (Optional)
```
❯ docker exec -it picoclaw-gateway  /bin/sh
/ $ picoclaw agent
Warning: deny patterns are disabled. All commands will be allowed.
2026/02/26 21:24:16 [2026-02-26T21:24:16Z] [INFO] agent: Created implicit main agent (no agents.list configured)
2026/02/26 21:24:16 [2026-02-26T21:24:16Z] [INFO] agent: Agent initialized {tools_count=14, skills_total=6, skills_available=6}
🦞 Interactive mode (Ctrl+C to exit)

🦞 You: hi
2026/02/26 21:24:21 [2026-02-26T21:24:21Z] [INFO] agent: Processing message from cli:cron: hi {channel=cli, chat_id=direct, sender_id=cron, session_key=cli:default}
2026/02/26 21:24:21 [2026-02-26T21:24:21Z] [INFO] agent: Routed message {session_key=agent:main:main, matched_by=default, agent_id=main}
2026/02/26 21:24:21 [2026-02-26T21:24:21Z] [INFO] agent: LLM response without tool calls (direct answer) {content_chars=75, agent_id=main, iteration=1}
2026/02/26 21:24:21 [2026-02-26T21:24:21Z] [INFO] agent: Response: Hello! I'm PicoClaw, your helpful AI assistant. How can I assist you today? {session_key=agent:main:main, iterations=1, final_length=75, agent_id=main}

🦞 Hello! I'm PicoClaw, your helpful AI assistant. How can I assist you today?

🦞 You:
```


## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.