### PR TITLE
fix: avoid printing banner in completion commands, add env PICOCLAW_N…

### DIFF
--- a/cmd/picoclaw/main.go
+++ b/cmd/picoclaw/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -61,8 +62,31 @@ const (
 		"\033[0m\r\n"
 )
 
+// shouldShowBanner returns true if the banner should be displayed.
+// Banner is suppressed when:
+// - PICOCLAW_NO_BANNER environment variable is set to "1" or "true"
+// - Running shell completion commands (e.g., __complete, completion)
+func shouldShowBanner() bool {
+	// Check environment variable
+	if noBanner := os.Getenv("PICOCLAW_NO_BANNER"); noBanner == "1" || strings.ToLower(noBanner) == "true" {
+		return false
+	}
+
+	// Check for shell completion commands
+	// Cobra uses "__complete" and "__completeNoDesc" for completion
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "__complete") || arg == "completion" {
+			return false
+		}
+	}
+
+	return true
+}
+
 func main() {
-	fmt.Printf("%s", banner)
+	if shouldShowBanner() {
+		fmt.Printf("%s", banner)
+	}
 	cmd := NewPicoclawCommand()
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/picoclaw/main_test.go
+++ b/cmd/picoclaw/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"slices"
 	"testing"
 
@@ -52,5 +53,95 @@ func TestNewPicoclawCommand(t *testing.T) {
 		assert.True(t, found, "unexpected subcommand %q", subcmd.Name())
 
 		assert.False(t, subcmd.Hidden)
+	}
+}
+
+func TestShouldShowBanner(t *testing.T) {
+	// Save original args to restore later
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	tests := []struct {
+		name     string
+		args     []string
+		envVar   string
+		expected bool
+	}{
+		{
+			name:     "default shows banner",
+			args:     []string{"picoclaw"},
+			envVar:   "",
+			expected: true,
+		},
+		{
+			name:     "normal command shows banner",
+			args:     []string{"picoclaw", "version"},
+			envVar:   "",
+			expected: true,
+		},
+		{
+			name:     "__complete suppresses banner",
+			args:     []string{"picoclaw", "__complete", "ver"},
+			envVar:   "",
+			expected: false,
+		},
+		{
+			name:     "__completeNoDesc suppresses banner",
+			args:     []string{"picoclaw", "__completeNoDesc", "ver"},
+			envVar:   "",
+			expected: false,
+		},
+		{
+			name:     "completion command suppresses banner",
+			args:     []string{"picoclaw", "completion", "bash"},
+			envVar:   "",
+			expected: false,
+		},
+		{
+			name:     "PICOCLAW_NO_BANNER=1 suppresses banner",
+			args:     []string{"picoclaw", "version"},
+			envVar:   "1",
+			expected: false,
+		},
+		{
+			name:     "PICOCLAW_NO_BANNER=true suppresses banner",
+			args:     []string{"picoclaw", "version"},
+			envVar:   "true",
+			expected: false,
+		},
+		{
+			name:     "PICOCLAW_NO_BANNER=TRUE suppresses banner",
+			args:     []string{"picoclaw", "version"},
+			envVar:   "TRUE",
+			expected: false,
+		},
+		{
+			name:     "PICOCLAW_NO_BANNER=0 does not suppress banner",
+			args:     []string{"picoclaw", "version"},
+			envVar:   "0",
+			expected: true,
+		},
+		{
+			name:     "PICOCLAW_NO_BANNER=false does not suppress banner",
+			args:     []string{"picoclaw", "version"},
+			envVar:   "false",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Args = tt.args
+
+			if tt.envVar != "" {
+				t.Setenv("PICOCLAW_NO_BANNER", tt.envVar)
+			} else {
+				// Clear env var if not set in test
+				os.Unsetenv("PICOCLAW_NO_BANNER")
+			}
+
+			result := shouldShowBanner()
+			assert.Equal(t, tt.expected, result)
+		})
 	}
 }


### PR DESCRIPTION


## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

- avoid printing banner in completion commands
- add env `PICOCLAW_NO_BANNER` to control printing banner or not

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->
Fixes  #1305

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

before: 
<img width="858" height="818" alt="image" src="https://github.com/user-attachments/assets/ae78a5a1-8133-4a09-a887-33bf773802fb" />
after:
<img width="841" height="376" alt="image" src="https://github.com/user-attachments/assets/79e73d38-d74a-4263-a915-c7e49f7314d9" />


</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.