### PR TITLE
fix(provider) prevent audio as image url

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -323,12 +323,14 @@ func serializeMessages(messages []Message) []any {
 			})
 		}
 		for _, mediaURL := range m.Media {
-			parts = append(parts, map[string]any{
-				"type": "image_url",
-				"image_url": map[string]any{
-					"url": mediaURL,
-				},
-			})
+			if strings.HasPrefix(mediaURL, "data:image/") {
+				parts = append(parts, map[string]any{
+					"type": "image_url",
+					"image_url": map[string]any{
+						"url": mediaURL,
+					},
+				})
+			}
 		}
 
 		msg := map[string]any{


### PR DESCRIPTION
## 📝 Description

This PR fixes a critical bug where transcribed voice messages were causing text-only LLMs (like Zhipu `glm-4.7-flash`) to crash with a 404 error. 

Previously, after the `transcriber` processed an audio file, the audio reference remained in the `msg.Media` array. The `openai_compat` provider then blindly converted **all** media files into `image_url` blocks. When sending an `image_url` payload to a text-only model, the API rejected the request entirely.

**Changes made:**
- Updated `pkg/providers/openai_compat/provider.go` (`serializeMessages`) to strictly filter media types. It now only appends `image_url` blocks for actual images (`strings.HasPrefix(mediaURL, "data:image/")`). Transcribed audio is safely ignored at the serialization layer since its content is already injected as text.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** macOS
- **Model/Provider:** Zhipu / `glm-4.7-flash`
- **Channels:** Telegram


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

**Before the fix (Error Log):**
```text
2026/03/04 19:03:49 [DEBUG] voice: Sending transcription request to Groq API
2026/03/04 19:03:50 [INFO] voice: Transcription completed successfully {text_length=4, transcription_preview= Hi.}
...
2026/03/04 19:03:50 [ERROR] agent: LLM call failed {iteration=1, error=API request failed:
  Status: 404
  Body:   {"error":{"message":"No endpoints found that support image input","code":404}}, agent_id=main}