### PR TITLE
fix: prevent duplicate messages after delegating to subagent

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -571,7 +571,7 @@ func (al *AgentLoop) processSystemMessage(
 		UserMessage:     fmt.Sprintf("[System: %s] %s", msg.SenderID, msg.Content),
 		DefaultResponse: "Background task completed.",
 		EnableSummary:   false,
-		SendResponse:    true,
+		SendResponse:    false,  // Prevent duplicate responses caused by system message processing
 	})
 }
 

--- a/pkg/tools/subagent.go
+++ b/pkg/tools/subagent.go
@@ -20,6 +20,7 @@ type SubagentTask struct {
 	Status        string
 	Result        string
 	Created       int64
+	announcedOnce sync.Once  // Ensures the completion announcement is sent only once
 }
 
 type SubagentManager struct {
@@ -216,7 +217,7 @@ After completing the task, provide a clear summary of what was done.`
 	}
 
 	// Send announce message back to main agent
-	if sm.bus != nil {
+	task.announcedOnce.Do(func() {
 		announceContent := fmt.Sprintf("Task '%s' completed.\n\nResult:\n%s", task.Label, task.Result)
 		pubCtx, pubCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer pubCancel()
@@ -227,7 +228,21 @@ After completing the task, provide a clear summary of what was done.`
 			ChatID:  fmt.Sprintf("%s:%s", task.OriginChannel, task.OriginChatID),
 			Content: announceContent,
 		})
-	}
+	})
+
+		task.announcedOnce.Do(func() {
+			// Send announce message back to main agent
+			announceContent := fmt.Sprintf("Task '%s' completed.\n\nResult:\n%s", task.Label, task.Result)
+			pubCtx, pubCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer pubCancel()
+			sm.bus.PublishInbound(pubCtx, bus.InboundMessage{
+				Channel:  "system",
+				SenderID: fmt.Sprintf("subagent:%s", task.ID),
+				// Format: "original_channel:original_chat_id" for routing back
+				ChatID:  fmt.Sprintf("%s:%s", task.OriginChannel, task.OriginChatID),
+				Content: announceContent,
+			})
+		})
 }
 
 func (sm *SubagentManager) GetTask(taskID string) (*SubagentTask, bool) {


### PR DESCRIPTION
…: false in processSystemMessage and adding unique tracking with Once for subagent announcements

This commit addresses the issue where subagent tasks were producing multiple answers after delegation:

- Changed SendResponse from true to false in processSystemMessage to prevent duplicate notifications

- Added sync.Once field to SubagentTask to ensure unique announcement tracking

- Modified announcement logic to use sync.Once for idempotency

The fixes ensure that when subagents complete their tasks, their results are communicated uniquely

without duplication by preventing: 1) system messages from re-triggering user responses,

and 2) multiple announcement attempts from the same subagent task.

## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.