### PR TITLE
Remove stale `TOOLS.md` references from all README translations and migration code.

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -649,7 +649,6 @@ PicoClaw stocke les données dans votre workspace configuré (par défaut : `~/.
 ├── HEARTBEAT.md      # Invites de tâches périodiques (vérifiées toutes les 30 min)
 ├── IDENTITY.md       # Identité de l'Agent
 ├── SOUL.md           # Âme de l'Agent
-├── TOOLS.md          # Description des outils
 └── USER.md           # Préférences utilisateur
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -610,7 +610,6 @@ PicoClaw は設定されたワークスペース（デフォルト: `~/.picoclaw
 ├── HEARTBEAT.md       # 定期タスクプロンプト（30分ごとに確認）
 ├── IDENTITY.md        # エージェントのアイデンティティ
 ├── SOUL.md            # エージェントのソウル
-├── TOOLS.md           # ツールの説明
 └── USER.md            # ユーザー設定
 ```
 

--- a/README.md
+++ b/README.md
@@ -787,7 +787,6 @@ PicoClaw stores data in your configured workspace (default: `~/.picoclaw/workspa
 ├── HEARTBEAT.md      # Periodic task prompts (checked every 30 min)
 ├── IDENTITY.md       # Agent identity
 ├── SOUL.md           # Agent soul
-├── TOOLS.md          # Tool descriptions
 └── USER.md           # User preferences
 ```
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -645,7 +645,6 @@ O PicoClaw armazena dados no workspace configurado (padrão: `~/.picoclaw/worksp
 ├── HEARTBEAT.md       # Prompts de tarefas periodicas (verificado a cada 30 min)
 ├── IDENTITY.md        # Identidade do Agente
 ├── SOUL.md            # Alma do Agente
-├── TOOLS.md           # Descrição das ferramentas
 └── USER.md            # Preferencias do usuario
 ```
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -617,7 +617,6 @@ PicoClaw lưu trữ dữ liệu trong workspace đã cấu hình (mặc định:
 ├── HEARTBEAT.md      # Prompt tác vụ định kỳ (kiểm tra mỗi 30 phút)
 ├── IDENTITY.md       # Danh tính Agent
 ├── SOUL.md           # Tâm hồn/Tính cách Agent
-├── TOOLS.md          # Mô tả công cụ
 └── USER.md           # Tùy chọn người dùng
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -365,7 +365,6 @@ PicoClaw 将数据存储在您配置的工作区中（默认：`~/.picoclaw/work
 ├── HEARTBEAT.md      # 周期性任务提示词 (每 30 分钟检查一次)
 ├── IDENTITY.md       # Agent 身份设定
 ├── SOUL.md           # Agent 灵魂/性格
-├── TOOLS.md          # 工具描述
 └── USER.md           # 用户偏好
 
 ```

--- a/pkg/migrate/sources/openclaw/common.go
+++ b/pkg/migrate/sources/openclaw/common.go
@@ -4,7 +4,6 @@ var migrateableFiles = []string{
 	"AGENTS.md",
 	"SOUL.md",
 	"USER.md",
-	"TOOLS.md",
 	"HEARTBEAT.md",
 }
 


### PR DESCRIPTION
  Remove stale `TOOLS.md` references from all README translations and migration code.

  `TOOLS.md` was intentionally removed in 21d60f6 and #771, as tools are now provided to
  the LLM via JSON schema through `ToProviderDefs()`. These leftover references were missed
  during that cleanup.

  This cleanup was suggested by @yinwm during review of #1355.

  ## 🗣️ Type of Change
  - [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [x] 📖 Documentation update
  - [ ] ⚡ Code refactoring (no functional changes, no api changes)

  ## 🤖 AI Code Generation
  - [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
  - [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
  - [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

  AI identified all stale references. I reviewed and validated the changes.

  ## 🔗 Related Issue

  Cleanup suggested in #1355 by @yinwm.

  ## 📚 Technical Context (Skip for Docs)
  - **Reference URL:** https://github.com/sipeed/picoclaw/pull/1355
  - **Reasoning:**
    - `TOOLS.md` was removed from `LoadBootstrapFiles()` in 21d60f6
    - `buildToolsSection()` was removed entirely in #771
    - Tools are now provided via JSON schema — `TOOLS.md` is no longer used
    - 6 README translations and `pkg/migrate/sources/openclaw/common.go` still referenced it

  ## 🧪 Test Environment
  - **Hardware:** PC
  - **OS:** Windows 11
  - **Model/Provider:** N/A (documentation change)
  - **Channels:** N/A

  ## ☑️ Checklist
  - [x] My code/docs follow the style of this project.
  - [x] I have performed a self-review of my own changes.
  - [x] I have updated the documentation accordingly.