### PR TITLE
fix(provider): enable reasoning_split for MiniMax to separate CoT from content

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -163,6 +163,13 @@ func (p *Provider) Chat(
 		}
 	}
 
+	// MiniMax provider: enable reasoning_split to separate CoT from content
+	// This prevents chain-of-thought from leaking into the main content field.
+	// See: https://github.com/sipeed/picoclaw/issues/1320
+	if strings.Contains(strings.ToLower(p.apiBase), "minimaxi.com") {
+		requestBody["reasoning_split"] = true
+	}
+
 	jsonData, err := json.Marshal(requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)


### PR DESCRIPTION
## 📝 Description

Enable `reasoning_split` parameter for MiniMax provider API requests to prevent chain-of-thought from leaking into the main content field.

MiniMax's `v1/chat/completions` endpoint includes thinking/CoT content directly in the `content` field by default, causing reasoning text (wrapped in `<thinkceria>` tags) to appear in user-visible responses.

With `reasoning_split: true`, MiniMax separates CoT into `reasoning_details` field, which PicoClaw already handles correctly via existing parsing logic.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1320

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1320
- **Reasoning:**
  - MiniMax API `v1/chat/completions` puts CoT in `content` field unless `reasoning_split: true` is passed
  - With the flag, CoT is returned in `reasoning_details` array instead
  - PicoClaw already parses `reasoning_details` in `openai_compat/provider.go:281`
  - Detection is done by checking if `apiBase` contains `minimaxi.com`

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows
- **Model/Provider:** MiniMax-M2.5 (api.minimaxi.com)
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view API Test Results</summary>

**Without `reasoning_split`:**
```json
{
  "content": "<thinkceria>The user asks 1+1...</thinkceria>1+1=2"
}
```

**With `reasoning_split: true`:**
```json
{
  "content": "1 + 1 = 2",
  "reasoning_details": [{"type": "reasoning.text", "text": "The user asks 1+1..."}]
}
```

**Test results:**
```
=== RUN   TestProviderChat_ParsesReasoningContent
--- PASS
...all 21 tests PASS
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.