### PR TITLE
feat(feishu): add inbound image message support

### DIFF
--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -344,8 +344,8 @@ func (c *FeishuChannel) downloadImage(ctx context.Context, messageID, imageKey s
 	}
 
 	mediaDir := filepath.Join(os.TempDir(), "picoclaw_media")
-	if err := os.MkdirAll(mediaDir, 0o700); err != nil {
-		return "", fmt.Errorf("create media dir: %w", err)
+	if mkErr := os.MkdirAll(mediaDir, 0o700); mkErr != nil {
+		return "", fmt.Errorf("create media dir: %w", mkErr)
 	}
 
 	localPath := filepath.Join(mediaDir, uuid.New().String()[:8]+"_feishu_image")

--- a/pkg/channels/feishu/feishu_64_test.go
+++ b/pkg/channels/feishu/feishu_64_test.go
@@ -8,8 +8,6 @@ import (
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 )
 
-func strPtr(s string) *string { return &s }
-
 func TestExtractFeishuImageKey(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Description

Add inbound image message support for the Feishu channel. When users send images (or images with text) via Feishu, the channel now downloads and stores them as `media://` refs for the vision pipeline to process.

**Depends on:** #1020 (vision pipeline — resolves `media://` refs to base64 data URLs for the LLM)

### Changes

**`pkg/channels/feishu/feishu_64.go`:**
- **Pure image messages** (`MsgTypeImage`): extract `image_key` from `{"image_key":"..."}` content, download via MessageResource API
- **Rich text post messages** (`MsgTypePost`): parse `{"content":[[{"tag":"img","image_key":"..."}]]}` format to extract all embedded images
- **`downloadImage()`**: uses `MessageResource.Get(messageID, fileKey, type="image")` — the correct API for downloading user-sent images (`Image.Get` only works for bot-uploaded images)
- **No hardcoded extensions**: filenames use `image_key` instead of `.jpg` — MIME detection is handled downstream by `h2non/filetype` magic bytes
- **MediaStore integration**: downloaded images stored via `store.Store()` → `media://` ref → passed to agent via `HandleMessage()`

**`pkg/channels/feishu/feishu_64_test.go`** (new file):
- `extractFeishuImageKey` tests (valid key, empty, invalid JSON, missing field)
- `extractFeishuMessageContent` tests (text, image, nil message)

### Data flow

```
Feishu image/post message
  → handleMessageReceive() detects MsgTypeImage or MsgTypePost
  → extractFeishuImageKey() / extractFeishuPostImageKeys()
  → downloadImage() via MessageResource.Get API
  → MediaStore.Store() → media://uuid ref
  → HandleMessage(..., mediaPaths, ...) → InboundMessage.Media
  → (vision pipeline resolves to base64 for LLM)
```

### E2E verification

Tested on Radxa Cubie A7A (arm64) with Feishu channel + Dashscope LLM (kimi-k2.5). Sent image via Feishu, LLM correctly identified image content.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## AI Code Generation
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## Test Environment
- **Hardware:** Radxa Cubie A7A (arm64, 4GB RAM)
- **OS:** Debian 11 (bullseye)
- **Model/Provider:** Dashscope (kimi-k2.5, vision-capable)
- **Channel:** Feishu (WebSocket mode)

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own changes
- [x] Backward compatible — non-image messages unaffected
- [x] All existing tests pass (`make test`)