### PR TITLE
fix: preserve openrouter model ids with custom api_base

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -433,6 +433,10 @@ func normalizeModel(model, apiBase string) string {
 		return model
 	}
 
+	if strings.HasPrefix(strings.ToLower(model), "openrouter/") {
+		return model
+	}
+
 	if strings.Contains(strings.ToLower(apiBase), "openrouter.ai") {
 		return model
 	}

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -517,6 +517,9 @@ func TestNormalizeModel_UsesAPIBase(t *testing.T) {
 	if got := normalizeModel("openrouter/auto", "https://openrouter.ai/api/v1"); got != "openrouter/auto" {
 		t.Fatalf("normalizeModel(openrouter) = %q, want %q", got, "openrouter/auto")
 	}
+	if got := normalizeModel("openrouter/free", "https://gateway.example.com/v1"); got != "openrouter/free" {
+		t.Fatalf("normalizeModel(openrouter custom api_base) = %q, want %q", got, "openrouter/free")
+	}
 	if got := normalizeModel("vivgrid/managed", "https://api.vivgrid.com/v1"); got != "managed" {
 		t.Fatalf("normalizeModel(vivgrid) = %q, want %q", got, "managed")
 	}


### PR DESCRIPTION
## Summary
- keep `openrouter/...` model ids intact even when requests go through a custom `api_base`
- add a regression test for proxied OpenRouter endpoints

Fixes #1247

## Testing
- `go test ./pkg/providers/openai_compat`