### PR TITLE
Fix Docker first-run bootstrap and local compose image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ cmd/**/workspace
 .picoclaw/
 config.json
 sessions/
+docker/data/
 build/
 
 # Coverage

--- a/README.fr.md
+++ b/README.fr.md
@@ -190,17 +190,17 @@ docker compose -f docker/docker-compose.yml --profile gateway down
 
 ```bash
 # Poser une question
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent -m "Combien font 2+2 ?"
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent -m "Combien font 2+2 ?"
 
 # Mode interactif
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent
 ```
 
 ### Mettre à jour
 
 ```bash
-docker compose -f docker/docker-compose.yml pull
-docker compose -f docker/docker-compose.yml --profile gateway up -d
+git pull
+docker compose -f docker/docker-compose.yml --profile gateway up --build -d
 ```
 
 ### 🚀 Démarrage Rapide

--- a/README.ja.md
+++ b/README.ja.md
@@ -152,17 +152,17 @@ docker compose -f docker/docker-compose.yml --profile gateway down
 
 ```bash
 # 質問を投げる
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent -m "What is 2+2?"
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent -m "What is 2+2?"
 
 # インタラクティブモード
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent
 ```
 
 ### アップデート
 
 ```bash
-docker compose -f docker/docker-compose.yml pull
-docker compose -f docker/docker-compose.yml --profile gateway up -d
+git pull
+docker compose -f docker/docker-compose.yml --profile gateway up --build -d
 ```
 
 ### 🚀 クイックスタート（ネイティブ）

--- a/README.md
+++ b/README.md
@@ -198,17 +198,17 @@ docker compose -f docker/docker-compose.yml --profile gateway down
 
 ```bash
 # Ask a question
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent -m "What is 2+2?"
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent -m "What is 2+2?"
 
 # Interactive mode
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent
 ```
 
 ### Update
 
 ```bash
-docker compose -f docker/docker-compose.yml pull
-docker compose -f docker/docker-compose.yml --profile gateway up -d
+git pull
+docker compose -f docker/docker-compose.yml --profile gateway up --build -d
 ```
 
 ### 🚀 Quick Start

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -191,17 +191,17 @@ docker compose -f docker/docker-compose.yml --profile gateway down
 
 ```bash
 # Fazer uma pergunta
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent -m "Quanto e 2+2?"
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent -m "Quanto e 2+2?"
 
 # Modo interativo
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent
 ```
 
 ### Atualizar
 
 ```bash
-docker compose -f docker/docker-compose.yml pull
-docker compose -f docker/docker-compose.yml --profile gateway up -d
+git pull
+docker compose -f docker/docker-compose.yml --profile gateway up --build -d
 ```
 
 ### 🚀 Início Rápido

--- a/README.vi.md
+++ b/README.vi.md
@@ -171,17 +171,17 @@ docker compose -f docker/docker-compose.yml --profile gateway down
 
 ```bash
 # Đặt câu hỏi
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent -m "2+2 bằng mấy?"
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent -m "2+2 bằng mấy?"
 
 # Chế độ tương tác
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent
 ```
 
 ### Cập nhật
 
 ```bash
-docker compose -f docker/docker-compose.yml pull
-docker compose -f docker/docker-compose.yml --profile gateway up -d
+git pull
+docker compose -f docker/docker-compose.yml --profile gateway up --build -d
 ```
 
 ### 🚀 Bắt đầu nhanh

--- a/README.zh.md
+++ b/README.zh.md
@@ -192,17 +192,17 @@ docker compose -f docker/docker-compose.yml --profile gateway down
 
 ```bash
 # 提问
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent -m "2+2 等于几？"
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent -m "2+2 等于几？"
 
 # 交互模式
-docker compose -f docker/docker-compose.yml run --rm picoclaw-agent
+docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent
 ```
 
 ### 更新镜像
 
 ```bash
-docker compose -f docker/docker-compose.yml pull
-docker compose -f docker/docker-compose.yml --profile gateway up -d
+git pull
+docker compose -f docker/docker-compose.yml --profile gateway up --build -d
 ```
 
 ### 🚀 快速开始

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,20 +24,23 @@ RUN apk add --no-cache ca-certificates tzdata curl
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -q --spider http://localhost:18790/health || exit 1
+  CMD curl -fsS http://localhost:18790/health >/dev/null || exit 1
 
 # Copy binary
 COPY --from=builder /src/build/picoclaw /usr/local/bin/picoclaw
+COPY docker/entrypoint.sh /entrypoint.sh
 
 # Create non-root user and group
 RUN addgroup -g 1000 picoclaw && \
-    adduser -D -u 1000 -G picoclaw picoclaw
+    adduser -D -u 1000 -h /home/picoclaw -G picoclaw picoclaw && \
+    mkdir -p /home/picoclaw/.picoclaw && \
+    chown -R picoclaw:picoclaw /home/picoclaw && \
+    chmod +x /entrypoint.sh
+
+ENV HOME=/home/picoclaw
 
 # Switch to non-root user
 USER picoclaw
 
