### PR TITLE
fix(discord): 修正discord 渠道检查运行列表逻辑以包含用户名

### DIFF
--- a/pkg/channels/discord.go
+++ b/pkg/channels/discord.go
@@ -175,11 +175,12 @@ func (c *DiscordChannel) handleMessage(s *discordgo.Session, m *discordgo.Messag
 	if m.Author.ID == s.State.User.ID {
 		return
 	}
+	senderID := m.Author.ID + "|" + m.Author.Username
 
 	// Check allowlist first to avoid downloading attachments and transcribing for rejected users
-	if !c.IsAllowed(m.Author.ID) {
+	if !c.IsAllowed(senderID) {
 		logger.DebugCF("discord", "Message rejected by allowlist", map[string]any{
-			"user_id": m.Author.ID,
+			"user_id": senderID,
 		})
 		return
 	}
@@ -202,7 +203,6 @@ func (c *DiscordChannel) handleMessage(s *discordgo.Session, m *discordgo.Messag
 		}
 	}
 
-	senderID := m.Author.ID
 	senderName := m.Author.Username
 	if m.Author.Discriminator != "" && m.Author.Discriminator != "0" {
 		senderName += "#" + m.Author.Discriminator


### PR DESCRIPTION
在检查允许列表时，将用户ID和用户名组合作为唯一标识符，让配置可以通过用户名进行允许

## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:**  MacBookpro m3
- **OS:** Macos
- **Model/Provider:** zhipu glm4.7
- **Channels:**  discord


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [ ] My code/docs follow the style of this project.
- [ ] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.