### PR TITLE
fix: separate ContextWindow from MaxTokens configuration

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -82,6 +82,13 @@ func NewAgentInstance(
 		maxTokens = 8192
 	}
 
+	// ContextWindow defaults to 128K if not specified (most modern models support this)
+	// For models with smaller context, users should configure this explicitly
+	contextWindow := defaults.ContextWindow
+	if contextWindow == 0 {
+		contextWindow = 128000
+	}
+
 	temperature := 0.7
 	if defaults.Temperature != nil {
 		temperature = *defaults.Temperature
@@ -103,7 +110,7 @@ func NewAgentInstance(
 		MaxIterations:  maxIter,
 		MaxTokens:      maxTokens,
 		Temperature:    temperature,
-		ContextWindow:  maxTokens,
+		ContextWindow:  contextWindow,
 		Provider:       provider,
 		Sessions:       sessionsManager,
 		ContextBuilder: contextBuilder,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -177,6 +177,7 @@ type AgentDefaults struct {
 	ImageModel          string   `json:"image_model,omitempty"           env:"PICOCLAW_AGENTS_DEFAULTS_IMAGE_MODEL"`
 	ImageModelFallbacks []string `json:"image_model_fallbacks,omitempty"`
 	MaxTokens           int      `json:"max_tokens"                      env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOKENS"`
+	ContextWindow       int      `json:"context_window"                  env:"PICOCLAW_AGENTS_DEFAULTS_CONTEXT_WINDOW"`
 	Temperature         *float64 `json:"temperature,omitempty"           env:"PICOCLAW_AGENTS_DEFAULTS_TEMPERATURE"`
 	MaxToolIterations   int      `json:"max_tool_iterations"             env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOOL_ITERATIONS"`
 }


### PR DESCRIPTION
## Problem

The current implementation incorrectly sets `ContextWindow` to `MaxTokens` value in `pkg/agent/instance.go`:

```go
ContextWindow:  maxTokens,  // Wrong: maxTokens is output limit, not context window
```

This causes several issues:
1. **GLM-5** with 128K context window was incorrectly limited to 65K
2. Compression threshold was underestimated by ~50%
3. Forced compression dropped 50% of history without preserving summary

## Solution

- Add new `ContextWindow` field to `AgentDefaults` config
- Default to 128K (most modern models support this)
- Users can configure smaller values for models with limited context

## Changes

1. `pkg/config/config.go`: Add `ContextWindow` field to `AgentDefaults`
2. `pkg/agent/instance.go`: Use separate `ContextWindow` value instead of `MaxTokens`

## Configuration Example

```json
{
  "agents": {
    "defaults": {
      "max_tokens": 8192,
      "context_window": 128000
    }
  }
}
```

## Testing

- Code compiles successfully
- Backward compatible: existing configs without `context_window` will use 128K default

## Related

This fixes the context window handling for large-context models like GLM-5, Claude, GPT-4-turbo, etc.