### PR TITLE
fix(qq): use PostGroupMessage for group chat responses

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -343,6 +343,7 @@ func (al *AgentLoop) Run(ctx context.Context) error {
 							Channel: msg.Channel,
 							ChatID:  msg.ChatID,
 							Content: response,
+							Peer:    msg.Peer,
 						})
 						logger.InfoCF("agent", "Published outbound response",
 							map[string]any{

--- a/pkg/bus/types.go
+++ b/pkg/bus/types.go
@@ -33,6 +33,7 @@ type OutboundMessage struct {
 	Channel string `json:"channel"`
 	ChatID  string `json:"chat_id"`
 	Content string `json:"content"`
+	Peer    Peer   `json:"peer"` // routing peer (direct, group, etc.)
 }
 
 // MediaPart describes a single media attachment to send.

--- a/pkg/channels/qq/qq.go
+++ b/pkg/channels/qq/qq.go
@@ -126,13 +126,25 @@ func (c *QQChannel) Send(ctx context.Context, msg bus.OutboundMessage) error {
 		Content: msg.Content,
 	}
 
-	// send C2C message
-	_, err := c.api.PostC2CMessage(ctx, msg.ChatID, msgToCreate)
-	if err != nil {
-		logger.ErrorCF("qq", "Failed to send C2C message", map[string]any{
-			"error": err.Error(),
-		})
-		return fmt.Errorf("qq send: %w", channels.ErrTemporary)
+	// Use appropriate API based on peer type
+	if msg.Peer.Kind == "group" {
+		// send group message
+		_, err := c.api.PostGroupMessage(ctx, msg.ChatID, msgToCreate)
+		if err != nil {
+			logger.ErrorCF("qq", "Failed to send group message", map[string]any{
+				"error": err.Error(),
+			})
+			return fmt.Errorf("qq send: %w", channels.ErrTemporary)
+		}
+	} else {
+		// send C2C (private) message
+		_, err := c.api.PostC2CMessage(ctx, msg.ChatID, msgToCreate)
+		if err != nil {
+			logger.ErrorCF("qq", "Failed to send C2C message", map[string]any{
+				"error": err.Error(),
+			})
+			return fmt.Errorf("qq send: %w", channels.ErrTemporary)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Fixes #1221 - QQ channel was using the wrong API endpoint for group messages.

## Problem

The QQ channel incorrectly used `PostC2CMessage` (private message API) for all messages, including group messages. This caused the bot to fail when responding to @mentions in QQ groups, with API error code 11255 "invalid request".

## Changes

- Added `Peer` field to `OutboundMessage` struct in `pkg/bus/types.go`
- Modified `Send` method in `pkg/channels/qq/qq.go` to check `msg.Peer.Kind`:
  - If "group" → use `PostGroupMessage`
  - Otherwise → use `PostC2CMessage`
- Updated `pkg/agent/loop.go` to pass Peer info when publishing outbound messages

## Testing

The fix correctly routes:
- Group messages to: `POST /v2/groups/{group_id}/messages`
- Private messages to: `POST /v2/users/{user_id}/messages`

---

**Fixes:** sipeed/picoclaw#1221