### PR TITLE
fix(agent): auto-inject SKILL.md into LLM context when user references a skill

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -786,12 +786,31 @@ func (cb *ContextBuilder) MatchSkillsInMessage(message string) []string {
 }
 
 // LoadSkillContext loads the full SKILL.md content for the given skill names
-// via the underlying SkillsLoader.
+// via the underlying SkillsLoader. It resolves frontmatter names to directory
+// names so that skills whose metadata name differs from the directory name
+// are loaded correctly.
 func (cb *ContextBuilder) LoadSkillContext(skillNames []string) string {
-	if cb.skillsLoader == nil {
+	if cb.skillsLoader == nil || len(skillNames) == 0 {
 		return ""
 	}
-	return cb.skillsLoader.LoadSkillsForContext(skillNames)
+
+	allSkills := cb.skillsLoader.ListSkills()
+	nameToDir := make(map[string]string, len(allSkills))
+	for _, s := range allSkills {
+		dirName := filepath.Base(filepath.Dir(s.Path))
+		nameToDir[strings.ToLower(s.Name)] = dirName
+	}
+
+	resolved := make([]string, 0, len(skillNames))
+	for _, name := range skillNames {
+		if dir, ok := nameToDir[strings.ToLower(name)]; ok {
+			resolved = append(resolved, dir)
+		} else {
+			resolved = append(resolved, name)
+		}
+	}
+
+	return cb.skillsLoader.LoadSkillsForContext(resolved)
 }
 
 // isSkillNameChar returns true for characters that can appear inside a skill

--- a/pkg/agent/context_skills_test.go
+++ b/pkg/agent/context_skills_test.go
@@ -171,6 +171,35 @@ func TestLoadSkillContext(t *testing.T) {
 	}
 }
 
