### PR TITLE
fix(agent): drop assistant tool_calls turns with incomplete tool results

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -602,7 +602,52 @@ func sanitizeHistoryForProvider(history []providers.Message) []providers.Message
 		}
 	}
 
-	return sanitized
+	final := make([]providers.Message, 0, len(sanitized))
+	for i := 0; i < len(sanitized); i++ {
+		msg := sanitized[i]
+		if msg.Role != "assistant" || len(msg.ToolCalls) == 0 {
+			final = append(final, msg)
+			continue
+		}
+
+		expected := make(map[string]bool, len(msg.ToolCalls))
+		for _, tc := range msg.ToolCalls {
+			expected[tc.ID] = false
+		}
+
+		for j := i + 1; j < len(sanitized); j++ {
+			next := sanitized[j]
+			if next.Role != "tool" {
+				break
+			}
+			if _, ok := expected[next.ToolCallID]; ok {
+				expected[next.ToolCallID] = true
+			}
+		}
+
+		allFound := true
+		for _, found := range expected {
+			if !found {
+				allFound = false
+				break
+			}
+		}
+		if !allFound {
+			logger.DebugCF(
+				"agent",
+				"Dropping assistant tool-call turn with incomplete tool results",
+				map[string]any{"tool_calls": len(expected)},
+			)
+			for i+1 < len(sanitized) && sanitized[i+1].Role == "tool" {
+				i++
+			}
+			continue
+		}
+
+		final = append(final, msg)
+	}
+
+	return final
 }
 
 func (cb *ContextBuilder) AddToolResult(

--- a/pkg/agent/context_test.go
+++ b/pkg/agent/context_test.go
@@ -188,6 +188,54 @@ func TestSanitizeHistoryForProvider_PlainConversation(t *testing.T) {
 	assertRoles(t, result, "user", "assistant", "user", "assistant")
 }
 
+func TestSanitizeHistoryForProvider_AssistantToolCallMissingAllResults(t *testing.T) {
+	history := []providers.Message{
+		msg("user", "run tool"),
+		assistantWithTools("A"),
+		msg("assistant", "fallback text"),
+	}
+
+	result := sanitizeHistoryForProvider(history)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages, got %d: %+v", len(result), roles(result))
+	}
+	assertRoles(t, result, "user", "assistant")
+}
+
+func TestSanitizeHistoryForProvider_AssistantToolCallIncompleteResults(t *testing.T) {
+	history := []providers.Message{
+		msg("user", "run two tools"),
+		assistantWithTools("A", "B"),
+		toolResult("A"),
+		msg("assistant", "next"),
+	}
+
+	result := sanitizeHistoryForProvider(history)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages, got %d: %+v", len(result), roles(result))
+	}
+	assertRoles(t, result, "user", "assistant")
+}
+
+func TestSanitizeHistoryForProvider_DropsBrokenRoundKeepsCompleteRound(t *testing.T) {
+	history := []providers.Message{
+		msg("user", "first"),
+		assistantWithTools("A", "B"),
+		toolResult("A"),
+		msg("assistant", "after broken round"),
+		msg("user", "second"),
+		assistantWithTools("C"),
+		toolResult("C"),
+		msg("assistant", "done"),
+	}
+
+	result := sanitizeHistoryForProvider(history)
+	if len(result) != 6 {
+		t.Fatalf("expected 6 messages, got %d: %+v", len(result), roles(result))
+	}
+	assertRoles(t, result, "user", "assistant", "user", "assistant", "tool", "assistant")
+}
+
 func roles(msgs []providers.Message) []string {
 	r := make([]string, len(msgs))
 	for i, m := range msgs {


### PR DESCRIPTION
## 📝 Description

Fix issue #1004 where strict OpenAI-compatible providers (e.g., DeepSeek) reject history containing assistant `tool_calls` without complete matching `tool` results.

Current `sanitizeHistoryForProvider()` validates backward consistency (tool -> previous assistant with tool calls), but misses forward completeness (assistant tool_calls -> following tool results).
This PR adds a second pass to drop incomplete assistant tool-call turns and their partial trailing tool messages, ensuring provider-compatible message history.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1004

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1004
- **Reasoning:**
  For each `assistant` message with `tool_calls`, providers like DeepSeek require corresponding `tool` messages with matching `tool_call_id`.
  The new forward validation pass:
  1. collects expected tool_call IDs,
  2. scans following contiguous tool messages,
  3. drops the assistant turn if any ID is missing, and skips its partial tool segment.

  Scope is minimal and style-consistent: only `pkg/agent/context.go` and `pkg/agent/context_test.go`.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows
- **Model/Provider:** DeepSeek (problem context), sanitizer unit tests
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Code changes:
- `pkg/agent/context.go`
  - add second forward completeness pass in `sanitizeHistoryForProvider()`
- `pkg/agent/context_test.go`
  - add tests:
    - `TestSanitizeHistoryForProvider_AssistantToolCallMissingAllResults`
    - `TestSanitizeHistoryForProvider_AssistantToolCallIncompleteResults`
    - `TestSanitizeHistoryForProvider_DropsBrokenRoundKeepsCompleteRound`

Verification run:
```bash
go test ./pkg/agent -run TestSanitizeHistoryForProvider -count=1
# ok   github.com/sipeed/picoclaw/pkg/agent
```

Performance note:
- Adds one extra validation pass over sanitized history.
- Worst-case overhead increases with history length, but in normal session sizes this is much smaller than LLM request latency.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.