### PR TITLE
feat:solve the problem of incorrect handling of the sessionID field in pico channel

### DIFF
--- a/pkg/channels/pico/pico.go
+++ b/pkg/channels/pico/pico.go
@@ -43,18 +43,6 @@ func (pc *picoConn) addSession(sessionID string) {
 	pc.sessions[sessionID] = struct{}{}
 }
 
-// removeSession removes a session ID from this connection.
-func (pc *picoConn) removeSession(sessionID string) {
-	if sessionID == "" || sessionID == pc.sessionID {
-		return
-	}
-
-	pc.sessionsMu.Lock()
-	defer pc.sessionsMu.Unlock()
-
-	delete(pc.sessions, sessionID)
-}
-
 // hasSession checks if this connection belongs to a session.
 func (pc *picoConn) hasSession(sessionID string) bool {
 	if sessionID == "" {


### PR DESCRIPTION
…oMessage

## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->
If the session ID in the pico message is inconsistent with the session ID when establishing the WebSocket, the reply should be rejected. The code fix associates the new session ID in the pico message with the WebSocket connection, so that a normal reply can be made.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🧪 Test Environment
- **Hardware:** pc
- **OS:** win11
- **Model/Provider:** kimi-k2.5
- **Channels:** pico

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.