### PR TITLE
feat(skills): implement per-agent SkillsFilter

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -25,6 +25,7 @@ type ContextBuilder struct {
 	memory             *MemoryStore
 	toolDiscoveryBM25  bool
 	toolDiscoveryRegex bool
+	skillsFilter       []string
 
 	// Cache for system prompt to avoid rebuilding on every call.
 	// This fixes issue #607: repeated reprocessing of the entire context.
@@ -48,6 +49,13 @@ type ContextBuilder struct {
 func (cb *ContextBuilder) WithToolDiscovery(useBM25, useRegex bool) *ContextBuilder {
 	cb.toolDiscoveryBM25 = useBM25
 	cb.toolDiscoveryRegex = useRegex
+	return cb
+}
+
+// WithSkillsFilter restricts which skills appear in the system prompt to the
+// named list. An empty or nil filter means all available skills are included.
+func (cb *ContextBuilder) WithSkillsFilter(filter []string) *ContextBuilder {
+	cb.skillsFilter = filter
 	return cb
 }
 
@@ -141,7 +149,7 @@ func (cb *ContextBuilder) BuildSystemPrompt() string {
 	}
 
 	// Skills - show summary, AI can read full content with read_file tool
-	skillsSummary := cb.skillsLoader.BuildSkillsSummary()
+	skillsSummary := cb.skillsLoader.BuildSkillsSummaryFiltered(cb.skillsFilter)
 	if skillsSummary != "" {
 		parts = append(parts, fmt.Sprintf(`# Skills
 
@@ -718,16 +726,27 @@ func (cb *ContextBuilder) AddAssistantMessage(
 	return messages
 }
 
-// GetSkillsInfo returns information about loaded skills.
+// GetSkillsInfo returns information about loaded skills, respecting any active filter.
 func (cb *ContextBuilder) GetSkillsInfo() map[string]any {
 	allSkills := cb.skillsLoader.ListSkills()
+
+	var allowed map[string]bool
+	if len(cb.skillsFilter) > 0 {
+		allowed = make(map[string]bool, len(cb.skillsFilter))
+		for _, n := range cb.skillsFilter {
+			allowed[n] = true
+		}
+	}
+
 	skillNames := make([]string, 0, len(allSkills))
 	for _, s := range allSkills {
-		skillNames = append(skillNames, s.Name)
+		if allowed == nil || allowed[s.Name] {
+			skillNames = append(skillNames, s.Name)
+		}
 	}
 	return map[string]any{
 		"total":     len(allSkills),
-		"available": len(allSkills),
+		"available": len(skillNames),
 		"names":     skillNames,
 	}
 }

--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -117,6 +117,8 @@ func NewAgentInstance(
 		skillsFilter = agentCfg.Skills
 	}
 
+	contextBuilder.WithSkillsFilter(skillsFilter)
+
 	maxIter := defaults.MaxToolIterations
 	if maxIter == 0 {
 		maxIter = 20

--- a/pkg/skills/loader.go
+++ b/pkg/skills/loader.go
@@ -192,19 +192,36 @@ func (sl *SkillsLoader) LoadSkillsForContext(skillNames []string) string {
 }
 
 func (sl *SkillsLoader) BuildSkillsSummary() string {
+	return sl.BuildSkillsSummaryFiltered(nil)
+}
+
+// BuildSkillsSummaryFiltered builds the XML skills summary, restricted to
+// allowedNames if non-empty. An empty/nil allowedNames includes all skills.
+func (sl *SkillsLoader) BuildSkillsSummaryFiltered(allowedNames []string) string {
 	allSkills := sl.ListSkills()
 	if len(allSkills) == 0 {
 		return ""
 	}
 
+	var allowed map[string]bool
+	if len(allowedNames) > 0 {
+		allowed = make(map[string]bool, len(allowedNames))
+		for _, n := range allowedNames {
+			allowed[n] = true
+		}
+	}
+
 	var lines []string
 	lines = append(lines, "<skills>")
 	for _, s := range allSkills {
+		if allowed != nil && !allowed[s.Name] {
+			continue
+		}
 		escapedName := escapeXML(s.Name)
 		escapedDesc := escapeXML(s.Description)
 		escapedPath := escapeXML(s.Path)
 
-		lines = append(lines, fmt.Sprintf("  <skill>"))
+		lines = append(lines, "  <skill>")
 		lines = append(lines, fmt.Sprintf("    <name>%s</name>", escapedName))
 		lines = append(lines, fmt.Sprintf("    <description>%s</description>", escapedDesc))
 		lines = append(lines, fmt.Sprintf("    <location>%s</location>", escapedPath))
@@ -213,6 +230,10 @@ func (sl *SkillsLoader) BuildSkillsSummary() string {
 	}
 	lines = append(lines, "</skills>")
 
+	if len(lines) == 2 {
+		// Only open/close tags — filter excluded everything
+		return ""
+	}
 	return strings.Join(lines, "\n")
 }
 


### PR DESCRIPTION
## Summary

- Wires the existing-but-unused `AgentConfig.Skills` config field through `ContextBuilder` into `SkillsLoader`
- Each agent now only sees the skills listed in its `skills` array in config
- Empty/nil filter = all skills visible — fully backwards compatible

## Example

```json
{
  "agents": {
    "list": [{"id": "main", "skills": ["github", "weather"]}]
  }
}
```
→ Agent `main` only sees `github` and `weather` in its system prompt, even if 11 skills are installed.

## Changes

- `pkg/skills/loader.go` — Add `BuildSkillsSummaryFiltered(allowedNames []string)`. `BuildSkillsSummary()` delegates to it with `nil` (all skills, no behaviour change).
- `pkg/agent/context.go` — Add `skillsFilter []string` field and `WithSkillsFilter()` builder method. `BuildSystemPrompt()` calls the filtered variant. `GetSkillsInfo()` now reports correct `available` vs `total` counts.
- `pkg/agent/instance.go` — Call `contextBuilder.WithSkillsFilter(skillsFilter)` after `skillsFilter` is assigned from `agentCfg.Skills`.

## Type of Change

- [x] Bug fix (correcting dead/broken feature)
- [x] New feature (per-agent skill scoping now works)

## 🤖 AI Code Generation

🤖 Fully AI-generated — reviewed and tested by contributor.

## Test Environment

- macOS darwin arm64, Go 1.25.7
- Model: deepseek-chat

## Evidence

```
skills_available=2 skills_total=11  (with filter ["github","weather"])
skills_available=11 skills_total=11 (without filter)
```

System prompt XML confirmed to contain only the 2 filtered skills.

## Checklist

- [x] `go test ./pkg/skills/... ./pkg/agent/...` passes
- [x] Backwards compatible (nil filter = all skills)
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)