### PR TITLE
fix(pkg/channles):fix the resource leak for slack.go

### DIFF
--- a/pkg/channels/slack.go
+++ b/pkg/channels/slack.go
@@ -257,8 +257,9 @@ func (c *SlackChannel) handleMessageEvent(ev *slackevents.MessageEvent) {
 
 			if utils.IsAudioFile(file.Name, file.Mimetype) && c.transcriber != nil && c.transcriber.IsAvailable() {
 				ctx, cancel := context.WithTimeout(c.ctx, 30*time.Second)
-				defer cancel()
 				result, err := c.transcriber.Transcribe(ctx, localPath)
+				// Release context resources immediately to avoid leaks in for loop
+				cancel()
 
 				if err != nil {
 					logger.ErrorCF("slack", "Voice transcription failed", map[string]any{"error": err.Error()})


### PR DESCRIPTION
## 📝 Description
Cancel the context immediately after `result, err := c.transcriber.Transcribe(ctx, localPath)` to avoid resource leak

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC--> PC
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 --> Ubuntu 22.04
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 --> N/A
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... --> Slack


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.