### PR TITLE
fix(telegram): pass senderID with username to HandleMessage

### DIFF
--- a/pkg/channels/telegram.go
+++ b/pkg/channels/telegram.go
@@ -384,7 +384,7 @@ func (c *TelegramChannel) handleMessage(ctx context.Context, message *telego.Mes
 		"peer_id":    peerID,
 	}
 
-	c.HandleMessage(fmt.Sprintf("%d", user.ID), fmt.Sprintf("%d", chatID), content, mediaPaths, metadata)
+	c.HandleMessage(senderID, fmt.Sprintf("%d", chatID), content, mediaPaths, metadata)
 	return nil
 }
 


### PR DESCRIPTION
## Problem

A regression was introduced in commit 9d5728ec5 (#164) where the Telegram channel handler was calling `HandleMessage()` with only the numeric user ID instead of the full `senderID` that includes the username.

This caused the allowlist check in `base.go:85-87` to fail when using username-based filtering in the `allow_from` configuration, resulting in all messages being silently rejected even from authorized users.

## Example Failure Scenario

With config:
```json
"telegram": {
  "allow_from": ["username123"]
}
```

- The code correctly constructs `senderID = "123456|username123"` on line 219-222
- But line 387 calls `HandleMessage(fmt.Sprintf("%d", user.ID), ...)` passing only `"123456"`
- The allowlist check compares `"123456"` against `"username123"` and rejects the message

## Solution

Changed line 387 in `pkg/channels/telegram.go`:
```go
- c.HandleMessage(fmt.Sprintf("%d", user.ID), fmt.Sprintf("%d", chatID), content, mediaPaths, metadata)
+ c.HandleMessage(senderID, fmt.Sprintf("%d", chatID), content, mediaPaths, metadata)
```

This ensures the correctly formatted senderID (with username) is passed to HandleMessage, restoring support for username-based allowlist filtering.

## Testing

Tested with:
- Telegram bot with `allow_from: ["username"]` configuration
- Verified messages are now properly accepted and bot responds
- Verified existing numeric ID-based filtering still works (handled by `base.go:45-82`)

Fixes username-based allowlist filtering broken since v0.x (commit 9d5728e)