### PR TITLE
Fix(provider) Prevent openrouter Provider models from getting cut

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -183,7 +183,7 @@ func NewAgentInstance(
 				if fullModel == raw {
 					return ensureProtocol(fullModel), true
 				}
-				_, modelID := providers.ExtractProtocol(fullModel)
+				_, modelID := providers.ExtractProtocol(fullModel, cfg.GetAPIBase())
 				if modelID == raw {
 					return ensureProtocol(fullModel), true
 				}

--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -38,15 +38,20 @@ func createCodexAuthProvider() (LLMProvider, error) {
 
 // ExtractProtocol extracts the protocol prefix and model identifier from a model string.
 // If no prefix is specified, it defaults to "openai".
+// If the model is from OpenRouter, it returns the model as is.
 // Examples:
-//   - "openai/gpt-4o" -> ("openai", "gpt-4o")
-//   - "anthropic/claude-sonnet-4.6" -> ("anthropic", "claude-sonnet-4.6")
-//   - "gpt-4o" -> ("openai", "gpt-4o")  // default protocol
-func ExtractProtocol(model string) (protocol, modelID string) {
+//   - "openai/gpt-4o", "https://openrouter.ai/api/v1" -> ("openai", "gpt-4o")
+//   - "anthropic/claude-sonnet-4.6", "https://api.anthropic.com/v1" -> ("anthropic", "claude-sonnet-4.6")
+//   - "gpt-4o", "https://api.openai.com/v1" -> ("openai", "gpt-4o")  // default protocol
+//   - "openrouter/gpt-4o", "https://openrouter.ai/api/v1" -> ("openrouter", "openrouter/gpt-4o")
+func ExtractProtocol(model string, url string) (protocol, modelID string) {
 	model = strings.TrimSpace(model)
 	protocol, modelID, found := strings.Cut(model, "/")
 	if !found {
 		return "openai", model
+	}
+	if strings.Contains(strings.ToLower(url), "openrouter.ai") {
+		return protocol, model
 	}
 	return protocol, modelID
 }
@@ -64,7 +69,7 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 		return nil, "", fmt.Errorf("model is required")
 	}
 
-	protocol, modelID := ExtractProtocol(cfg.Model)
+	protocol, modelID := ExtractProtocol(cfg.Model, cfg.APIBase)
 
 	switch protocol {
 	case "openai":

--- a/pkg/providers/factory_provider_test.go
+++ b/pkg/providers/factory_provider_test.go
@@ -19,6 +19,7 @@ func TestExtractProtocol(t *testing.T) {
 	tests := []struct {
 		name         string
 		model        string
+		apiBase      string
 		wantProtocol string
 		wantModelID  string
 	}{
@@ -64,11 +65,18 @@ func TestExtractProtocol(t *testing.T) {
 			wantProtocol: "nvidia",
 			wantModelID:  "meta/llama-3.1-8b",
 		},
+		{
+			name:         "open router model",
+			model:        "openrouter/llama-3.1-8b",
+			wantProtocol: "openrouter",
+			wantModelID:  "openrouter/llama-3.1-8b",
+			apiBase:      "https://openrouter.ai/api/v1",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			protocol, modelID := ExtractProtocol(tt.model)
+			protocol, modelID := ExtractProtocol(tt.model, tt.apiBase)
 			if protocol != tt.wantProtocol {
 				t.Errorf("ExtractProtocol(%q) protocol = %q, want %q", tt.model, protocol, tt.wantProtocol)
 			}
@@ -96,6 +104,27 @@ func TestCreateProviderFromConfig_OpenAI(t *testing.T) {
 	}
 	if modelID != "gpt-4o" {
 		t.Errorf("modelID = %q, want %q", modelID, "gpt-4o")
+	}
+}
+
+func TestCreateProviderFromConfig_OpenRouter(t *testing.T) {
+	target := "openai/gpt-4o"
+	cfg := &config.ModelConfig{
+		ModelName: "test-openai",
+		Model:     target,
+		APIKey:    "test-key",
+		APIBase:   "https://openrouter.ai/api/v1",
+	}
+
+	provider, modelID, err := CreateProviderFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("CreateProviderFromConfig() error = %v", err)
+	}
+	if provider == nil {
+		t.Fatal("CreateProviderFromConfig() returned nil provider")
+	}
+	if modelID != target {
+		t.Errorf("modelID = %q, want %q", modelID, target)
 	}
 }
 

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -523,6 +523,27 @@ func TestNormalizeModel_UsesAPIBase(t *testing.T) {
 	if got := normalizeModel("vivgrid/auto", "https://api.vivgrid.com/v1"); got != "auto" {
 		t.Fatalf("normalizeModel(vivgrid auto) = %q, want %q", got, "auto")
 	}
+
+	// Bug fix: qwen/qwen3-235b-a22b-2507 sent to openrouter.ai must be preserved in full
+	if got := normalizeModel("qwen/qwen3-235b-a22b-2507", "https://openrouter.ai/api/v1"); got != "qwen/qwen3-235b-a22b-2507" {
+		t.Fatalf("normalizeModel(qwen@openrouter) = %q, want %q", got, "qwen/qwen3-235b-a22b-2507")
+	}
+	// Same prefix, different (native) provider: strip the prefix
+	if got := normalizeModel("qwen/qwen3-235b-a22b-2507", "https://dashscope.aliyuncs.com/compatible-mode/v1"); got != "qwen3-235b-a22b-2507" {
+		t.Fatalf("normalizeModel(qwen@dashscope) = %q, want %q", got, "qwen3-235b-a22b-2507")
+	}
+	// openai/ prefix should be stripped for non-openrouter providers
+	if got := normalizeModel("openai/gpt-4o", "https://api.openai.com/v1"); got != "gpt-4o" {
+		t.Fatalf("normalizeModel(openai) = %q, want %q", got, "gpt-4o")
+	}
+	// anthropic/ prefix should be stripped for non-openrouter providers
+	if got := normalizeModel("anthropic/claude-sonnet-4.6", "https://api.anthropic.com/v1"); got != "claude-sonnet-4.6" {
+		t.Fatalf("normalizeModel(anthropic) = %q, want %q", got, "claude-sonnet-4.6")
+	}
+	// Models with unknown prefix are left unchanged
+	if got := normalizeModel("meta-llama/llama-3.1-8b", "https://openrouter.ai/api/v1"); got != "meta-llama/llama-3.1-8b" {
+		t.Fatalf("normalizeModel(meta-llama@openrouter) = %q, want %q", got, "meta-llama/llama-3.1-8b")
+	}
 }
 
 func TestProvider_RequestTimeoutDefault(t *testing.T) {


### PR DESCRIPTION
# 📝 Description
This PR fixes an issue where model name prefixes (e.g., `qwen/`) were being incorrectly truncated when using the **OpenRouter** provider. For OpenRouter, vendor prefixes are required to correctly route the request (e.g., `qwen/qwen3-next-80b-a3b-instruct:free`).

The fix updates `ExtractProtocol` to be aware of the `APIBase`. When the URL contains `openrouter.ai`, the full model identifier (including the vendor prefix) is preserved as the `modelID`, while still allowing standard prefix-stripping for native providers (like Groq or OpenAI) to maintain backward compatibility.

## 🚀 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactor

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated
- [ ] 🛠️ Mostly AI-generated
- [x] 👨‍💻 Mostly Human-written (Developed with AI assistance but human-led implementation)

## 🔗 Related Issue
https://github.com/sipeed/picoclaw/issues/1247

## 🛠️ Technical Context
The core problem was that `ExtractProtocol` was stripping everything before the first slash unconditionally. This PR modifies `ExtractProtocol` to accept the `apiBase` URL. If the URL points to OpenRouter, the full model string (e.g., `qwen/model-id`) is returned.

### Example Config:

#### Before (Broken - Prefix cut)
```json
{
  "model_name": "openrouter-free",
  "model": "stepfun/step-3.5-flash:free",
  "api_key": "",
  "api_base": "https://openrouter.ai/api/v1"
}
```

#### After (Previously required workaround)
```json
{
  "model_name": "openrouter-free",
  "model": "gemini/stepfun/step-3.5-flash:free",
  "api_key": "",
  "api_base": "https://openrouter.ai/api/v1"
}
```


Relevant changes:
- **`pkg/providers/factory_provider.go`**: Modified `ExtractProtocol` to accept `url` and `CreateProviderFromConfig` to pass `cfg.APIBase`.
- **`pkg/agent/instance.go`**: Updated the `ensureProtocol` helper to correctly pass the API base.
- **`pkg/providers/factory_provider_test.go`**: Added test cases for the new URL-aware protocol extraction.
- **`pkg/providers/openai_compat/provider_test.go`**: Added regression tests for model normalization with OpenRouter.

## 🧪 Test Environment
- **OS**: macOS
- **Go Version**: 1.25+
- **Provider**: OpenRouter
- **Model tested**: `qwen/qwen3-235b-a22b-2507`

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] `make check` passes locally
