### PR TITLE
Fix: improve history compression with retry logic and multi-byte character support

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1463,7 +1463,7 @@ func (al *AgentLoop) retryLLMCall(
 			return resp, nil
 		}
 		if attempt < maxRetries-1 {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond)
 		}
 	}
 
@@ -1478,10 +1478,11 @@ func (al *AgentLoop) summarizeBatch(
 	existingSummary string,
 ) (string, error) {
 	const (
-		llmMaxRetries            = 3
-		llmMaxTokens             = 1024
-		llmTemperature           = 0.3
-		fallbackMaxContentLength = 200
+		llmMaxRetries             = 3
+		llmMaxTokens              = 1024
+		llmTemperature            = 0.3
+		fallbackMinContentLength  = 200
+		fallbackMaxContentPercent = 10
 	)
 
 	var sb strings.Builder
@@ -1512,8 +1513,23 @@ func (al *AgentLoop) summarizeBatch(
 		}
 		content := strings.TrimSpace(m.Content)
 		runes := []rune(content)
-		if len(runes) > fallbackMaxContentLength {
-			content = string(runes[:fallbackMaxContentLength]) + "..."
+		if len(runes) == 0 {
+			fallback.WriteString(fmt.Sprintf("%s: ", m.Role))
+			continue
+		}
+
+		keepLength := len(runes) * fallbackMaxContentPercent / 100
+		if keepLength < fallbackMinContentLength {
+			keepLength = fallbackMinContentLength
+		}
+
+		if keepLength > len(runes) {
+			keepLength = len(runes)
+		}
+
+		content = string(runes[:keepLength])
+		if keepLength < len(runes) {
+			content += "..."
 		}
 		fallback.WriteString(fmt.Sprintf("%s: %s", m.Role, content))
 	}


### PR DESCRIPTION
## 📝 Description

## Summary

Historical messages were cleared by mistake

1.`summarizeBatch` function may return empty results
2. The content returned by`provider.Chat` calls in `summarizeSession` function may be empty

## Changes

1. When splitting the content into two parts in summarizeSession, ensure that the second part starts with "user"
2. `summarizeBatch` function may return empty results:
- Add a retry mechanism (up to 3 times), with increasing wait times after failures
- If all retries fail, generate a fallback summary (retain the first 200 characters of each message)
- Ensure the function never returns an empty string or error
3. Add a retry mechanism for `provider.Chat` calls in `summarizeSession` function
## Testing
- Verified compilation: `go build ./pkg/agent/`
- Verified formatting: `gofmt -d pkg/agent/loop.go`

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.