### PR TITLE
fix(skills): use --registry flag value as registry name

### DIFF
--- a/cmd/picoclaw/internal/skills/install.go
+++ b/cmd/picoclaw/internal/skills/install.go
@@ -21,8 +21,8 @@ picoclaw skills install --registry clawhub github
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if registry != "" {
-				if len(args) != 2 {
-					return fmt.Errorf("when --registry is set, exactly 2 arguments are required: <name> <slug>")
+				if len(args) != 1 {
+					return fmt.Errorf("when --registry is set, exactly 1 argument is required: <slug>")
 				}
 				return nil
 			}
@@ -45,7 +45,7 @@ picoclaw skills install --registry clawhub github
 					return err
 				}
 
-				return skillsInstallFromRegistry(cfg, args[0], args[1])
+				return skillsInstallFromRegistry(cfg, registry, args[0])
 			}
 
 			return skillsInstallCmd(installer, args[0])

--- a/cmd/picoclaw/internal/skills/install_test.go
+++ b/cmd/picoclaw/internal/skills/install_test.go
@@ -26,3 +26,72 @@ func TestNewInstallSubcommand(t *testing.T) {
 
 	assert.Len(t, cmd.Aliases, 0)
 }
+
+func TestInstallCommandArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		registry    string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "no registry, one arg",
+			args:        []string{"sipeed/picoclaw-skills/weather"},
+			registry:    "",
+			expectError: false,
+		},
+		{
+			name:        "no registry, no args",
+			args:        []string{},
+			registry:    "",
+			expectError: true,
+			errorMsg:    "exactly 1 argument is required: <github>",
+		},
+		{
+			name:        "no registry, too many args",
+			args:        []string{"arg1", "arg2"},
+			registry:    "",
+			expectError: true,
+			errorMsg:    "exactly 1 argument is required: <github>",
+		},
+		{
+			name:        "with registry, one arg",
+			args:        []string{"weather-skill"},
+			registry:    "clawhub",
+			expectError: false,
+		},
+		{
+			name:        "with registry, no args",
+			args:        []string{},
+			registry:    "clawhub",
+			expectError: true,
+			errorMsg:    "when --registry is set, exactly 1 argument is required: <slug>",
+		},
+		{
+			name:        "with registry, too many args",
+			args:        []string{"arg1", "arg2"},
+			registry:    "clawhub",
+			expectError: true,
+			errorMsg:    "when --registry is set, exactly 1 argument is required: <slug>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newInstallCommand(nil)
+
+			if tt.registry != "" {
+				require.NoError(t, cmd.Flags().Set("registry", tt.registry))
+			}
+
+			err := cmd.Args(cmd, tt.args)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Equal(t, tt.errorMsg, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

The `--registry` flag value in `picoclaw skills install` was previously ignored and only used as a switch to enable registry mode. The actual registry name was expected as a positional argument, which was confusing and misleading.

This fix changes the behavior to use the flag value as the registry name, requiring only one positional argument (slug) when `--registry` is set.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation

- [x] 🛠️ Mostly AI-generated — AI produced the draft; contributor made significant modifications

## Related Issue

Fixes #1104

## Technical Context

The previous implementation:
```go
if registry != "" {
    return skillsInstallFromRegistry(cfg, args[0], args[1])
}
```

The `registry` variable (flag value) was never passed to the function.

The fix:
```go
if registry != "" {
    return skillsInstallFromRegistry(cfg, registry, args[0])
}
```

## Test Environment

- OS: Linux
- Go: 1.25+
- Tests: All tests in `./cmd/picoclaw/internal/skills/...` pass

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] I have run `go fmt` and `go vet` locally
- [x] I have run relevant tests locally
- [x] I have linked the related issue