### PR TITLE
feat: add streaming support and custom base URL for Anthropic API

### DIFF
--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sipeed/picoclaw/pkg/config"
+	anthropicprovider "github.com/sipeed/picoclaw/pkg/providers/anthropic"
 )
 
 // createClaudeAuthProvider creates a Claude provider using OAuth credentials from auth store.
@@ -167,6 +168,17 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 			return nil, "", err
 		}
 		return provider, modelID, nil
+
+	case "kimi-coding", "kimicoding":
+		// Kimi for Coding uses Anthropic API format
+		apiBase := cfg.APIBase
+		if apiBase == "" {
+			apiBase = "https://api.kimi.com/coding"
+		}
+		if cfg.APIKey == "" {
+			return nil, "", fmt.Errorf("api_key is required for kimi-coding protocol (model: %s)", cfg.Model)
+		}
+		return anthropicprovider.NewProviderWithBaseURL(cfg.APIKey, apiBase), modelID, nil
 
 	default:
 		return nil, "", fmt.Errorf("unknown protocol %q in model %q", protocol, cfg.Model)


### PR DESCRIPTION
## Summary

This PR adds support for custom Anthropic API endpoints and streaming support.

## Changes

- **Anthropic Provider**: Add streaming API support using `Messages.NewStreaming` for better compatibility with various Anthropic-compatible endpoints
- **Factory Provider**: Add support for custom base URL configuration in Anthropic provider
- **New Protocol**: Add `kimi-coding` protocol support that uses Anthropic API format

## Usage

Users can now configure custom Anthropic API endpoints via the `model_list` configuration:

```json
{
  "model_list": [
    {
      "model_name": "custom-anthropic",
      "model": "anthropic/claude-sonnet-4.6",
      "api_key": "sk-...",
      "api_base": "https://custom-api-endpoint.com/v1"
    }
  ]
}
```

## Technical Details

- Streaming is now the default mode for Anthropic provider to ensure compatibility with endpoints that require it
- Non-streaming mode is still available as fallback
- Proper handling of streaming events: message_start, content_block_start, content_block_delta, message_stop, message_delta

## Testing

Tested with custom Anthropic-compatible endpoints.