### PR TITLE
fix(provider): local picolm provider no longer requires API key

### DIFF
--- a/pkg/providers/factory.go
+++ b/pkg/providers/factory.go
@@ -22,6 +22,7 @@ const (
 	providerTypeClaudeCLI
 	providerTypeCodexCLI
 	providerTypeGitHubCopilot
+	providerTypePicoLM
 )
 
 type providerSelection struct {
@@ -199,6 +200,15 @@ func resolveProviderSelection(cfg *config.Config) (providerSelection, error) {
 			}
 			sel.connectMode = cfg.Providers.GitHubCopilot.ConnectMode
 			return sel, nil
+		case "picolm":
+			// Local picolm provider - no API key required
+			workspace := cfg.WorkspacePath()
+			if workspace == "" {
+				workspace = "."
+			}
+			sel.providerType = providerTypePicoLM
+			sel.workspace = workspace
+			return sel, nil
 		}
 	}
 
@@ -304,6 +314,15 @@ func resolveProviderSelection(cfg *config.Config) (providerSelection, error) {
 			sel.apiKey = cfg.Providers.VLLM.APIKey
 			sel.apiBase = cfg.Providers.VLLM.APIBase
 			sel.proxy = cfg.Providers.VLLM.Proxy
+		case strings.Contains(lowerModel, "picolm") || strings.HasPrefix(model, "picolm/"):
+			// Local picolm provider - no API key required
+			workspace := cfg.WorkspacePath()
+			if workspace == "" {
+				workspace = "."
+			}
+			sel.providerType = providerTypePicoLM
+			sel.workspace = workspace
+			return sel, nil
 		default:
 			if cfg.Providers.OpenRouter.APIKey != "" {
 				sel.apiKey = cfg.Providers.OpenRouter.APIKey


### PR DESCRIPTION
## Description

Fixes #488

Local picolm provider was incorrectly requiring an API key, preventing users from running GGUF models locally without API configuration.

## Changes

- Added providerTypePicoLM constant for local picolm provider
- Added explicit "picolm" case in provider selection that bypasses API key requirement  
- Added fallback case for models starting with "picolm/"
- Local picolm provider now behaves like other local providers (claude-cli, codex-cli)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified local picolm providers with GGUF models run without API key
- Confirmed existing functionality remains unaffected
- Tested both explicit provider and model prefix scenarios

## AI Code Generation

- [x] 🤖 AI Assisted - Human designed the solution, AI helped implement it

## Related PR

This is a rebased version of #1110 to resolve merge conflicts.