### PR TITLE
chore: remove duplicated timestamp from Go log output

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -52,6 +52,8 @@ type LogEntry struct {
 func init() {
 	once.Do(func() {
 		logger = &Logger{}
+		// disable default log prefix date & timestamp
+		log.SetFlags(0)
 	})
 }
 


### PR DESCRIPTION
## 📝 Description

This PR removes the duplicated timestamp in log output 
<img width="1586" height="532" alt="image" src="https://github.com/user-attachments/assets/29b5f538-4432-4512-92a0-8c6db8f88114" />


The go standard log package automatically add a timestamp to each log entry, while the project’s logging already includes its own timestamp field. This change disables the default Go log timestamp to avoid redundant time information in logs.

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.