### PR TITLE
fix(cron): publish agent response for deliver=false cron tasks

### DIFF
--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -337,7 +337,16 @@ func (t *CronTool) ExecuteJob(ctx context.Context, job *cron.CronJob) string {
 		return fmt.Sprintf("Error: %v", err)
 	}
 
-	// Response is automatically sent via MessageBus by AgentLoop
-	_ = response // Will be sent by AgentLoop
+	// Send agent response to channel (ProcessDirectWithChannel does not
+	// publish on its own — only the Run() inbound loop does that).
+	if response != "" {
+		pubCtx, pubCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer pubCancel()
+		t.msgBus.PublishOutbound(pubCtx, bus.OutboundMessage{
+			Channel: channel,
+			ChatID:  chatID,
+			Content: response,
+		})
+	}
 	return "ok"
 }


### PR DESCRIPTION
## 📝 Description

Fix `deliver=false` cron tasks silently discarding the LLM response.

`ExecuteJob` calls `ProcessDirectWithChannel` which returns the LLM response,
but the response was discarded with `_ = response`. The comment claimed
"Will be sent by AgentLoop" but `ProcessDirectWithChannel` bypasses the
`Run()` inbound loop that would normally publish the response.

Now the response is published via MessageBus explicitly, matching the pattern
used by the `deliver=true` and `command` execution paths.

```diff
-// Response is automatically sent via MessageBus by AgentLoop
-_ = response // Will be sent by AgentLoop
+// Send agent response to channel (ProcessDirectWithChannel does not
+// publish on its own — only the Run() inbound loop does that).
+if response != "" {
+    pubCtx, pubCancel := context.WithTimeout(context.Background(), 5*time.Second)
+    defer pubCancel()
+    t.msgBus.PublishOutbound(pubCtx, bus.OutboundMessage{
+        Channel: channel,
+        ChatID:  chatID,
+        Content: response,
+    })
+}
```

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## 🔗 Related Issue

Fixes #1058

## 📚 Technical Context (Skip for Docs)
- **Reasoning:** `ProcessDirectWithChannel` → `processMessage` → `runAgentLoop`
  with `SendResponse: false`. The normal `Run()` loop publishes the response
  after `processMessage` returns, but `ProcessDirectWithChannel` bypasses `Run()`
  entirely, so the response must be published by the caller.

## 🧪 Test Environment
- **Hardware:** Linux server (runtime), MacBook Apple Silicon (development)
- **OS:** Ubuntu Linux (runtime), macOS (development & testing)
- **Model/Provider:** GPT-5.2, GPT-5.3-codex
- **Channels:** Discord

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.