### PR TITLE
Fix: calling URLs with curl

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -75,6 +77,9 @@ var (
 
 	// absolutePathPattern matches absolute file paths in commands (Unix and Windows).
 	absolutePathPattern = regexp.MustCompile(`[A-Za-z]:\\[^\\\"']+|/[^\s\"']+`)
+
+	// split command in command + options/flags + arguments
+	splitPattern = regexp.MustCompile(`("[^"]*"|'[^']*'|[\S]+)+`)
 )
 
 func NewExecTool(workingDir string, restrict bool) (*ExecTool, error) {
@@ -286,30 +291,48 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 	}
 
 	if t.restrictToWorkspace {
-		if strings.Contains(cmd, "..\\") || strings.Contains(cmd, "../") {
-			return "Command blocked by safety guard (path traversal detected)"
-		}
 
 		cwdPath, err := filepath.Abs(cwd)
 		if err != nil {
-			return ""
+			cwdPath = ""
 		}
 
-		matches := absolutePathPattern.FindAllString(cmd, -1)
-
-		for _, raw := range matches {
-			p, err := filepath.Abs(raw)
+		parts := splitPattern.FindAllString(cmd, -1)
+		for _, part := range parts {
+			unquoted, err := strconv.Unquote(part)
 			if err != nil {
+				unquoted = part
+			}
+
+			u, err := url.ParseRequestURI(unquoted)
+			if err == nil && u.Scheme != "" && u.Host != "" {
 				continue
 			}
 
-			rel, err := filepath.Rel(cwdPath, p)
-			if err != nil {
+			if strings.Contains(part, "..\\") || strings.Contains(part, "../") {
+				return "Command blocked by safety guard (path traversal detected)"
+			}
+
+			if cwdPath == "" {
 				continue
 			}
 
-			if strings.HasPrefix(rel, "..") {
-				return "Command blocked by safety guard (path outside working dir)"
+			matches := absolutePathPattern.FindAllString(part, -1)
+
+			for _, raw := range matches {
+				p, err := filepath.Abs(raw)
+				if err != nil {
+					continue
+				}
+
+				rel, err := filepath.Rel(cwdPath, p)
+				if err != nil {
+					continue
+				}
+
+				if strings.HasPrefix(rel, "..") {
+					return "Command blocked by safety guard (path outside working dir)"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Calling URLs via curl results in the error: “Command blocked by safety guard (path outside working dir)”. This commit fixes the problem.

My changes to guardCommand ensure that the command is split into its individual parts (command + options/flags + arguments) and that each part is checked individually. In addition, web URLs are excluded from the check.

## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [X] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [X] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** MacBook Pro M3
- **OS:**macOS
- **Model/Provider:** Qwen3.5
- **Channels:** Discord

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [X] My code/docs follow the style of this project.
- [X] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.