### PR TITLE
fix: propagate error when no channels are enabled during startup

### DIFF
--- a/cmd/picoclaw/internal/gateway/helpers.go
+++ b/cmd/picoclaw/internal/gateway/helpers.go
@@ -175,6 +175,7 @@ func gatewayCmd(debug bool) error {
 
 	if err := channelManager.StartAll(ctx); err != nil {
 		fmt.Printf("Error starting channels: %v\n", err)
+		return err
 	}
 
 	fmt.Printf("✓ Health endpoints available at http://%s:%d/health and /ready\n", cfg.Gateway.Host, cfg.Gateway.Port)

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -313,7 +313,7 @@ func (m *Manager) StartAll(ctx context.Context) error {
 
 	if len(m.channels) == 0 {
 		logger.WarnC("channels", "No channels enabled")
-		return nil
+		return errors.New("no channels enabled")
 	}
 
 	logger.InfoC("channels", "Starting all channels")


### PR DESCRIPTION
## Description

This PR fixes an issue where the gateway process would continue running even when no channels are enabled during startup. It correctly propagates the error from `channelManager.StartAll()` in `pkg/channels/manager.go` so that the `gatewayCmd` caller in `cmd/picoclaw/internal/gateway/helpers.go` catches it and halts execution gracefully.

## Type of Change

- [x] Bug fix

## 🤖 AI Code Generation

- [x] 👨‍💻 Mostly Human-written

## Related Issue

N/A

## Technical Context

Before this change, if no channels were enabled, `manager.go` simply warned and returned `nil`. The startup process expected a proper error to determine if it should fail. This updates `StartAll()` to return a non-nil error, and the wrapper correctly handles the returned error, printing the message and exiting.

## Test Environment

- OS: macOS
- Go: 1.25

## Evidence

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have read and understand the AI-Assisted Contributions policy
