### PR TITLE
chore: remove placeholder index.html from dist

### DIFF
--- a/web/backend/.gitignore
+++ b/web/backend/.gitignore
@@ -10,7 +10,6 @@ picoclaw-web
 # Frontend build artifacts (embedded by Go)
 dist/*
 !dist/.gitkeep
-!dist/index.html
 
 # OS
 .DS_Store

--- a/web/backend/dist/index.html
+++ b/web/backend/dist/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><html><head><meta charset="utf-8"><title>PicoClaw</title></head><body><div id="root"></div></body></html>


### PR DESCRIPTION
## 📝 Description

The .gitkeep is sufficient for go:embed to find the dist directory.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.