### PR TITLE
fix(agent): invalidate system prompt cache for global/builtin skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,20 @@ PicoClaw stores data in your configured workspace (default: `~/.picoclaw/workspa
 └── USER.md           # User preferences
 ```
 
+### Skill Sources
+
+By default, skills are loaded from:
+
+1. `~/.picoclaw/workspace/skills` (workspace)
+2. `~/.picoclaw/skills` (global)
+3. `<current-working-directory>/skills` (builtin)
+
+For advanced/test setups, you can override the builtin skills root with:
+
+```bash
+export PICOCLAW_BUILTIN_SKILLS=/path/to/skills
+```
+
 ### 🔒 Security Sandbox
 
 PicoClaw runs in a sandboxed environment by default. The agent can only access files and execute commands within the configured workspace.

--- a/README.zh.md
+++ b/README.zh.md
@@ -335,6 +335,20 @@ PicoClaw 将数据存储在您配置的工作区中（默认：`~/.picoclaw/work
 
 ```
 
+### 技能来源 (Skill Sources)
+
+默认情况下，技能会按以下顺序加载：
+
+1. `~/.picoclaw/workspace/skills`（工作区）
+2. `~/.picoclaw/skills`（全局）
+3. `<current-working-directory>/skills`（内置）
+
+在高级/测试场景下，可通过以下环境变量覆盖内置技能目录：
+
+```bash
+export PICOCLAW_BUILTIN_SKILLS=/path/to/skills
+```
+
 ### 心跳 / 周期性任务 (Heartbeat)
 
 PicoClaw 可以自动执行周期性任务。在工作区创建 `HEARTBEAT.md` 文件：

--- a/pkg/skills/loader.go
+++ b/pkg/skills/loader.go
@@ -72,10 +72,11 @@ func (sl *SkillsLoader) SkillRoots() []string {
 	out := make([]string, 0, len(roots))
 
 	for _, root := range roots {
-		if strings.TrimSpace(root) == "" {
+		trimmed := strings.TrimSpace(root)
+		if trimmed == "" {
 			continue
 		}
-		clean := filepath.Clean(root)
+		clean := filepath.Clean(trimmed)
 		if _, ok := seen[clean]; ok {
 			continue
 		}

--- a/pkg/skills/loader_test.go
+++ b/pkg/skills/loader_test.go
@@ -326,3 +326,19 @@ func TestStripFrontmatter(t *testing.T) {
 		})
 	}
 }
+
+func TestSkillRootsTrimsWhitespaceAndDedups(t *testing.T) {
+	tmp := t.TempDir()
+	workspace := filepath.Join(tmp, "workspace")
+	global := filepath.Join(tmp, "global")
+	builtin := filepath.Join(tmp, "builtin")
+
+	sl := NewSkillsLoader(workspace, "  "+global+"  ", "\t"+builtin+"\n")
+	roots := sl.SkillRoots()
+
+	assert.Equal(t, []string{
+		filepath.Join(workspace, "skills"),
+		global,
+		builtin,
+	}, roots)
+}


### PR DESCRIPTION
## Summary
- align system-prompt cache invalidation scope with actual skills summary sources (workspace/global/builtin)
- add `SkillRoots()` in `SkillsLoader` as the single source of truth for tracked skill roots
- add regression tests for global and builtin skill file changes to ensure cached prompt rebuilds correctly

## Root Cause
`BuildSkillsSummary()` reads from workspace/global/builtin skill roots, but cache invalidation only tracked workspace files and `workspace/skills`. This could keep serving stale cached system prompts when global or builtin skills changed.

## Changes
- `pkg/skills/loader.go`
  - add `SkillRoots()` to expose unique effective skill roots in priority order
- `pkg/agent/context.go`
  - track all skill roots in cache baseline (`existedAtCache` + `maxMtime`)
  - check all skill roots for creation/deletion/mtime/content changes in `sourceFilesChangedLocked()`
- `pkg/agent/context_cache_test.go`
  - add `TestGlobalSkillFileContentChange`
  - add `TestBuiltinSkillFileContentChange`

## Test Plan
- [x] `go test ./pkg/agent -run 'Test(GlobalSkillFileContentChange|BuiltinSkillFileContentChange)'`
- [x] `go test ./pkg/agent ./pkg/skills`
- [x] `go test ./...`
