### PR TITLE
fix(openai_compat): strip leaked Thinking/Final tags from content

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -39,6 +40,13 @@ type Provider struct {
 type Option func(*Provider)
 
 const defaultRequestTimeout = 120 * time.Second
+
+var (
+	// Providers sometimes leak chain-of-thought in these tags in `content`.
+	quickReasoningTagRE = regexp.MustCompile(`(?i)<\s*/?\s*(?:think(?:ing)?|thought|reasoning|final)\b`)
+	finalTagRE          = regexp.MustCompile(`(?i)<\s*/?\s*final\b[^>]*>`)
+	thinkingTagRE       = regexp.MustCompile(`(?i)<\s*(/?)\s*(?:think(?:ing)?|thought|reasoning)\b[^>]*>`)
+)
 
 func WithMaxTokensField(maxTokensField string) Option {
 	return func(p *Provider) {
@@ -271,6 +279,52 @@ func responsePreview(body []byte, maxLen int) string {
 	return string(trimmed[:maxLen]) + "..."
 }
 
+// stripThinkingAndFinalTags removes leaked reasoning blocks while preserving
+// user-facing answer text (e.g. <final>answer</final> -> answer).
+func stripThinkingAndFinalTags(content string) string {
+	if content == "" {
+		return content
+	}
+	// Some APIs double-escape angle brackets in JSON payloads.
+	content = strings.ReplaceAll(content, `\u003c`, "<")
+	content = strings.ReplaceAll(content, `\u003e`, ">")
+	content = strings.ReplaceAll(content, `\u003C`, "<")
+	content = strings.ReplaceAll(content, `\u003E`, ">")
+
+	if !quickReasoningTagRE.MatchString(content) {
+		return strings.TrimSpace(content)
+	}
+
+	cleaned := finalTagRE.ReplaceAllString(content, "")
+	indexes := thinkingTagRE.FindAllStringSubmatchIndex(cleaned, -1)
+	if len(indexes) == 0 {
+		return strings.TrimSpace(cleaned)
+	}
+
+	var b strings.Builder
+	lastIndex := 0
+	inThinking := false
+	for _, idx := range indexes {
+		matchStart, matchEnd := idx[0], idx[1]
+		isClose := idx[2] >= 0 && cleaned[idx[2]:idx[3]] == "/"
+
+		if !inThinking {
+			b.WriteString(cleaned[lastIndex:matchStart])
+			if !isClose {
+				inThinking = true
+			}
+		} else if isClose {
+			inThinking = false
+		}
+		lastIndex = matchEnd
+	}
+
+	if !inThinking {
+		b.WriteString(cleaned[lastIndex:])
+	}
+	return strings.TrimSpace(b.String())
+}
+
 func parseResponse(body io.Reader) (*LLMResponse, error) {
 	var apiResponse struct {
 		Choices []struct {
@@ -351,7 +405,7 @@ func parseResponse(body io.Reader) (*LLMResponse, error) {
 	}
 
 	return &LLMResponse{
-		Content:          choice.Message.Content,
+		Content:          stripThinkingAndFinalTags(choice.Message.Content),
 		ReasoningContent: choice.Message.ReasoningContent,
 		Reasoning:        choice.Message.Reasoning,
 		ReasoningDetails: choice.Message.ReasoningDetails,

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -152,6 +152,63 @@ func TestProviderChat_ParsesReasoningContent(t *testing.T) {
 	}
 }
 
+func TestParseResponse_StripsThinkingAndFinalTags(t *testing.T) {
+	body := strings.NewReader(`{
+		"choices": [{
+			"message": {
+				"content": "<think>internal reasoning</think><final>The answer is 2</final>"
+			},
+			"finish_reason": "stop"
+		}]
+	}`)
+
+	out, err := parseResponse(body)
+	if err != nil {
+		t.Fatalf("parseResponse() error = %v", err)
+	}
+	if out.Content != "The answer is 2" {
+		t.Fatalf("Content = %q, want %q", out.Content, "The answer is 2")
+	}
+}
+
+func TestParseResponse_StripsEscapedThinkingTags(t *testing.T) {
+	body := strings.NewReader(`{
+		"choices": [{
+			"message": {
+				"content": "\\u003cthink\\u003einternal\\u003c/think\\u003e\\u003cfinal\\u003eOK\\u003c/final\\u003e"
+			},
+			"finish_reason": "stop"
+		}]
+	}`)
+
+	out, err := parseResponse(body)
+	if err != nil {
+		t.Fatalf("parseResponse() error = %v", err)
+	}
+	if out.Content != "OK" {
+		t.Fatalf("Content = %q, want %q", out.Content, "OK")
+	}
+}
+
+func TestParseResponse_DropsUnclosedThinkingBlock(t *testing.T) {
+	body := strings.NewReader(`{
+		"choices": [{
+			"message": {
+				"content": "Visible<think>hidden reasoning"
+			},
+			"finish_reason": "stop"
+		}]
+	}`)
+
+	out, err := parseResponse(body)
+	if err != nil {
+		t.Fatalf("parseResponse() error = %v", err)
+	}
+	if out.Content != "Visible" {
+		t.Fatalf("Content = %q, want %q", out.Content, "Visible")
+	}
+}
+
 func TestProviderChat_PreservesReasoningContentInHistory(t *testing.T) {
 	var requestBody map[string]any
 


### PR DESCRIPTION
## 📝 Description

This PR fixes a leak path in `openai_compat` response parsing where provider-emitted reasoning wrappers (e.g. `<think>...</think>`) can surface in user-facing `content`.

Changes:
- add defensive sanitizer in `parseResponse` to strip thinking/reasoning blocks
- strip `<final>` wrappers while preserving final answer text
- handle escaped bracket forms (`\\u003c`/`\\u003e`)
- drop trailing unclosed thinking block to avoid reasoning leakage
- add focused unit tests for normal, escaped, and unclosed-tag cases

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

Fixes #1235

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
  - https://github.com/openclaw/openclaw/issues/6328
  - https://github.com/openclaw/openclaw/pull/1629
- **Reasoning:**
  - OpenClaw had a similar “Thinking/Final Tag Stripping” leak path and converged on central defensive stripping + variant tests.
  - PicoClaw currently forwarded `message.content` directly in `openai_compat`, so malformed/legacy provider payloads could expose reasoning tags.

## 🧪 Test Environment
- **Hardware:** x86_64 PC
- **OS:** Ubuntu Linux (kernel 6.17)
- **Model/Provider:** OpenAI-compatible provider parser path (unit tests)
- **Channels:** N/A (provider layer)


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```bash
make check
# => PASS
ok   github.com/sipeed/picoclaw/pkg/providers/openai_compat 0.044s
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
