### PR TITLE
fix(provider): improve error message when API returns HTML instead of JSON

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -223,8 +223,14 @@ func parseResponse(body []byte) (*LLMResponse, error) {
 	}
 
 	if err := json.Unmarshal(body, &apiResponse); err != nil {
+		// Check if the response is HTML instead of JSON (e.g., wrong api_base URL)
+		bodyStr := string(body)
+		if strings.HasPrefix(strings.TrimSpace(bodyStr), "<") {
+			return nil, fmt.Errorf("API returned HTML instead of JSON. Please check your api_base URL configuration. The server may be returning an error page or the endpoint URL may be incorrect (e.g., missing '/v1' path)")
+		}
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
+
 
 	if len(apiResponse.Choices) == 0 {
 		return &LLMResponse{


### PR DESCRIPTION
## Description

When the API endpoint is misconfigured (e.g., wrong `api_base` URL), the API returns an HTML error page, but the error message was cryptic:
```
failed to unmarshal response: invalid character '<' looking for beginning of value
```

This doesn't help users identify that their `api_base` URL is wrong.

## Changes

Added HTML response detection in `parseResponse` function before attempting JSON unmarshal:
- Check if response body starts with "<" (HTML tag)
- Provide clear error message guiding users to check their `api_base` URL configuration
- Include suggestions about common mistakes (e.g., missing '/v1' path)

### Before
```
failed to unmarshal response: invalid character '<' looking for beginning of value
```

### After
```
API returned HTML instead of JSON. Please check your api_base URL configuration. The server may be returning an error page or the endpoint URL may be incorrect (e.g., missing '/v1' path)
```

## Testing

- All existing tests pass
- Added test case `TestParseResponse_HTMLResponse` to verify HTML detection

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## AI Code Generation

- [x] 🤖 Fully AI generated - AI implemented the fix and I reviewed and tested it

## Related Issue

Fixes #1068

## Checklist

- [x] I have run `make check` and all checks pass
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective