### PR TITLE
feat: add nightly build GitHub Actions workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,70 @@
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    name: GoReleaser Snapshot
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go from go.mod
+        id: setup-go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser (snapshot)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: ~> v2
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          DOCKERHUB_IMAGE_NAME: ${{ vars.DOCKERHUB_REPOSITORY }}
+          GOVERSION: ${{ steps.setup-go.outputs.go-version }}
+
+      - name: Delete existing nightly release and tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
+
+      - name: Create nightly release with artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          SHORT_SHA="${COMMIT_SHA:0:8}"
+          BUILD_DATE="$(date -u +'%Y-%m-%d')"
+          BUILD_TIME="$(date -u +'%Y-%m-%d %H:%M UTC')"
+          gh release create nightly dist/*.tar.gz dist/*.zip dist/*.deb dist/*.rpm \
+            --title "Nightly Build ($BUILD_DATE)" \
+            --notes "Automated nightly build from \`$SHORT_SHA\` on \`$BUILD_TIME\`." \
+            --prerelease \
+            --target "$COMMIT_SHA"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/nightly.yml` that runs daily at 00:00 UTC (and supports manual dispatch)
- Uses GoReleaser `--snapshot` to build all platform artifacts without requiring a git tag
- Deletes and recreates a rolling `nightly` pre-release on each run, keeping a single up-to-date entry with all `.tar.gz`, `.zip`, `.deb`, and `.rpm` artifacts

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` to verify it completes successfully
- [ ] Confirm a `nightly` pre-release appears in the repository releases page with the expected artifacts
- [ ] Wait for the next scheduled run to confirm the old release is replaced correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)