### PR TITLE
fix: prevent file descriptor leak in discord SendMedia

### DIFF
--- a/pkg/channels/discord/discord.go
+++ b/pkg/channels/discord/discord.go
@@ -190,6 +190,15 @@ func (c *DiscordChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaMes
 		return nil
 	}
 
+	// Ensure all opened files are closed when done
+	defer func() {
+		for _, f := range files {
+			if closer, ok := f.Reader.(*os.File); ok {
+				closer.Close()
+			}
+		}
+	}()
+
 	sendCtx, cancel := context.WithTimeout(ctx, sendTimeout)
 	defer cancel()
 
@@ -204,23 +213,11 @@ func (c *DiscordChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaMes
 
 	select {
 	case err := <-done:
-		// Close all file readers
-		for _, f := range files {
-			if closer, ok := f.Reader.(*os.File); ok {
-				closer.Close()
-			}
-		}
 		if err != nil {
 			return fmt.Errorf("discord send media: %w", channels.ErrTemporary)
 		}
 		return nil
 	case <-sendCtx.Done():
-		// Close all file readers
-		for _, f := range files {
-			if closer, ok := f.Reader.(*os.File); ok {
-				closer.Close()
-			}
-		}
 		return sendCtx.Err()
 	}
 }


### PR DESCRIPTION
Replace duplicated file cleanup code in select branches with a single defer, ensuring files are always closed even on unexpected panics.

## 📝 Description

File cleanup code was duplicated across both `select` branches, and files
would leak on unexpected panics. Consolidate into a single `defer` to
ensure opened files are always closed.


## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [ ] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.