+func TestLoadSkillContext_MetadataNameDiffersFromDir(t *testing.T) {
+	tmpDir := setupWorkspace(t, nil)
+	defer os.RemoveAll(tmpDir)
+
+	createTestSkill(
+		t,
+		filepath.Join(tmpDir, "skills"),
+		"weather-skill",
+		"weather",
+		"Get weather",
+		"Call the weather API (metadata name test).",
+	)
+
+	cb := NewContextBuilder(tmpDir)
+
+	matched := cb.MatchSkillsInMessage("use the weather skill")
+	if len(matched) == 0 {
+		t.Fatal("expected to match skill by metadata name 'weather'")
+	}
+
+	ctx := cb.LoadSkillContext(matched)
+	if ctx == "" {
+		t.Fatal("expected non-empty skill context when metadata name differs from directory name")
+	}
+	if !strings.Contains(ctx, "metadata name test") {
+		t.Errorf("skill context should contain skill body, got: %s", ctx)
+	}
+}
+
 func TestLoadSkillContext_NilLoader(t *testing.T) {
 	cb := &ContextBuilder{skillsLoader: nil}
 	ctx := cb.LoadSkillContext([]string{"weather"})

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -61,6 +61,7 @@ type processOptions struct {
 	EnableSummary   bool     // Whether to trigger summarization
 	SendResponse    bool     // Whether to send response via bus
 	NoHistory       bool     // If true, don't load session history (for heartbeat)
+	SkillContext    string   // Injected SKILL.md content for matched skills
 }
 
 const (
@@ -802,11 +803,10 @@ func (al *AgentLoop) runAgentLoop(
 	}
 
 	// Auto-inject SKILL.md content when the user references an installed skill.
-	var skillCtx string
 	if matched := agent.ContextBuilder.MatchSkillsInMessage(opts.UserMessage); len(matched) > 0 {
-		skillCtx = agent.ContextBuilder.LoadSkillContext(matched)
+		opts.SkillContext = agent.ContextBuilder.LoadSkillContext(matched)
 		logger.DebugCF("agent", "Skills matched in user message",
-			map[string]any{"matched": matched, "context_len": len(skillCtx)})
+			map[string]any{"matched": matched, "context_len": len(opts.SkillContext)})
 	}
 
 	messages := agent.ContextBuilder.BuildMessages(
@@ -816,7 +816,7 @@ func (al *AgentLoop) runAgentLoop(
 		opts.Media,
 		opts.Channel,
 		opts.ChatID,
-		skillCtx,
+		opts.SkillContext,
 	)
 
 	// Resolve media:// refs to base64 data URLs (streaming)
@@ -1085,6 +1085,7 @@ func (al *AgentLoop) runLLMIteration(
 				messages = agent.ContextBuilder.BuildMessages(
 					newHistory, newSummary, "",
 					nil, opts.Channel, opts.ChatID,
+					opts.SkillContext,
 				)
 				continue
 			}


### PR DESCRIPTION
## 📝 Description

Wire up the existing but unused `LoadSkillsForContext()` so that skill instructions (SKILL.md) are automatically injected into the LLM context when the user's message references an installed skill by name.

**Problem:** The system prompt lists installed skills in an XML `<skills>` summary and tells the LLM: "To use a skill, read its SKILL.md file using the read_file tool." However, smaller and local models (e.g. Ollama qwen3:14b) do not reliably decide to call `read_file` on their own. The LLM only sees the skill name and path — never the actual instructions. This makes skills effectively broken for local model setups.

**Fix:**
- Added `MatchSkillsInMessage()` — case-insensitive whole-word matching of installed skill names against the user message
- Added `LoadSkillContext()` — thin wrapper that calls the previously dead-code `LoadSkillsForContext()`
- Extended `BuildMessages()` with a variadic `skillContext` parameter (backward-compatible — all existing callers unchanged)
- Injected matched skill content as a dynamic (per-request, non-cached) content block in the system message
- Wired matching and injection into `runAgentLoop()` before `BuildMessages()` is called

**Note on Agent Refactor (#1216):** This is a narrow fix that wires up existing dead code (`LoadSkillsForContext` in `pkg/skills/loader.go`), not a new Agent abstraction or semantic expansion. No new concepts are introduced.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1249

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1249
- **Reasoning:** `LoadSkillsForContext()` in `pkg/skills/loader.go:177` was implemented and tested but never called from anywhere in the codebase. The context builder already generates a `<skills>` XML summary in the system prompt (Level 1), but the full SKILL.md content injection (Level 2) was dead code. This PR wires it up with message-level skill name matching so the LLM receives the actual skill instructions when a user references a skill.

## 🧪 Test Environment
- **Hardware:** Raspberry Pi Zero 2 W
- **OS:** Raspberry Pi OS Lite 64-bit
- **Model/Provider:** stepfun/step-3.5-flash:free via OpenRouter
- **Channels:** Telegram

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

all modules verified Run generate... Run generate complete ok github.com/sipeed/picoclaw/cmd/picoclaw 0.829s ok github.com/sipeed/picoclaw/cmd/picoclaw/internal 1.381s ok github.com/sipeed/picoclaw/cmd/picoclaw/internal/agent 2.824s ok github.com/sipeed/picoclaw/cmd/picoclaw/internal/auth 2.033s ok github.com/sipeed/picoclaw/cmd/picoclaw/internal/cron 3.392s ok github.com/sipeed/picoclaw/cmd/picoclaw/internal/gateway 4.196s ok github.com/sipeed/picoclaw/cmd/picoclaw/internal/migrate 4.679s ok github.com/sipeed/picoclaw/cmd/picoclaw/internal/onboard 5.232s ok github.com/sipeed/picoclaw/cmd/picoclaw/internal/skills 5.271s ok github.com/sipeed/picoclaw/cmd/picoclaw/internal/status 5.335s ok github.com/sipeed/picoclaw/cmd/picoclaw/internal/version 5.247s ok github.com/sipeed/picoclaw/cmd/picoclaw-launcher/internal/server 5.304s ok github.com/sipeed/picoclaw/pkg/agent 6.418s ok github.com/sipeed/picoclaw/pkg/auth 5.137s ok github.com/sipeed/picoclaw/pkg/bus 5.052s ok github.com/sipeed/picoclaw/pkg/channels 18.259s ok github.com/sipeed/picoclaw/pkg/channels/discord 5.131s ok github.com/sipeed/picoclaw/pkg/channels/feishu 5.128s ok github.com/sipeed/picoclaw/pkg/channels/irc 5.124s ok github.com/sipeed/picoclaw/pkg/channels/matrix 4.909s ok github.com/sipeed/picoclaw/pkg/channels/slack 4.625s ok github.com/sipeed/picoclaw/pkg/channels/telegram 5.353s ok github.com/sipeed/picoclaw/pkg/channels/wecom 5.489s ok github.com/sipeed/picoclaw/pkg/channels/whatsapp 5.222s ok github.com/sipeed/picoclaw/pkg/commands 5.148s ok github.com/sipeed/picoclaw/pkg/config 5.199s ok github.com/sipeed/picoclaw/pkg/cron 4.531s ok github.com/sipeed/picoclaw/pkg/heartbeat 3.301s ok github.com/sipeed/picoclaw/pkg/identity 3.634s ok github.com/sipeed/picoclaw/pkg/logger 4.057s ok github.com/sipeed/picoclaw/pkg/mcp 4.021s ok github.com/sipeed/picoclaw/pkg/media 4.736s ok github.com/sipeed/picoclaw/pkg/memory 9.930s ok github.com/sipeed/picoclaw/pkg/migrate 4.875s ok github.com/sipeed/picoclaw/pkg/migrate/internal 4.756s ok github.com/sipeed/picoclaw/pkg/migrate/sources/openclaw 5.229s ok github.com/sipeed/picoclaw/pkg/providers 20.150s ok github.com/sipeed/picoclaw/pkg/providers/anthropic 4.491s ok github.com/sipeed/picoclaw/pkg/providers/openai_compat 4.578s ok github.com/sipeed/picoclaw/pkg/routing 3.675s ok github.com/sipeed/picoclaw/pkg/session 3.655s ok github.com/sipeed/picoclaw/pkg/skills 9.172s ok github.com/sipeed/picoclaw/pkg/state 4.545s ok github.com/sipeed/picoclaw/pkg/tools 13.302s ok github.com/sipeed/picoclaw/pkg/utils 3.660s ok github.com/sipeed/picoclaw/pkg/voice 3.956s


</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.