### PR TITLE
Fix: Recurring cron jobs silently become one-time tasks

### DIFF
--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -150,6 +150,13 @@ func (t *CronTool) addJob(args map[string]any) *ToolResult {
 	everySeconds, hasEvery := args["every_seconds"].(float64)
 	cronExpr, hasCron := args["cron_expr"].(string)
 
+	// Validate that values are meaningful (not zero/empty)
+	// This prevents LLMs from setting unused optional params to default values (e.g., at_seconds: 0)
+	// which would otherwise cause hasAt/hasEvery to be true via Go type assertion
+	hasAt = hasAt && atSeconds > 0
+	hasEvery = hasEvery && everySeconds > 0
+	hasCron = hasCron && cronExpr != ""
+
 	// Priority: at_seconds > every_seconds > cron_expr
 	if hasAt {
 		atMS := time.Now().UnixMilli() + int64(atSeconds)*1000


### PR DESCRIPTION
Fixes #1043

## Description

This PR fixes issue #1043 where recurring cron jobs (every_seconds / cron_expr) silently become one-time "at" tasks.

## Root Cause

Go type assertions return true for zero values (e.g., `at_seconds: 0`), causing LLMs that fill unused optional parameters with defaults to inadvertently trigger the wrong schedule type.

## Fix

Added value validity checks after type assertions in `pkg/tools/cron.go`:
```go
hasAt = hasAt && atSeconds > 0
hasEvery = hasEvery && everySeconds > 0
hasCron = hasCron && cronExpr != ""
```

This ensures only meaningful values trigger their respective schedule types, allowing recurring tasks (every_seconds/cron_expr) to work correctly.

## Testing

Tested with recurring tasks like "remind me every 2 hours" - they now correctly create recurring jobs instead of one-time tasks.

This is a minimal fix with zero risk of regression — legitimate `at_seconds > 0` values continue to work exactly as before.