### PR TITLE
fix: skip prompt_cache_key for Groq API endpoints

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -158,7 +158,7 @@ func (p *Provider) Chat(
 	// Gemini and other providers reject unknown fields, so skip for non-OpenAI APIs.
 	if cacheKey, ok := options["prompt_cache_key"].(string); ok && cacheKey != "" {
 		if !strings.Contains(p.apiBase, "generativelanguage.googleapis.com") &&
-		   !strings.Contains(p.apiBase, "api.groq.com")  {
+			!strings.Contains(p.apiBase, "api.groq.com") {
 			requestBody["prompt_cache_key"] = cacheKey
 		}
 	}


### PR DESCRIPTION
## 📝 Description

Groq returns a 400 error when prompt_cache_key is in the request body since they don't support it. There was already a check to skip it for Gemini so I just added Groq to the same condition.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://console.groq.com/docs/openai
- **Reasoning:** Groq's API rejects unknown fields. Same issue as Gemini, same fix.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** macOS 15
- **Model/Provider:** Groq (llama-3.3-70b-versatile)
- **Channels:** CLI

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Groq returns 400 without this fix, works fine after. All tests pass.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.