### PR TITLE
feat: add configurable timeout for exec tool

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -224,6 +224,7 @@
       "exec_timeout_minutes": 5
     },
     "exec": {
+      "timeout_seconds": 0,
       "enable_deny_patterns": false,
       "custom_deny_patterns": []
     },

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -466,6 +466,7 @@ type CronToolsConfig struct {
 }
 
 type ExecConfig struct {
+	TimeoutSeconds     int      `json:"timeout_seconds" env:"PICOCLAW_TOOLS_EXEC_TIMEOUT_SECONDS"` // 0 means use default (60s)
 	EnableDenyPatterns bool     `json:"enable_deny_patterns" env:"PICOCLAW_TOOLS_EXEC_ENABLE_DENY_PATTERNS"`
 	CustomDenyPatterns []string `json:"custom_deny_patterns" env:"PICOCLAW_TOOLS_EXEC_CUSTOM_DENY_PATTERNS"`
 }

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -75,6 +75,7 @@ func NewExecTool(workingDir string, restrict bool) *ExecTool {
 
 func NewExecToolWithConfig(workingDir string, restrict bool, config *config.Config) *ExecTool {
 	denyPatterns := make([]*regexp.Regexp, 0)
+	timeout := 60 * time.Second // default timeout
 
 	if config != nil {
 		execConfig := config.Tools.Exec
@@ -96,13 +97,18 @@ func NewExecToolWithConfig(workingDir string, restrict bool, config *config.Conf
 			// If deny patterns are disabled, we won't add any patterns, allowing all commands.
 			fmt.Println("Warning: deny patterns are disabled. All commands will be allowed.")
 		}
+
+		// Apply configured timeout if set (0 means use default)
+		if execConfig.TimeoutSeconds > 0 {
+			timeout = time.Duration(execConfig.TimeoutSeconds) * time.Second
+		}
 	} else {
 		denyPatterns = append(denyPatterns, defaultDenyPatterns...)
 	}
 
 	return &ExecTool{
 		workingDir:          workingDir,
-		timeout:             60 * time.Second,
+		timeout:             timeout,
 		denyPatterns:        denyPatterns,
 		allowPatterns:       nil,
 		restrictToWorkspace: restrict,


### PR DESCRIPTION
## 概述

为 `exec` 工具添加可配置的超时时间，解决长时间运行命令被意外终止的问题。

## 背景

当前 `exec` 工具的超时时间硬编码为 60 秒，无法根据实际需求调整。某些场景下（如大文件处理、长时间编译等）可能需要更长的执行时间。

## 改动内容

### 1. 配置项新增 (`pkg/config/config.go`)

```go
type ExecConfig struct {
    TimeoutSeconds     int      `json:"timeout_seconds" env:"PICOCLAW_TOOLS_EXEC_TIMEOUT_SECONDS"` // 0 means use default (60s)
    // ...
}
```

### 2. 超时逻辑实现 (`pkg/tools/shell.go`)

- 默认超时保持 60 秒不变
- 当配置 `timeout_seconds > 0` 时使用配置值
- 配置为 0 或未配置时使用默认值

### 3. 配置示例更新 (`config/config.example.json`)

新增配置项示例，方便用户参考。

## 使用方式

### 方式一：配置文件

```json
{
  "tools": {
    "exec": {
      "timeout_seconds": 120
    }
  }
}
```

### 方式二：环境变量

```bash
export PICOCLAW_TOOLS_EXEC_TIMEOUT_SECONDS=120
```

## 文件变更

| 文件 | 新增 | 删除 |
|------|------|------|
| `config/config.example.json` | 1 | 0 |
| `pkg/config/config.go` | 1 | 0 |
| `pkg/tools/shell.go` | 7 | 1 |

**总计**: +9 行, -1 行

## 兼容性

- ✅ 完全向后兼容
- ✅ 默认行为不变（60 秒超时）
- ✅ 可选配置，不影响现有用户