### PR TITLE
fix(providers): resolve correct provider per fallback candidate

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -48,6 +48,7 @@ type AgentLoop struct {
 	mediaStore     media.MediaStore
 	transcriber    voice.Transcriber
 	cmdRegistry    *commands.Registry
+	providerCache  sync.Map // map[string]providers.LLMProvider — lazily created per provider/model
 }
 
 // processOptions configures how a message is processed
@@ -233,6 +234,45 @@ func registerSharedTools(
 			}
 		}
 	}
+}
+
+// resolveProvider returns the correct LLM provider for a fallback candidate.
+// It lazily creates and caches provider instances per provider/model key so that
+// each candidate uses its own API key and endpoint from the model_list config.
+func (al *AgentLoop) resolveProvider(
+	providerName, model string,
+	fallbackProvider providers.LLMProvider,
+) providers.LLMProvider {
+	key := providers.ModelKey(providerName, model)
+
+	if cached, ok := al.providerCache.Load(key); ok {
+		return cached.(providers.LLMProvider)
+	}
+
+	// Search model_list for a config entry matching this provider/model.
+	target := providerName + "/" + model
+	for i := range al.cfg.ModelList {
+		entryModel := strings.TrimSpace(al.cfg.ModelList[i].Model)
+		if !strings.EqualFold(entryModel, target) {
+			continue
+		}
+		mc := al.cfg.ModelList[i]
+		if mc.Workspace == "" {
+			mc.Workspace = al.cfg.WorkspacePath()
+		}
+		p, _, err := providers.CreateProviderFromConfig(&mc)
+		if err != nil {
+			logger.WarnCF("agent", "Failed to create provider for fallback candidate, using default",
+				map[string]any{"candidate": target, "error": err.Error()})
+			break
+		}
+		al.providerCache.Store(key, p)
+		return p
+	}
+
+	// Not found or creation failed — fall back to agent's default provider.
+	al.providerCache.Store(key, fallbackProvider)
+	return fallbackProvider
 }
 
 func (al *AgentLoop) Run(ctx context.Context) error {
@@ -939,7 +979,8 @@ func (al *AgentLoop) runLLMIteration(
 					ctx,
 					activeCandidates,
 					func(ctx context.Context, provider, model string) (*providers.LLMResponse, error) {
-						return agent.Provider.Chat(ctx, messages, providerToolDefs, model, llmOpts)
+						p := al.resolveProvider(provider, model, agent.Provider)
+						return p.Chat(ctx, messages, providerToolDefs, model, llmOpts)
 					},
 				)
 				if fbErr != nil {


### PR DESCRIPTION
## Summary

- Fix: fallback chain reused the primary model's provider instance (API key + endpoint) for all candidates
- When the primary model was zhipu and fallbacks were moonshot/anthropic/minimax, every fallback request was sent with zhipu's API key, causing 401 across the board
- Add a lazy `resolveProvider` method that looks up each candidate's `ModelConfig` from `model_list` and creates the correct provider instance with the right API key and base URL

## Root Cause

The `run` closure in the fallback execution always called `agent.Provider.Chat()`, where `agent.Provider` was the single provider instance created at startup for the primary model. Although the fallback chain correctly identified candidates like `moonshot/kimi-k2.5`, the actual HTTP requests were sent through the primary (zhipu) provider with the wrong credentials.

## Changes

- `pkg/agent/loop.go`:
  - Add `providerCache sync.Map` field to `AgentLoop`
  - Add `resolveProvider(providerName, model, fallbackProvider)` method that lazily creates and caches providers per candidate from `model_list` config
  - Update fallback `run` closure to use `resolveProvider()` instead of `agent.Provider`

## Test Plan

- [x] `go test ./pkg/agent/` — passed
- [x] `go test ./pkg/providers/` — passed
- [x] `make vet` — clean
- [ ] Manual test: intentionally break primary model key, verify fallback correctly switches to other providers