### PR TITLE
fix(config): correct off-by-one in round-robin model selection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -914,8 +914,11 @@ func (c *Config) GetModelConfig(modelName string) (*ModelConfig, error) {
 		return &matches[0], nil
 	}
 
-	// Multiple configs - use round-robin for load balancing
-	idx := rrCounter.Add(1) % uint64(len(matches))
+	// Multiple configs - use round-robin for load balancing.
+	// Subtract 1 because Add returns the new (post-increment) value,
+	// so without the subtraction the first entry (index 0) is skipped
+	// on the initial call.
+	idx := (rrCounter.Add(1) - 1) % uint64(len(matches))
 	return &matches[idx], nil
 }
 

--- a/pkg/config/model_config_test.go
+++ b/pkg/config/model_config_test.go
@@ -80,6 +80,55 @@ func TestGetModelConfig_RoundRobin(t *testing.T) {
 	}
 }
 
+func TestGetModelConfig_RoundRobinSequence(t *testing.T) {
+	cfg := &Config{
+		ModelList: []ModelConfig{
+			{ModelName: "seq-model", Model: "openai/model-a", APIKey: "key1"},
+			{ModelName: "seq-model", Model: "openai/model-b", APIKey: "key2"},
+			{ModelName: "seq-model", Model: "openai/model-c", APIKey: "key3"},
+		},
+	}
+
+	// Three consecutive calls must produce three distinct models,
+	// proving that every entry is reachable within one full cycle.
+	seen := make(map[string]bool)
+	for range 3 {
+		result, err := cfg.GetModelConfig("seq-model")
+		if err != nil {
+			t.Fatalf("GetModelConfig() error = %v", err)
+		}
+		seen[result.Model] = true
+	}
+
+	if len(seen) != 3 {
+		t.Errorf("Expected all 3 models within one cycle, got %d distinct: %v", len(seen), seen)
+	}
+}
+
+func TestGetModelConfig_TwoEntries_BothReachable(t *testing.T) {
+	cfg := &Config{
+		ModelList: []ModelConfig{
+			{ModelName: "pair", Model: "openai/first", APIKey: "key1"},
+			{ModelName: "pair", Model: "openai/second", APIKey: "key2"},
+		},
+	}
+
+	// Two calls must hit both entries — the old off-by-one bug caused the
+	// first entry to be skipped on every other pair of calls.
+	seen := make(map[string]bool)
+	for range 2 {
+		result, err := cfg.GetModelConfig("pair")
+		if err != nil {
+			t.Fatalf("GetModelConfig() error = %v", err)
+		}
+		seen[result.Model] = true
+	}
+
+	if !seen["openai/first"] || !seen["openai/second"] {
+		t.Errorf("Both entries should be reachable within 2 calls, got: %v", seen)
+	}
+}
+
 func TestGetModelConfig_Concurrent(t *testing.T) {
 	cfg := &Config{
 		ModelList: []ModelConfig{


### PR DESCRIPTION
Closes #1153

## Problem

When multiple `model_list` entries share the same `model_name` (for load
balancing), the round-robin selector in `GetModelConfig` always skips the
first entry on its initial call.

**Root cause:** `rrCounter.Add(1)` returns the *post-increment* value (1 on
the first call), so `1 % N` resolves to index 1 — the second entry.  The
first entry (index 0) is only reached after N calls instead of on the very
first call.

With 3 entries the observed pattern is: 2nd → 3rd → 1st → 2nd → ...
instead of: 1st → 2nd → 3rd → 1st → ...

## Fix

Subtract 1 from the counter before the modulo operation:

```go
idx := (rrCounter.Add(1) - 1) % uint64(len(matches))
```

This makes the sequence start at index 0 while keeping atomic increment
semantics for concurrent safety.

## Tests

- `TestGetModelConfig_RoundRobinSequence` — 3 entries, verifies all 3 are
  reached within one full cycle.
- `TestGetModelConfig_TwoEntries_BothReachable` — 2 entries, verifies both
  are hit within 2 calls.
- All existing config tests continue to pass.