### PR TITLE
fix(provider): map 'free' model to openrouter/auto for OpenRouter free tier

### DIFF
--- a/pkg/providers/factory.go
+++ b/pkg/providers/factory.go
@@ -101,6 +101,10 @@ func resolveProviderSelection(cfg *config.Config) (providerSelection, error) {
 				} else {
 					sel.apiBase = "https://openrouter.ai/api/v1"
 				}
+				// Map "free" model alias to openrouter/auto for free tier access
+				if model == "free" {
+					sel.model = "openrouter/auto"
+				}
 			}
 		case "zhipu", "glm":
 			if cfg.Providers.Zhipu.APIKey != "" {
@@ -303,6 +307,10 @@ func resolveProviderSelection(cfg *config.Config) (providerSelection, error) {
 					sel.apiBase = cfg.Providers.OpenRouter.APIBase
 				} else {
 					sel.apiBase = "https://openrouter.ai/api/v1"
+				}
+				// Map "free" model alias to openrouter/auto for free tier access
+				if model == "free" {
+					sel.model = "openrouter/auto"
 				}
 			} else {
 				return providerSelection{}, fmt.Errorf("no API key configured for model: %s", model)


### PR DESCRIPTION
## Summary

- Fix issue #901: Users can now use `model: "free"` with OpenRouter provider
- The "free" alias is automatically mapped to "openrouter/auto" which selects the best available free model

## Description

When using OpenRouter with `model: "free"`, the API was returning an error:
```
"free is not a valid model ID"
```

This fix adds model alias mapping in `pkg/providers/factory.go` - when the model is set to "free", it's automatically converted to "openrouter/auto" which is the correct identifier for OpenRouter's free tier.

Changes made in two locations:
1. Explicit `openrouter` provider case (lines 95-108)
2. Default fallback case when OpenRouter is inferred (lines 302-314)

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor

## 🤖 AI Code Generation

- [x] 🤖 Fully AI-generated - AI wrote the code; contributor reviewed and validated it
- [ ] 🛠️ Mostly AI-generated
- [ ] 👨‍💻 Mostly Human-written

## Related Issue

Closes #901

## Technical Context

- OpenRouter requires specific model identifiers like "openrouter/auto" or actual model names
- "free" is an alias that should map to "openrouter/auto"
- Similar pattern used for deepseek model defaults (lines 171-173)

## Test Environment

- Go 1.25+
- Tested with: `go test -run TestResolveProviderSelection ./pkg/providers/`
- All provider selection tests pass