### PR TITLE
fix(provider): add configurable timeout for Ollama local models

### DIFF
--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -84,12 +84,17 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 		if apiBase == "" {
 			apiBase = getDefaultAPIBase(protocol)
 		}
+		// Special handling for Ollama models - extend timeout to 300 seconds
+		requestTimeout := cfg.RequestTimeout
+		if protocol == "ollama" && requestTimeout <= 0 {
+			requestTimeout = 300
+		}
 		return NewHTTPProviderWithMaxTokensFieldAndRequestTimeout(
 			cfg.APIKey,
 			apiBase,
 			cfg.Proxy,
 			cfg.MaxTokensField,
-			cfg.RequestTimeout,
+			requestTimeout,
 		), modelID, nil
 
 	case "litellm", "openrouter", "groq", "zhipu", "gemini", "nvidia",
@@ -103,12 +108,17 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 		if apiBase == "" {
 			apiBase = getDefaultAPIBase(protocol)
 		}
+		// Special handling for Ollama models - extend timeout to 300 seconds
+		requestTimeout := cfg.RequestTimeout
+		if protocol == "ollama" && requestTimeout <= 0 {
+			requestTimeout = 300
+		}
 		return NewHTTPProviderWithMaxTokensFieldAndRequestTimeout(
 			cfg.APIKey,
 			apiBase,
 			cfg.Proxy,
 			cfg.MaxTokensField,
-			cfg.RequestTimeout,
+			requestTimeout,
 		), modelID, nil
 
 	case "anthropic":


### PR DESCRIPTION
## Description

Fixes #430

Ollama local models were timing out at 120 seconds in PicoClaw, while the same models respond fine via direct Ollama API. This prevented users from running larger local models that take longer to generate responses.

## Changes

- Added special timeout handling for Ollama models in CreateProviderFromConfig
- When protocol is "ollama" and no explicit timeout is configured, default to 300 seconds instead of 120 seconds
- Maintains backward compatibility - explicit timeout configuration still works as before
- Applies to both explicit "ollama" protocol and models with "ollama/" prefix

## Testing

- Verified Ollama local models now work without timeout errors
- Confirmed configurable timeouts still work when explicitly set
- Tested both direct protocol usage and model prefix scenarios

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## AI Code Generation

- [x] 🤖 AI Assisted - Human designed the solution, AI helped implement it