-# Run onboard to create initial directories and config
-RUN /usr/local/bin/picoclaw onboard
-
-ENTRYPOINT ["picoclaw"]
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["gateway"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,29 @@
 services:
   # ─────────────────────────────────────────────
+  # PicoClaw Init (one-shot bootstrap)
+  #   docker compose -f docker/docker-compose.yml --profile init run --rm picoclaw-init
+  # ─────────────────────────────────────────────
+  picoclaw-init:
+    image: picoclaw-local:dev
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    container_name: picoclaw-init
+    profiles:
+      - init
+    volumes:
+      - ./data:/home/picoclaw/.picoclaw
+    command: ["onboard"]
+
+  # ─────────────────────────────────────────────
   # PicoClaw Agent (one-shot query)
-  #   docker compose -f docker/docker-compose.yml run --rm picoclaw-agent -m "Hello"
+  #   docker compose -f docker/docker-compose.yml --profile agent run --rm picoclaw-agent -m "Hello"
   # ─────────────────────────────────────────────
   picoclaw-agent:
-    image: docker.io/sipeed/picoclaw:latest
+    image: picoclaw-local:dev
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     container_name: picoclaw-agent
     profiles:
       - agent
@@ -12,17 +31,20 @@ services:
     #extra_hosts:
     #  - "host.docker.internal:host-gateway"
     volumes:
-      - ./data:/root/.picoclaw
-    entrypoint: ["picoclaw", "agent"]
+      - ./data:/home/picoclaw/.picoclaw
+    entrypoint: ["/entrypoint.sh", "agent"]
     stdin_open: true
     tty: true
 
   # ─────────────────────────────────────────────
   # PicoClaw Gateway (Long-running Bot)
-  #   docker compose -f docker/docker-compose.yml up picoclaw-gateway
+  #   docker compose -f docker/docker-compose.yml --profile gateway up picoclaw-gateway
   # ─────────────────────────────────────────────
   picoclaw-gateway:
-    image: docker.io/sipeed/picoclaw:latest
+    image: picoclaw-local:dev
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     container_name: picoclaw-gateway
     restart: on-failure
     profiles:
@@ -31,4 +53,4 @@ services:
     #extra_hosts:
     #  - "host.docker.internal:host-gateway"
     volumes:
-      - ./data:/root/.picoclaw
+      - ./data:/home/picoclaw/.picoclaw

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,15 +1,22 @@
 #!/bin/sh
 set -e
 
-# First-run: neither config nor workspace exists.
-# If config.json is already mounted but workspace is missing we skip onboard to
-# avoid the interactive "Overwrite? (y/n)" prompt hanging in a non-TTY container.
-if [ ! -d "${HOME}/.picoclaw/workspace" ] && [ ! -f "${HOME}/.picoclaw/config.json" ]; then
-    picoclaw onboard
-    echo ""
-    echo "First-run setup complete."
-    echo "Edit ${HOME}/.picoclaw/config.json (add your API key, etc.) then restart the container."
-    exit 0
+if [ "$#" -eq 0 ]; then
+    set -- gateway
 fi
 
-exec picoclaw gateway "$@"
+# First-run bootstrap for non-interactive Docker execution.
+# We key off config.json because `picoclaw onboard` only prompts when the config
+# already exists. This also repairs partial states where the workspace exists
+# but config.json was never created.
+if [ "$1" = "gateway" ] || [ "$1" = "agent" ]; then
+    if [ ! -f "${HOME}/.picoclaw/config.json" ]; then
+        picoclaw onboard
+        echo ""
+        echo "First-run setup complete."
+        echo "Edit ${HOME}/.picoclaw/config.json (add your API key, etc.) then restart the container."
+        exit 0
+    fi
+fi
+
+exec picoclaw "$@"


### PR DESCRIPTION
## Summary
- switch Docker Compose services from the stale published image to the local project build
- move first-run onboarding from image build time to container startup so mounted volumes get initialized correctly
- fix Docker docs and healthcheck behavior to match the local image workflow

## Problem
The Docker setup was still pointing at , which meant Compose was not using the local Dockerfile changes. The Dockerfile also ran  during image build, so the first container start did not create  for the mounted volume as documented.

## Changes
- add  and run onboarding at container startup when  is missing
- set the runtime home directory to  and mount Docker data there
- build  from the repo for the init/agent/gateway services
- keep  working by pinning the agent entrypoint
- replace the broken  healthcheck with 
- update README Docker commands, including the local rebuild flow and agent profile usage
- ignore generated  bootstrap output

## Verification
- ran 
- confirmed the container printed  and exited with code 0
- confirmed  and the default workspace tree were created on first run