### PR TITLE
Fix: retryLLM return empty by using incorrect max_tokens

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1495,7 +1495,6 @@ func (al *AgentLoop) summarizeSession(agent *AgentInstance, sessionKey string) {
 	const (
 		maxSummarizationMessages = 10
 		llmMaxRetries            = 3
-		llmMaxTokens             = 1024
 		llmTemperature           = 0.3
 		fallbackMaxContentLength = 200
 	)
@@ -1573,7 +1572,6 @@ func (al *AgentLoop) retryLLMCall(
 	maxRetries int,
 ) (*providers.LLMResponse, error) {
 	const (
-		llmMaxTokens   = 1024
 		llmTemperature = 0.3
 	)
 
@@ -1587,7 +1585,7 @@ func (al *AgentLoop) retryLLMCall(
 			nil,
 			agent.Model,
 			map[string]any{
-				"max_tokens":       llmMaxTokens,
+				"max_tokens":       agent.MaxTokens,
 				"temperature":      llmTemperature,
 				"prompt_cache_key": agent.ID,
 			},
@@ -1612,7 +1610,6 @@ func (al *AgentLoop) summarizeBatch(
 ) (string, error) {
 	const (
 		llmMaxRetries             = 3
-		llmMaxTokens              = 1024
 		llmTemperature            = 0.3
 		fallbackMinContentLength  = 200
 		fallbackMaxContentPercent = 10


### PR DESCRIPTION
## 📝 Description

## Summary
- Fix retryLLM returning empty response by using agent.MaxTokens instead of hardcoded 1024
- Remove duplicate llmMaxTokens constants in summarizeSession and summarizeBatch
- Ensure LLM calls respect the agent's configured token limits during retry scenarios
## Changes
- Replace hardcoded max_tokens (1024) with agent.MaxTokens in retryLLMCall
- Clean up unused llmMaxTokens constants in summarizeSession and summarizeBatch functions

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.