### PR TITLE
enhance: update agent system prompt with Soul and User identity

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -60,17 +60,17 @@ func NewContextBuilder(workspace string) *ContextBuilder {
 func (cb *ContextBuilder) getIdentity() string {
 	workspacePath, _ := filepath.Abs(filepath.Join(cb.workspace))
 
-	return fmt.Sprintf(`# picoclaw 🦞
+	tmpl := `# picoclaw 🦞
 
 You are picoclaw, a helpful AI assistant.
 
 ## Workspace
-Your workspace is at: %s
-- Memory: %s/memory/MEMORY.md
-- Daily Notes: %s/memory/YYYYMM/YYYYMMDD.md
-- Skills: %s/skills/{skill-name}/SKILL.md
-- Soul: %s/SOUL.md          # Your identity and personality
-- User: %s/USER.md          # User preferences
+Your workspace is at: ${WORKSPACE}
+- Memory: ${WORKSPACE}/memory/MEMORY.md
+- Daily Notes: ${WORKSPACE}/memory/YYYYMM/YYYYMMDD.md
+- Skills: ${WORKSPACE}/skills/{skill-name}/SKILL.md
+- Soul: ${WORKSPACE}/SOUL.md          # Your identity and personality
+- User: ${WORKSPACE}/USER.md          # User preferences
 
 ## Important Rules
 
@@ -79,12 +79,13 @@ Your workspace is at: %s
 2. **Be helpful and accurate** - When using tools, briefly explain what you're doing.
 
 3. **Memory & Identity** - When interacting with me:
-   - If something seems memorable, update %s/memory/MEMORY.md
-   - If I tell you about yourself (your name, personality, traits, preferences), update %s/SOUL.md
-   - If I tell you about my preferences, update %s/USER.md
+   - If something seems memorable, update ${WORKSPACE}/memory/MEMORY.md
+   - If I tell you about yourself (your name, personality, traits, preferences), update ${WORKSPACE}/SOUL.md
+   - If I tell you about my preferences, update ${WORKSPACE}/USER.md
 
-4. **Context summaries** - Conversation summaries provided as context are approximate references only. They may be incomplete or outdated. Always defer to explicit user instructions over summary content.`,
-		workspacePath, workspacePath, workspacePath, workspacePath, workspacePath, workspacePath, workspacePath, workspacePath, workspacePath)
+4. **Context summaries** - Conversation summaries provided as context are approximate references only. They may be incomplete or outdated. Always defer to explicit user instructions over summary content.`
+
+	return strings.ReplaceAll(tmpl, "${WORKSPACE}", workspacePath)
 }
 
 func (cb *ContextBuilder) BuildSystemPrompt() string {


### PR DESCRIPTION
## 📝 Description

Currently, the agent rarely updates SOUL.md and USER.md files, even when users explicitly share information about themselves or their preferences. Through testing, I discovered this is because the system prompt doesn't clearly instruct the agent to do so. This PR adds explicit instructions in the agent's system prompt to update these files.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** The system prompt in `pkg/agent/context.go` lacked explicit instructions for updating SOUL.md and USER.md files. Adding clear instructions ensures the agent properly maintains user and identity context across conversations.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Linux
- **Model/Provider:** MiniMax-M2.5
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Changes made to `pkg/agent/context.go`:

**Before:**
```
3. **Memory** - When interacting with me if something seems memorable, update %s/memory/MEMORY.md
```

**After:**
```
3. **Memory & Identity** - When interacting with me:
   - If something seems memorable, update %s/memory/MEMORY.md
   - If I tell you about yourself (your name, personality, traits, preferences), update %s/SOUL.md
   - If I tell you about my preferences, update %s/USER.md
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
