### PR TITLE
fix(agent): skip final reply only when message tool sent to same chat

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -346,7 +346,7 @@ func (al *AgentLoop) Run(ctx context.Context) error {
 					if defaultAgent != nil {
 						if tool, ok := defaultAgent.Tools.Get("message"); ok {
 							if mt, ok := tool.(*tools.MessageTool); ok {
-								alreadySent = mt.HasSentInRound() && mt.SentToChatID() == msg.ChatID
+								alreadySent = mt.HasSentInRound() && mt.HasSentToChatID(msg.ChatID)
 							}
 						}
 					}

--- a/pkg/tools/message.go
+++ b/pkg/tools/message.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 )
 
@@ -10,8 +11,10 @@ type SendCallback func(channel, chatID, content string) error
 
 type MessageTool struct {
 	sendCallback SendCallback
-	sentInRound  atomic.Bool  // Tracks whether a message was sent in the current processing round
-	sentChatID   atomic.Value // Tracks the chat_id that the message was sent to in the current round
+	sentInRound  atomic.Bool // Tracks whether a message was sent in the current processing round
+
+	mu          sync.Mutex        // protects sentChatIDs
+	sentChatIDs map[string]struct{} // All chat_ids the message tool sent to in the current round
 }
 
 func NewMessageTool() *MessageTool {
@@ -51,7 +54,9 @@ func (t *MessageTool) Parameters() map[string]any {
 // Called by the agent loop at the start of each inbound message processing round.
 func (t *MessageTool) ResetSentInRound() {
 	t.sentInRound.Store(false)
-	t.sentChatID.Store("")
+	t.mu.Lock()
+	t.sentChatIDs = nil
+	t.mu.Unlock()
 }
 
 // HasSentInRound returns true if the message tool sent a message during the current round.
@@ -59,10 +64,12 @@ func (t *MessageTool) HasSentInRound() bool {
 	return t.sentInRound.Load()
 }
 
-// SentToChatID returns the chat_id that the message was sent to in the current round.
-func (t *MessageTool) SentToChatID() string {
-	v, _ := t.sentChatID.Load().(string)
-	return v
+// HasSentToChatID returns true if the message tool sent to the given chat_id in this round.
+func (t *MessageTool) HasSentToChatID(chatID string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, ok := t.sentChatIDs[chatID]
+	return ok
 }
 
 func (t *MessageTool) SetSendCallback(callback SendCallback) {
@@ -102,7 +109,12 @@ func (t *MessageTool) Execute(ctx context.Context, args map[string]any) *ToolRes
 	}
 
 	t.sentInRound.Store(true)
-	t.sentChatID.Store(chatID)
+	t.mu.Lock()
+	if t.sentChatIDs == nil {
+		t.sentChatIDs = make(map[string]struct{})
+	}
+	t.sentChatIDs[chatID] = struct{}{}
+	t.mu.Unlock()
 	// Silent: user already received the message directly
 	return &ToolResult{
 		ForLLM: fmt.Sprintf("Message sent to %s:%s", channel, chatID),


### PR DESCRIPTION
## Summary

- Fix: when the message tool sends to a different chat_id (e.g. a newly created Feishu group), the final reply to the original chat was incorrectly suppressed
- Track the target chat_id in `MessageTool` and only skip the outbound reply when it matches the inbound message's chat_id

## Changes

- `pkg/tools/message.go`: add `sentChatID` field, `SentToChatID()` method, reset in `ResetSentInRound`
- `pkg/agent/loop.go`: `alreadySent` condition now checks `SentToChatID() == msg.ChatID`

## Test Plan

- [x] `go test ./pkg/tools/` — passed
- [x] `go test ./pkg/agent/` — passed
- [x] `go vet` — clean
- [x] Manual test: bot creates Feishu group and sends message to it, original private chat still receives the final reply

## bug behavior
拉群之后，能在新群里发消息，但是在原始对话里无法继续。
After bot create group and send messages in the new group, the bot can not send messages in the old chat, which still have a streaming stuck card
<img width="373" height="361" alt="image" src="https://github.com/user-attachments/assets/1f1e979a-1bb6-481c-b003-b49355c1bbfd" />

