### PR TITLE
fix: error check on state

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -41,7 +41,7 @@ func NewManager(workspace string) *Manager {
 
 	// Create state directory if it doesn't exist
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
-		log.Printf("[WARN] state: failed to create state directory: %v", err)
+		log.Fatalf("[FATAL] state: failed to create state directory: %v", err)
 	}
 
 	sm := &Manager{

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -2,8 +2,10 @@ package state
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -213,4 +215,40 @@ func TestNewManager_EmptyWorkspace(t *testing.T) {
 	if !sm.GetTimestamp().IsZero() {
 		t.Error("Expected zero timestamp for new state")
 	}
+}
+
+func TestNewManager_MkdirFailureCrashes(t *testing.T) {
+	// Since log.Fatalf calls os.Exit(1), we cannot test it normally
+	// Otherwise, the test suite would stop altogether.
+	// We use the standard pattern of Go: rerun this test in a subprocess.
+	if os.Getenv("BE_CRASHER") == "1" {
+		tmpDir := os.Getenv("CRASH_DIR")
+
+		statePath := filepath.Join(tmpDir, "state")
+		if err := os.WriteFile(statePath, []byte("I'm a file, not a folder"), 0o644); err != nil {
+			fmt.Printf("setup failed: %v", err)
+			os.Exit(0)
+		}
+
+		NewManager(tmpDir)
+		os.Exit(0)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "state-crash-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestNewManager_MkdirFailureCrashes")
+	cmd.Env = append(os.Environ(), "BE_CRASHER=1", "CRASH_DIR="+tmpDir)
+
+	err = cmd.Run()
+
+	var e *exec.ExitError
+	if errors.As(err, &e) && !e.Success() {
+		return
+	}
+
+	t.Fatalf("The process ended without error, a crash was expected via os.Exit(1). Err: %v", err)
 }


### PR DESCRIPTION
## 📝 Description

Added proper error handling and logging for filesystem operations in the state manager (`pkg/state/state.go`). 

Previously, directory creation (`os.MkdirAll`), state saving during migration (`sm.saveAtomic`), and state loading (`sm.load`) were executed without checking for returned errors. This PR wraps these calls in error checks and adds `[WARN]` logs to ensure that any filesystem issues (like permission errors or disk space issues) are properly surfaced instead of failing silently.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** Ignoring I/O errors during state initialization, migration, or loading can lead to inconsistent application states or silent data loss. Adding `if err := ...; err != nil` checks ensures operators are immediately notified of underlying environment issues via logs without necessarily crashing the application.

## 🧪 Test Environment
- **Hardware:** PC (Local testing)
- **OS:** Any supported OS
- **Model/Provider:** N/A
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

*(Expected log output if a failure occurs)*
`[WARN] state: failed to create state directory: permission denied`

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.