### PR TITLE
fix: keep raw JSON editor full-height in Firefox

### DIFF
--- a/web/frontend/src/components/config/raw-json-panel.tsx
+++ b/web/frontend/src/components/config/raw-json-panel.tsx
@@ -22,7 +22,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { Textarea } from "@/components/ui/textarea"
 
 export function RawJsonPanel() {
@@ -142,17 +141,15 @@ export function RawJsonPanel() {
               </div>
             )}
             <div className="bg-muted/30 relative rounded-lg border">
-              <ScrollArea className="h-[calc(100vh-20rem)] min-h-[200px]">
-                <Textarea
-                  value={effectiveEditorValue}
-                  onChange={(e) => {
-                    setEditorValue(e.target.value)
-                    setIsDirty(true)
-                  }}
-                  className="min-h-[200px] resize-none border-0 bg-transparent px-4 py-3 font-mono text-sm shadow-none focus-visible:ring-0"
-                  placeholder={t("pages.config.json_placeholder")}
-                />
-              </ScrollArea>
+              <Textarea
+                value={effectiveEditorValue}
+                onChange={(e) => {
+                  setEditorValue(e.target.value)
+                  setIsDirty(true)
+                }}
+                className="h-[calc(100vh-20rem)] min-h-[200px] w-full resize-none overflow-auto border-0 bg-transparent px-4 py-3 font-mono text-sm shadow-none focus-visible:ring-0"
+                placeholder={t("pages.config.json_placeholder")}
+              />
             </div>
             <div className="flex justify-end space-x-2">
               <Button


### PR DESCRIPTION
## Summary
- remove the Radix `ScrollArea` wrapper around the raw JSON editor
- let the native `textarea` own scrolling and explicit height sizing
- keep the existing desktop height and minimum height behavior

Fixes #1364

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/components/config/raw-json-panel.tsx`