### PR TITLE
build: add armv6 support to goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,7 @@ builds:
       - loong64
       - arm
     goarm:
+      - "6"
       - "7"
     main: ./cmd/picoclaw
     ignore:
@@ -59,6 +60,7 @@ builds:
       - loong64
       - arm
     goarm:
+      - "6"
       - "7"
     main: ./cmd/picoclaw-launcher
     ignore:


### PR DESCRIPTION
## 📝 Description

Add GOARM=6 build targets for both `picoclaw` and `picoclaw-launcher` in GoReleaser config, to support older ARM devices like Raspberry Pi Zero/1.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** The existing GoReleaser config only builds armv7 targets. Adding armv6 extends support to older ARM SoCs (ARMv6 instruction set), such as Raspberry Pi Zero, Pi 1, and similar low-cost boards that align with PicoClaw's lightweight design goals.

## 🧪 Test Environment
- **Hardware:** MacBook (Apple Silicon)
- **OS:** macOS
- **Model/Provider:** N/A (build config change only)
- **Channels:** N/A

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.