### PR TITLE
fix(pkg/bus):return correct boolean signal when channel is closed

### DIFF
--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -32,8 +32,8 @@ func (mb *MessageBus) PublishInbound(msg InboundMessage) {
 
 func (mb *MessageBus) ConsumeInbound(ctx context.Context) (InboundMessage, bool) {
 	select {
-	case msg := <-mb.inbound:
-		return msg, true
+	case msg, ok := <-mb.inbound:
+		return msg, ok
 	case <-ctx.Done():
 		return InboundMessage{}, false
 	}
@@ -50,8 +50,8 @@ func (mb *MessageBus) PublishOutbound(msg OutboundMessage) {
 
 func (mb *MessageBus) SubscribeOutbound(ctx context.Context) (OutboundMessage, bool) {
 	select {
-	case msg := <-mb.outbound:
-		return msg, true
+	case msg, ok := <-mb.outbound:
+		return msg, ok
 	case <-ctx.Done():
 		return OutboundMessage{}, false
 	}


### PR DESCRIPTION
## 📝 Description

Previously when channel is closed, picoclaw still returns true instead of false. It would not skip the empty message in loop
https://github.com/sipeed/picoclaw/blob/29d4019e628b57f50c15116c4597191a28ac2433/pkg/agent/loop.go#L165-L168
This PR fix the tiny issue.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Ubuntu 22.04
- **Model/Provider:** N/A
- **Channels:** N/A


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.