### PR TITLE
feat(telegram): support forum topics with per-topic session isolation

### DIFF
--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -520,14 +520,13 @@ func (c *TelegramChannel) handleMessage(ctx context.Context, message *telego.Mes
 		content = cleaned
 	}
 
-	// Build composite chatID. For forum topics, embed the thread ID in the
-	// chatID as "chatID/threadID" (same pattern as Slack's "channelID/threadTS")
-	// so all outbound methods route replies to the correct topic.
-	// Note: Telegram's "General" topic uses thread ID 1; it is treated like any
-	// other topic for session isolation and agent binding.
+	// For forum topics, embed the thread ID as "chatID/threadID" so replies
+	// route to the correct topic and each topic gets its own session.
+	// Only forum groups (IsForum) are handled; regular group reply threads
+	// must share one session per group.
 	compositeChatID := fmt.Sprintf("%d", chatID)
 	threadID := message.MessageThreadID
-	if threadID != 0 {
+	if message.Chat.IsForum && threadID != 0 {
 		compositeChatID = fmt.Sprintf("%d/%d", chatID, threadID)
 	}
 
@@ -555,9 +554,8 @@ func (c *TelegramChannel) handleMessage(ctx context.Context, message *telego.Mes
 		"is_group":   fmt.Sprintf("%t", message.Chat.Type != "private"),
 	}
 
-	// For forum topic messages, set parent_peer metadata so the routing system
-	// can isolate sessions per topic via the existing 7-level priority cascade.
-	if threadID != 0 {
+	// Set parent_peer metadata for per-topic agent binding.
+	if message.Chat.IsForum && threadID != 0 {
 		metadata["parent_peer_kind"] = "topic"
 		metadata["parent_peer_id"] = fmt.Sprintf("%d", threadID)
 	}
@@ -614,11 +612,8 @@ func (c *TelegramChannel) downloadFile(ctx context.Context, fileID, ext string) 
 	return c.downloadFileWithInfo(file, ext)
 }
 
-// parseTelegramChatID splits a composite chat ID "chatID/threadID" into its
-// components. For non-forum messages the threadID is 0. If the chatID string
-// contains a "/" segment, the second part must be a valid integer thread ID;
-// otherwise an error is returned. This mirrors the Slack adapter (channelID/threadTS).
-// Implemented with strings.Index to avoid allocating a slice in the hot path.
+// parseTelegramChatID splits "chatID/threadID" into its components.
+// Returns threadID=0 when no "/" is present (non-forum messages).
 func parseTelegramChatID(chatID string) (int64, int, error) {
 	idx := strings.Index(chatID, "/")
 	if idx == -1 {

--- a/pkg/channels/telegram/telegram_test.go
+++ b/pkg/channels/telegram/telegram_test.go
@@ -414,3 +414,49 @@ func TestHandleMessage_NoForum_NoThreadMetadata(t *testing.T) {
 	assert.Empty(t, inbound.Metadata["parent_peer_kind"])
 	assert.Empty(t, inbound.Metadata["parent_peer_id"])
 }
+
+func TestHandleMessage_ReplyThread_NonForum_NoIsolation(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	ch := &TelegramChannel{
+		BaseChannel: channels.NewBaseChannel("telegram", nil, messageBus, nil),
+		chatIDs:     make(map[string]int64),
+		ctx:         context.Background(),
+	}
+
+	// In regular groups, reply threads set MessageThreadID to the original
+	// message ID. This should NOT trigger per-thread session isolation.
+	msg := &telego.Message{
+		Text:            "reply in thread",
+		MessageID:       20,
+		MessageThreadID: 15,
+		Chat: telego.Chat{
+			ID:      -100999,
+			Type:    "supergroup",
+			IsForum: false,
+		},
+		From: &telego.User{
+			ID:        9,
+			FirstName: "Carol",
+		},
+	}
+
+	err := ch.handleMessage(context.Background(), msg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	inbound, ok := messageBus.ConsumeInbound(ctx)
+	require.True(t, ok)
+
+	// chatID should NOT include thread suffix for non-forum groups
+	assert.Equal(t, "-100999", inbound.ChatID)
+
+	// Peer ID should be raw chat ID (shared session for whole group)
+	assert.Equal(t, "group", inbound.Peer.Kind)
+	assert.Equal(t, "-100999", inbound.Peer.ID)
+
+	// No parent peer metadata
+	assert.Empty(t, inbound.Metadata["parent_peer_kind"])
+	assert.Empty(t, inbound.Metadata["parent_peer_id"])
+}


### PR DESCRIPTION
## 📝 Description

Add forum topic support for Telegram. Messages in forum topics now get per-topic session isolation and replies are routed back to the correct topic thread. This follows the same composite ID pattern used by the Slack adapter (`chatID/threadID`).

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

#1270


## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://core.telegram.org/bots/api#message (`message_thread_id` field)
- **Reasoning:**
  - Telegram forum groups assign a unique `MessageThreadID` to each topic. We embed this into the chat ID as `chatID/threadID` so that:
    1. **Session isolation** — each topic gets its own session key via `peer.ID`, preventing conversation history from leaking across topics.
    2. **Reply routing** — outbound messages (`Send`, `SendMedia`, `StartTyping`, `SendPlaceholder`, `EditMessage`) parse the composite ID and set `MessageThreadID` on the Telegram API call, so replies land in the correct topic.
    3. **Agent binding** — `parent_peer` metadata (`kind=topic`, `id=<threadID>`) is set for per-topic agent assignment through the existing routing priority cascade.
  - Regular groups and DMs are unaffected (`threadID=0`, no suffix appended).

## 🧪 Test Environment
- **Hardware:** amd64
- **OS:** Ubuntu
- **Model/Provider:** OpenAI GPT-5.2
- **Channels:** Telegram (forum-enabled supergroup with multiple topics)

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

**Topic 2 (session isolated):**
```
[DEBUG] telegram: Received message {chat_id=-1003771129578/2, thread_id=2, preview=My Name is Alice.}
[INFO] agent: Routed message {session_key=agent:main:telegram:group:-1003771129578/2}
```

**Topic 3 (separate session):**
```
[DEBUG] telegram: Received message {chat_id=-1003771129578/3, thread_id=3, preview=what is my name?}
[INFO] agent: Routed message {session_key=agent:main:telegram:group:-1003771129578/3}
```

Session keys differ per topic, confirming isolation works correctly.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
