### PR TITLE
feat: fix tool calling issue with Claude and update OAuth version

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -486,8 +486,10 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.M
 		for _, tc := range response.ToolCalls {
 			argumentsJSON, _ := json.Marshal(tc.Arguments)
 			assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, providers.ToolCall{
-				ID:   tc.ID,
-				Type: "function",
+				ID:        tc.ID,
+				Type:      "function",
+				Name:      tc.Name,
+				Arguments: tc.Arguments,
 				Function: &providers.FunctionCall{
 					Name:      tc.Name,
 					Arguments: string(argumentsJSON),

--- a/pkg/providers/claude_provider.go
+++ b/pkg/providers/claude_provider.go
@@ -4,22 +4,38 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/sipeed/picoclaw/pkg/auth"
 )
 
+// Would change with newer versions
+const oauthBetaHeader = "oauth-2025-04-20"
+
 type ClaudeProvider struct {
 	client      *anthropic.Client
 	tokenSource func() (string, error)
 }
 
-func NewClaudeProvider(token string) *ClaudeProvider {
-	client := anthropic.NewClient(
-		option.WithAuthToken(token),
+func claudeClientOptions(token string) []option.RequestOption {
+	opts := []option.RequestOption{
 		option.WithBaseURL("https://api.anthropic.com"),
-	)
+	}
+	if strings.HasPrefix(strings.TrimSpace(token), "sk-ant-oat") {
+		opts = append(opts,
+			option.WithAuthToken(token),
+			option.WithHeader("anthropic-beta", oauthBetaHeader),
+		)
+	} else {
+		opts = append(opts, option.WithAPIKey(token))
+	}
+	return opts
+}
+
+func NewClaudeProvider(token string) *ClaudeProvider {
+	client := anthropic.NewClient(claudeClientOptions(token)...)
 	return &ClaudeProvider{client: &client}
 }
 
@@ -36,7 +52,7 @@ func (p *ClaudeProvider) Chat(ctx context.Context, messages []Message, tools []T
 		if err != nil {
 			return nil, fmt.Errorf("refreshing token: %w", err)
 		}
-		opts = append(opts, option.WithAuthToken(tok))
+		opts = append(opts, claudeClientOptions(tok)...)
 	}
 
 	params, err := buildClaudeParams(messages, tools, model, options)


### PR DESCRIPTION
## Summary
- Added `Name` and `Arguments` fields to `ToolCall` struct population in `loop.go` to fix tool calling with Claude
- Introduced OAuth token detection in `claude_provider.go` — tokens prefixed with `sk-ant-oat` now use `WithAuthToken` + the `oauth-2025-04-20` beta header, while regular API keys use `WithAPIKey`
- Extracted `claudeClientOptions()` helper to unify token handling across initial client creation and per-request refresh

## Test plan
- [ ] Test with an OAuth token (`sk-ant-oat...`) — verify the beta header is sent and tool calls resolve correctly
- [ ] Test with a standard API key — verify normal flow is unaffected
- [ ] Verify tool calls complete end-to-end in the agent loop

> **Note:** The `oauthBetaHeader` constant (`oauth-2025-04-20`) may need to be updated with newer Claude Code versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)