### PR TITLE
fix(provider): improve error messages for non-JSON API responses

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -192,10 +192,31 @@ func (p *Provider) Chat(
 		return nil, fmt.Errorf("API request failed:\n  Status: %d\n  Body:   %s", resp.StatusCode, string(body))
 	}
 
+	// Check Content-Type header to catch HTML error pages early
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != "" && !strings.Contains(strings.ToLower(contentType), "application/json") {
+		// Truncate body for error message
+		preview := string(body)
+		if len(preview) > 200 {
+			preview = preview[:200] + "..."
+		}
+		return nil, fmt.Errorf("API returned non-JSON response (Content-Type: %s, check api_base URL): %s", contentType, preview)
+	}
+
 	return parseResponse(body)
 }
 
 func parseResponse(body []byte) (*LLMResponse, error) {
+	// Check if response is HTML (common when API URL is wrong or returns error page)
+	if len(body) > 0 && (body[0] == '<' || bytes.HasPrefix(bytes.ToLower(body[:min(len(body), 15)]), []byte("<!doctype")) || bytes.HasPrefix(bytes.ToLower(body[:min(len(body), 6)]), []byte("<html"))) {
+		// Truncate HTML content for error message
+		htmlPreview := string(body)
+		if len(htmlPreview) > 200 {
+			htmlPreview = htmlPreview[:200] + "..."
+		}
+		return nil, fmt.Errorf("API returned HTML instead of JSON (check api_base URL): response starts with %q", htmlPreview)
+	}
+
 	var apiResponse struct {
 		Choices []struct {
 			Message struct {
@@ -223,7 +244,12 @@ func parseResponse(body []byte) (*LLMResponse, error) {
 	}
 
 	if err := json.Unmarshal(body, &apiResponse); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+		// Provide more context for JSON parse errors
+		preview := string(body)
+		if len(preview) > 100 {
+			preview = preview[:100] + "..."
+		}
+		return nil, fmt.Errorf("failed to unmarshal response (got: %q): %w", preview, err)
 	}
 
 	if len(apiResponse.Choices) == 0 {


### PR DESCRIPTION
Add multi-layer validation to detect and report HTML error pages from misconfigured API endpoints:

1. Check Content-Type header for application/json
2. Detect HTML content by checking for '<' prefix and doctype
3. Show response preview in JSON parse errors

This helps users quickly identify api_base URL configuration issues instead of seeing cryptic 'invalid character < looking for beginning of value' errors.

Fixes the case where APIs return HTML error pages (404, rate limit pages, etc.) when the endpoint URL is incorrect.

## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

Improve error messages when API returns non-JSON responses (e.g., HTML error pages).
Users now see clear guidance to check their api_base URL configuration instead of 
cryptic JSON parse errors.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

Fixes #1068

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A - internal error handling improvement
- **Reasoning:** Multi-layer validation (Content-Type + HTML detection + enhanced JSON errors)
  provides defense-in-depth for catching misconfigured API endpoints

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

Before:
error=failed to unmarshal response: invalid character '<' looking for beginning of value
After:
API returned non-JSON response (Content-Type: text/html, check api_base URL): <!DOCTYPE html>...

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.