### PR TITLE
feat(docker): add Dokploy deployment template

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,15 @@ docker compose -f docker/docker-compose.yml pull
 docker compose -f docker/docker-compose.yml --profile gateway up -d
 ```
 
+### Dokploy Template
+
+If you deploy PicoClaw on Dokploy, use the ready template files:
+
+- `docker/dokploy/docker-compose.yml`
+- `docker/dokploy/template.toml`
+
+See [docs/DOKPLOY.md](docs/DOKPLOY.md) for details.
+
 ### 🚀 Quick Start
 
 > [!TIP]

--- a/docker/dokploy/docker-compose.yml
+++ b/docker/dokploy/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  picoclaw:
+    image: docker.io/sipeed/picoclaw:latest
+    restart: unless-stopped
+    environment:
+      TZ: ${TZ}
+      PICOCLAW_GATEWAY_HOST: ${PICOCLAW_GATEWAY_HOST}
+    volumes:
+      - picoclaw-workspace:/root/.picoclaw/workspace
+
+volumes:
+  picoclaw-workspace: {}

--- a/docker/dokploy/template.toml
+++ b/docker/dokploy/template.toml
@@ -1,0 +1,41 @@
+[variables]
+main_domain = "${domain}"
+openrouter_api_key = "${password:40}"
+
+[config]
+env = [
+  "TZ=UTC",
+  "PICOCLAW_GATEWAY_HOST=0.0.0.0",
+]
+mounts = []
+
+[[config.domains]]
+serviceName = "picoclaw"
+port = 18_790
+host = "${main_domain}"
+
+[[config.mounts]]
+filePath = "/root/.picoclaw/config.json"
+content = """
+{
+  "agents": {
+    "defaults": {
+      "workspace": "~/.picoclaw/workspace",
+      "restrict_to_workspace": true,
+      "model_name": "openrouter-default"
+    }
+  },
+  "model_list": [
+    {
+      "model_name": "openrouter-default",
+      "model": "openrouter/openai/gpt-4o-mini",
+      "api_key": "${openrouter_api_key}",
+      "api_base": "https://openrouter.ai/api/v1"
+    }
+  ],
+  "gateway": {
+    "host": "0.0.0.0",
+    "port": 18790
+  }
+}
+"""

--- a/docs/DOKPLOY.md
+++ b/docs/DOKPLOY.md
@@ -1,0 +1,22 @@
+# Dokploy Deployment
+
+This repository includes a Dokploy-ready template under [docker/dokploy](../docker/dokploy).
+
+## Included Files
+
+- `docker/dokploy/docker-compose.yml`: runtime service definition
+- `docker/dokploy/template.toml`: Dokploy template variables, domain mapping, and config mount
+
+## What This Template Provides
+
+- A persistent workspace volume at `/root/.picoclaw/workspace`
+- Automatic gateway host binding to `0.0.0.0`
+- A generated `config.json` mount with:
+  - model alias: `openrouter-default`
+  - model: `openrouter/openai/gpt-4o-mini`
+  - OpenRouter API key from template variable
+
+## Usage Notes
+
+- Set your domain and `openrouter_api_key` in Dokploy when deploying the template.
+- If you prefer another provider/model, edit the mounted `config.json` content in `template.toml`.


### PR DESCRIPTION
## Description

Add an official Dokploy deployment template for PicoClaw.

This PR introduces a Dokploy-ready compose blueprint and template metadata so users can deploy with minimal setup, including domain mapping, workspace persistence, and a generated `config.json` mount.

## What Changed

- add `docker/dokploy/docker-compose.yml`
- add `docker/dokploy/template.toml`
- add Dokploy usage guide in `docs/DOKPLOY.md`
- link Dokploy docs from README Docker section

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactoring

## Related Issue

Closes #1065