### PR TITLE
fix: set ModelName in legacy migration when user specifies provider+model (#958)

### DIFF
--- a/pkg/config/migration.go
+++ b/pkg/config/migration.go
@@ -385,6 +385,7 @@ func ConvertProvidersToModelList(cfg *Config) []ModelConfig {
 		// Check if this is the user's configured provider
 		if slices.Contains(m.providerNames, userProvider) && userModel != "" {
 			// Use the user's configured model instead of default
+			mc.ModelName = userModel
 			mc.Model = buildModelWithProtocol(m.protocol, userModel)
 		} else if userProvider == "" && userModel != "" && !legacyModelNameApplied {
 			// Legacy config: no explicit provider field but model is specified

--- a/pkg/config/migration_test.go
+++ b/pkg/config/migration_test.go
@@ -609,3 +609,42 @@ func TestConvertProvidersToModelList_LegacyModelWithProtocolPrefix(t *testing.T)
 		t.Errorf("Model = %q, want %q (should not duplicate prefix)", result[0].Model, "openrouter/auto")
 	}
 }
+
+func TestConvertProvidersToModelList_UserModelWithProvider(t *testing.T) {
+	cfg := &Config{
+		Agents: AgentsConfig{
+			Defaults: AgentDefaults{
+				Provider: "ollama",
+				Model:    "llama3.2",
+			},
+		},
+		Providers: ProvidersConfig{
+			Ollama: ProviderConfig{
+				APIBase: "http://localhost:11434/v1",
+			},
+		},
+	}
+
+	result := ConvertProvidersToModelList(cfg)
+
+	// Find the ollama entry
+	var found *ModelConfig
+	for i := range result {
+		if strings.Contains(result[i].Model, "ollama/") {
+			found = &result[i]
+			break
+		}
+	}
+
+	if found == nil {
+		t.Fatalf("expected an ollama entry in result, got %d entries: %+v", len(result), result)
+	}
+
+	if found.ModelName != "llama3.2" {
+		t.Errorf("ModelName = %q, want %q", found.ModelName, "llama3.2")
+	}
+
+	if found.Model != "ollama/llama3.2" {
+		t.Errorf("Model = %q, want %q", found.Model, "ollama/llama3.2")
+	}
+}


### PR DESCRIPTION
Split from #963 per maintainer request.

This PR only includes the legacy migration ModelName fix from #958.