### PR TITLE
docs(config): expose summarization thresholds in config example

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -6,7 +6,9 @@
       "model_name": "gpt4",
       "max_tokens": 8192,
       "temperature": 0.7,
-      "max_tool_iterations": 20
+      "max_tool_iterations": 20,
+      "summarize_message_threshold": 20,
+      "summarize_token_percent": 75
     }
   },
   "model_list": [


### PR DESCRIPTION
## Summary
- Add `summarize_message_threshold` and `summarize_token_percent` under `agents.defaults` in `config/config.example.json`.
- Keep values aligned with runtime defaults (`20`, `75`).
- Docs/example-only change; no runtime behavior change.

## Why
 #1029 added these settings but didn't update the example config.

Refs #854