### PR TITLE
fix(config): keep empty agents.defaults.model in saved config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -172,7 +172,7 @@ type AgentDefaults struct {
 	RestrictToWorkspace bool     `json:"restrict_to_workspace"           env:"PICOCLAW_AGENTS_DEFAULTS_RESTRICT_TO_WORKSPACE"`
 	Provider            string   `json:"provider"                        env:"PICOCLAW_AGENTS_DEFAULTS_PROVIDER"`
 	ModelName           string   `json:"model_name,omitempty"            env:"PICOCLAW_AGENTS_DEFAULTS_MODEL_NAME"`
-	Model               string   `json:"model,omitempty"                 env:"PICOCLAW_AGENTS_DEFAULTS_MODEL"` // Deprecated: use model_name instead
+	Model               string   `json:"model"                           env:"PICOCLAW_AGENTS_DEFAULTS_MODEL"` // Deprecated: use model_name instead
 	ModelFallbacks      []string `json:"model_fallbacks,omitempty"`
 	ImageModel          string   `json:"image_model,omitempty"           env:"PICOCLAW_AGENTS_DEFAULTS_IMAGE_MODEL"`
 	ImageModelFallbacks []string `json:"image_model_fallbacks,omitempty"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -321,6 +322,25 @@ func TestSaveConfig_FilePermissions(t *testing.T) {
 	perm := info.Mode().Perm()
 	if perm != 0o600 {
 		t.Errorf("config file has permission %04o, want 0600", perm)
+	}
+}
+
+func TestSaveConfig_IncludesEmptyLegacyModelField(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config.json")
+
+	cfg := DefaultConfig()
+	if err := SaveConfig(path, cfg); err != nil {
+		t.Fatalf("SaveConfig failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"model": ""`) {
+		t.Fatalf("saved config should include empty legacy model field, got: %s", string(data))
 	}
 }
 


### PR DESCRIPTION
  ## 📑 Description

  Fix onboard-generated `config.json` to always include `agents.defaults.model` even when empty (`"model": ""`).

  Previously, `AgentDefaults.Model` used `omitempty`, so `picoclaw onboard` wrote config files without the `model` field
  when its value was empty string. This PR removes `omitempty` for this legacy field to preserve explicit config shape
  and backward-compatible expectations.

  ## 🛠️ Type of Change
  - [x] 🐶 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 📝 Documentation update
  - [ ] ♻️ Code refactoring (no functional changes, no api changes)

  ## 🤖 AI Code Generation
  - [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
  - [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
  - [ ] 👆‍💻 Mostly Human-written (Human lead, AI assisted or none)

  ## 🔆 Related Issue

  N/A

  ## 📎 Technical Context (Skip for Docs)
  - **Reference URL:** N/A
  - **Reasoning:** `agents.defaults.model` is a deprecated but still supported field. `onboard` should emit a stable and
  explicit baseline config (`"model": ""`) instead of omitting it due to `omitempty`.

  ## 🧪 Test Environment
  - **Hardware:** PC
  - **OS:** Windows 11
  - **Model/Provider:** N/A (config serialization change)
  - **Channels:** N/A

  ## 📳 Evidence (Optional)
  <details>
  <summary>Click to view Logs/Screenshots</summary>

  - `go test ./pkg/config` ✅
  - `go test ./cmd/picoclaw/internal/onboard` ✅

  </details>

  ## ☑️ Checklist
  - [x] My code/docs follow the style of this project.
  - [x] I have performed a self-review of my own changes.
  - [ ] I have updated the documentation accordingly.