### PR TITLE
fix: prevent infinite optimization loop when all messages are tool outputs

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1508,6 +1508,8 @@ func (al *AgentLoop) summarizeSession(agent *AgentInstance, sessionKey string) {
 	}
 
 	if len(validMessages) == 0 {
+		agent.Sessions.TruncateHistory(sessionKey, 4)
+		agent.Sessions.Save(sessionKey)
 		return
 	}
 


### PR DESCRIPTION
## Description

`summarizeSession()` can enter an infinite "Memory threshold reached. Optimizing conversation history..." loop.

**Root cause:** When the conversation history consists entirely of tool-role messages (neither `"user"` nor `"assistant"`), the `validMessages` filter produces an empty slice. The early return at `loop.go:1510` exits without calling `TruncateHistory()`. Since the history is never shortened, the token threshold is immediately breached again on the next turn, re-triggering `summarizeSession()` indefinitely — locking the agent in a loop that pins CPU.

**Fix:** Call `TruncateHistory()` and `Save()` before the early return so the history is always shortened, breaking the cycle.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes, no api changes)

## AI Code Generation
- [ ] Fully AI-generated (100% AI, 0% Human)
- [x] Mostly AI-generated (AI draft, Human verified/modified)
- [ ] Mostly Human-written (Human lead, AI assisted or none)

## Related Issue

No existing issue. Discovered during development of LuckyClaw, a hard fork of PicoClaw optimized for Luckfox Pico boards (64MB RAM). The constrained memory environment made this bug surface more readily — tool-heavy sessions exhaust the context window fast, and with no user/assistant messages to summarize, the loop never escapes.

## Technical Context

- **Reference:** `pkg/agent/loop.go` -> `summarizeSession()` (around line 1506)
- **Reasoning:** The `validMessages` filter (lines ~1497-1507) only keeps messages with role `"user"` or `"assistant"`. When a session history is dominated by tool calls and tool results (role `"tool"`), `validMessages` ends up empty. The guard at line 1510 returns early but skips `TruncateHistory()` (which only runs at line 1552 inside `if finalSummary != ""`). This means `maybeSummarize()` fires again on the very next turn since nothing was truncated, creating an infinite loop.

  The fix adds `TruncateHistory(sessionKey, 4)` + `Save()` before the early return. This is safe because:
  1. History has already been confirmed to have > 4 messages (line 1486)
  2. `TruncateHistory(sessionKey, 4)` keeps the last 4 messages — same as the normal path
  3. No summary is generated (there is nothing valid to summarize), which is correct

## Test Environment
- **Hardware:** Luckfox Pico Plus (RV1103, 64MB DDR2)
- **OS:** Luckfox Buildroot Linux
- **Model/Provider:** arcee-ai/trinity via OpenRouter
- **Channels:** Telegram, Discord

## Evidence

<details>
<summary>Click to view logs</summary>

Before fix — gateway log showing infinite loop:
```
Memory threshold reached. Optimizing conversation history...
Memory threshold reached. Optimizing conversation history...
Memory threshold reached. Optimizing conversation history...
(repeats indefinitely, CPU pinned)
```

After fix — single cycle, then normal operation:
```
Memory threshold reached. Optimizing conversation history...
[session truncated to last 4 messages — no valid user/assistant messages to summarize]
```

</details>

## Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
