### PR TITLE
fix: spawn tool now respects target agent's model config

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -224,6 +224,13 @@ func registerSharedTools(
 			if cfg.Tools.IsToolEnabled("subagent") {
 				subagentManager := tools.NewSubagentManager(provider, agent.Model, agent.Workspace)
 				subagentManager.SetLLMOptions(agent.MaxTokens, agent.Temperature)
+				// Set model resolver so spawn can use target agent's model
+				subagentManager.SetModelResolver(func(targetAgentID string) string {
+					if targetAgent, ok := registry.GetAgent(targetAgentID); ok {
+						return targetAgent.Model
+					}
+					return ""
+				})
 				spawnTool := tools.NewSpawnTool(subagentManager)
 				currentAgentID := agentID
 				spawnTool.SetAllowlistChecker(func(targetAgentID string) bool {

--- a/pkg/tools/spawn_test.go
+++ b/pkg/tools/spawn_test.go
@@ -77,3 +77,38 @@ func TestSpawnTool_Execute_NilManager(t *testing.T) {
 		t.Errorf("Error message should mention manager not configured, got: %s", result.ForLLM)
 	}
 }
+
+func TestSubagentManager_ModelResolver(t *testing.T) {
+	provider := &MockLLMProvider{}
+	manager := NewSubagentManager(provider, "default-model", "/tmp/test")
+
+	// Set up model resolver
+	resolvedAgentID := ""
+	manager.SetModelResolver(func(agentID string) string {
+		resolvedAgentID = agentID
+		if agentID == "premium-agent" {
+			return "gpt-4"
+		}
+		return ""
+	})
+
+	// Verify resolver is set
+	if manager.modelResolver == nil {
+		t.Fatal("Model resolver should be set")
+	}
+
+	// Test resolver is called with correct agent ID
+	result := manager.modelResolver("premium-agent")
+	if resolvedAgentID != "premium-agent" {
+		t.Errorf("Expected resolver to be called with 'premium-agent', got '%s'", resolvedAgentID)
+	}
+	if result != "gpt-4" {
+		t.Errorf("Expected 'gpt-4', got '%s'", result)
+	}
+
+	// Test fallback for unknown agent
+	result = manager.modelResolver("unknown-agent")
+	if result != "" {
+		t.Errorf("Expected empty string for unknown agent, got '%s'", result)
+	}
+}

--- a/pkg/tools/subagent.go
+++ b/pkg/tools/subagent.go
@@ -34,6 +34,9 @@ type SubagentManager struct {
 	hasMaxTokens   bool
 	hasTemperature bool
 	nextID         int
+	// modelResolver resolves agentID to model name.
+	// Returns empty string if agent not found (falls back to defaultModel).
+	modelResolver func(agentID string) string
 }
 
 func NewSubagentManager(
@@ -59,6 +62,16 @@ func (sm *SubagentManager) SetLLMOptions(maxTokens int, temperature float64) {
 	sm.hasMaxTokens = true
 	sm.temperature = temperature
 	sm.hasTemperature = true
+}
+
+// SetModelResolver sets a function to resolve agentID to model name.
+// When spawn is called with agent_id, this resolver is used to get the
+// target agent's configured model. If the resolver returns empty string
+// or is not set, falls back to the defaultModel.
+func (sm *SubagentManager) SetModelResolver(resolver func(agentID string) string) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.modelResolver = resolver
 }
 
 // SetTools sets the tool registry for subagent execution.
@@ -147,7 +160,17 @@ After completing the task, provide a clear summary of what was done.`
 	temperature := sm.temperature
 	hasMaxTokens := sm.hasMaxTokens
 	hasTemperature := sm.hasTemperature
+	modelResolver := sm.modelResolver
+	defaultModel := sm.defaultModel
 	sm.mu.RUnlock()
+
+	// Resolve target agent model if agentID is specified
+	model := defaultModel
+	if task.AgentID != "" && modelResolver != nil {
+		if resolvedModel := modelResolver(task.AgentID); resolvedModel != "" {
+			model = resolvedModel
+		}
+	}
 
 	var llmOptions map[string]any
 	if hasMaxTokens || hasTemperature {
@@ -162,7 +185,7 @@ After completing the task, provide a clear summary of what was done.`
 
 	loopResult, err := RunToolLoop(ctx, ToolLoopConfig{
 		Provider:      sm.provider,
-		Model:         sm.defaultModel,
+		Model:         model,
 		Tools:         tools,
 		MaxIterations: maxIter,
 		LLMOptions:    llmOptions,


### PR DESCRIPTION
## Summary
Fixes #1322

Previously, when `spawn` tool was called with `agent_id` parameter, the subagent would use the caller agent's model instead of the target agent's configured model.

## Changes
- Add `modelResolver` field to `SubagentManager`
- Add `SetModelResolver()` method to inject model resolution function
- In `runTask()`, use target agent's model when `agent_id` is specified
- Add test case for model resolver functionality

## Test Plan
- [x] All existing tests pass (`go test ./pkg/tools/... ./pkg/agent/...`)
- [x] New `TestSubagentManager_ModelResolver` test passes
- [x] Build succeeds (`go build ./...`)