### PR TITLE
fix(openai_compat): only send prompt_cache_key to OpenAI endpoints

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -156,9 +156,10 @@ func (p *Provider) Chat(
 	// The key is typically the agent ID — stable per agent, shared across requests.
 	// See: https://platform.openai.com/docs/guides/prompt-caching
 	// Prompt caching is only supported by OpenAI-native endpoints.
-	// Gemini and other providers reject unknown fields, so skip for non-OpenAI APIs.
+	// Non-OpenAI providers (Mistral, Gemini, DeepSeek, etc.) reject unknown
+	// fields with 422 errors, so only include it for OpenAI APIs.
 	if cacheKey, ok := options["prompt_cache_key"].(string); ok && cacheKey != "" {
-		if !strings.Contains(p.apiBase, "generativelanguage.googleapis.com") {
+		if supportsPromptCacheKey(p.apiBase) {
 			requestBody["prompt_cache_key"] = cacheKey
 		}
 	}
@@ -475,4 +476,12 @@ func asFloat(v any) (float64, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// supportsPromptCacheKey reports whether the given API base is known to
+// support the prompt_cache_key request field. Currently only OpenAI's own
+// API supports this. All other OpenAI-compatible providers (Mistral,
+// Gemini, DeepSeek, Groq, etc.) reject unknown fields with 422 errors.
+func supportsPromptCacheKey(apiBase string) bool {
+	return strings.Contains(apiBase, "api.openai.com")
 }

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -669,6 +669,136 @@ func TestSerializeMessages_MediaWithToolCallID(t *testing.T) {
 	}
 }
 
+func TestProviderChat_PromptCacheKeySentToOpenAI(t *testing.T) {
+	var requestBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{
+					"message":       map[string]any{"content": "ok"},
+					"finish_reason": "stop",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	// Simulate an OpenAI endpoint by overriding the apiBase after creation.
+	p := NewProvider("key", server.URL, "")
+	p.apiBase = "https://api.openai.com/v1"
+	// Point the HTTP client at our test server instead.
+	p.httpClient = &http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			// Redirect all requests to the test server.
+			r.URL, _ = url.Parse(server.URL + r.URL.Path)
+			return http.DefaultTransport.RoundTrip(r)
+		}),
+	}
+
+	_, err := p.Chat(
+		t.Context(),
+		[]Message{{Role: "user", Content: "hi"}},
+		nil,
+		"gpt-4o",
+		map[string]any{"prompt_cache_key": "agent-main"},
+	)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+	if requestBody["prompt_cache_key"] != "agent-main" {
+		t.Fatalf("prompt_cache_key = %v, want %q", requestBody["prompt_cache_key"], "agent-main")
+	}
+}
+
+func TestProviderChat_PromptCacheKeyOmittedForNonOpenAI(t *testing.T) {
+	tests := []struct {
+		name    string
+		apiBase string
+	}{
+		{"mistral", "https://api.mistral.ai/v1"},
+		{"gemini", "https://generativelanguage.googleapis.com/v1beta"},
+		{"deepseek", "https://api.deepseek.com/v1"},
+		{"groq", "https://api.groq.com/openai/v1"},
+		{"minimax", "https://api.minimaxi.com/v1"},
+		{"ollama_local", "http://localhost:11434/v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestBody map[string]any
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				resp := map[string]any{
+					"choices": []map[string]any{
+						{
+							"message":       map[string]any{"content": "ok"},
+							"finish_reason": "stop",
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			}))
+			defer server.Close()
+
+			p := NewProvider("key", server.URL, "")
+			p.apiBase = tt.apiBase
+			p.httpClient = &http.Client{
+				Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+					r.URL, _ = url.Parse(server.URL + r.URL.Path)
+					return http.DefaultTransport.RoundTrip(r)
+				}),
+			}
+
+			_, err := p.Chat(
+				t.Context(),
+				[]Message{{Role: "user", Content: "hi"}},
+				nil,
+				"test-model",
+				map[string]any{"prompt_cache_key": "agent-main"},
+			)
+			if err != nil {
+				t.Fatalf("Chat() error = %v", err)
+			}
+			if _, exists := requestBody["prompt_cache_key"]; exists {
+				t.Fatalf("prompt_cache_key should NOT be sent to %s, but was included in request", tt.name)
+			}
+		})
+	}
+}
+
+func TestSupportsPromptCacheKey(t *testing.T) {
+	tests := []struct {
+		apiBase string
+		want    bool
+	}{
+		{"https://api.openai.com/v1", true},
+		{"https://api.openai.com/v1/", true},
+		{"https://api.mistral.ai/v1", false},
+		{"https://generativelanguage.googleapis.com/v1beta", false},
+		{"https://api.deepseek.com/v1", false},
+		{"https://api.groq.com/openai/v1", false},
+		{"http://localhost:11434/v1", false},
+		{"https://openrouter.ai/api/v1", false},
+	}
+	for _, tt := range tests {
+		if got := supportsPromptCacheKey(tt.apiBase); got != tt.want {
+			t.Errorf("supportsPromptCacheKey(%q) = %v, want %v", tt.apiBase, got, tt.want)
+		}
+	}
+}
+
 func TestSerializeMessages_StripsSystemParts(t *testing.T) {
 	messages := []protocoltypes.Message{
 		{


### PR DESCRIPTION
  Non-OpenAI providers (Mistral, DeepSeek, Groq, Minimax, etc.) reject unknown request fields  
  with HTTP 422 errors. The `prompt_cache_key` field was being sent to all providers except    
  Google/Gemini, even though the existing code comment already stated: *"Prompt caching is only
   supported by OpenAI-native endpoints."*

  This PR flips the logic from a **blocklist** (skip Google) to an **allowlist** (only send to 
  `api.openai.com`), which matches the comment's stated intent and fixes the 422 error for     
  Mistral and all other non-OpenAI providers.

  ## 🗣️ Type of Change

  - [x] 🐞 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 📖 Documentation update
  - [ ] ⚡ Code refactoring (no functional changes, no api changes)

  ## 🤖 AI Code Generation

  - [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
  - [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
  - [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

  AI provided the initial code draft. I reviewed, modified, and validated the changes.

  ## 🔗 Related Issue

  Fixes #1333

  ## 📚 Technical Context

  - **Reference URL:**
    - https://platform.openai.com/docs/guides/prompt-caching
  - **Reasoning:**
    - Old blocklist (`!contains("googleapis.com")`) only excluded Google, but 15+ providers    
  route through `openai_compat`
    - Only OpenAI's API supports `prompt_cache_key` — allowlist (`contains("api.openai.com")`) 
  is safer
    - New providers work by default without 422 errors

  ## 🧪 Test Environment

  - **Hardware:** PC
  - **OS:** Windows 11
  - **Model/Provider:** Tested with unit tests against Mistral, Gemini, DeepSeek, Groq,        
  Minimax, Ollama, and OpenAI API bases
  - **Channels:** N/A (provider-level fix)

  <details><summary>📸 Evidence</summary>

  ok    github.com/sipeed/picoclaw/pkg/providers/openai_compat  1.850s

  Tests added:
  - `TestProviderChat_PromptCacheKeySentToOpenAI` — verifies OpenAI still gets the field       
  - `TestProviderChat_PromptCacheKeyOmittedForNonOpenAI` — 6 providers excluded
  - `TestSupportsPromptCacheKey` — unit test for allowlist helper

  </details>

  ## ☑️ Checklist

  - [x] My code/docs follow the style of this project.
  - [x] I have performed a self-review of my own changes.
  - [x] I have updated the documentation accordingly.
