### PR TITLE
feat(providers): add vision/image support to CodexProvider (OAuth)

### DIFF
--- a/pkg/providers/codex_provider.go
+++ b/pkg/providers/codex_provider.go
@@ -224,6 +224,26 @@ func buildCodexParams(
 						},
 					},
 				})
+			} else if len(msg.Media) > 0 {
+				// Multipart content: text + images for vision-capable models
+				contentParts := make(responses.ResponseInputMessageContentListParam, 0, 1+len(msg.Media))
+				if msg.Content != "" {
+					contentParts = append(contentParts, responses.ResponseInputContentParamOfInputText(msg.Content))
+				}
+				for _, mediaURL := range msg.Media {
+					contentParts = append(contentParts, responses.ResponseInputContentUnionParam{
+						OfInputImage: &responses.ResponseInputImageParam{
+							ImageURL: openai.Opt(mediaURL),
+							Detail:   responses.ResponseInputImageDetailAuto,
+						},
+					})
+				}
+				inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
+					OfMessage: &responses.EasyInputMessageParam{
+						Role:    responses.EasyInputMessageRoleUser,
+						Content: responses.EasyInputMessageContentUnionParam{OfInputItemContentList: contentParts},
+					},
+				})
 			} else {
 				inputItems = append(inputItems, responses.ResponseInputItemUnionParam{
 					OfMessage: &responses.EasyInputMessageParam{


### PR DESCRIPTION
## Summary

Add multipart content support for messages with Media attachments in CodexProvider (OAuth). This enables vision-capable models like gpt-5.2 to process images when using OAuth authentication.

## Problem

PR #1020 added vision support to `openai_compat/provider.go` but not to `codex_provider.go`. Users authenticating via OAuth (using CodexProvider) couldn't use vision despite having access to vision-capable models.

## Changes

- Check for `msg.Media` in user messages within `buildCodexParams()`
- Build `ResponseInputMessageContentListParam` with text + image parts
- Use `ResponseInputImageParam` with `ImageURL` and auto detail level

## Implementation

Follows the same pattern as `serializeMessages()` in `openai_compat/provider.go`:

```go
} else if len(msg.Media) > 0 {
    contentParts := make(responses.ResponseInputMessageContentListParam, 0, 1+len(msg.Media))
    if msg.Content != "" {
        contentParts = append(contentParts, responses.ResponseInputContentParamOfInputText(msg.Content))
    }
    for _, mediaURL := range msg.Media {
        contentParts = append(contentParts, responses.ResponseInputContentUnionParam{
            OfInputImage: &responses.ResponseInputImageParam{
                ImageURL: openai.Opt(mediaURL),
                Detail:   responses.ResponseInputImageDetailAuto,
            },
        })
    }
    // ...
}
```

## Testing

Tested with WhatsApp → webhook → PicoClaw pipeline using OAuth + gpt-5.2:
- ✅ Food image sent via simulated WhatsApp message
- ✅ Image converted to base64 data URL and passed in Media field
- ✅ CodexProvider builds multipart content correctly
- ✅ Model analyzes image and responds with food identification

## Related

- PR #1020 - Original vision pipeline (only updated openai_compat)
- PR #990 / #1010 - Earlier vision attempt (reverted)
