### PR TITLE
fix(config): start model round robin from the first match

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -921,7 +921,7 @@ func (c *Config) GetModelConfig(modelName string) (*ModelConfig, error) {
 	}
 
 	// Multiple configs - use round-robin for load balancing
-	idx := rrCounter.Add(1) % uint64(len(matches))
+	idx := (rrCounter.Add(1) - 1) % uint64(len(matches))
 	return &matches[idx], nil
 }
 

--- a/pkg/config/model_config_test.go
+++ b/pkg/config/model_config_test.go
@@ -54,6 +54,8 @@ func TestGetModelConfig_EmptyList(t *testing.T) {
 }
 
 func TestGetModelConfig_RoundRobin(t *testing.T) {
+	rrCounter.Store(0)
+
 	cfg := &Config{
 		ModelList: []ModelConfig{
 			{ModelName: "lb-model", Model: "openai/gpt-4o-1", APIKey: "key1"},
@@ -62,20 +64,22 @@ func TestGetModelConfig_RoundRobin(t *testing.T) {
 		},
 	}
 
-	// Test round-robin distribution
-	results := make(map[string]int)
-	for range 30 {
+	want := []string{
+		"openai/gpt-4o-1",
+		"openai/gpt-4o-2",
+		"openai/gpt-4o-3",
+		"openai/gpt-4o-1",
+		"openai/gpt-4o-2",
+		"openai/gpt-4o-3",
+	}
+
+	for i, wantModel := range want {
 		result, err := cfg.GetModelConfig("lb-model")
 		if err != nil {
 			t.Fatalf("GetModelConfig() error = %v", err)
 		}
-		results[result.Model]++
-	}
-
-	// Each model should appear roughly 10 times (30 calls / 3 models)
-	for model, count := range results {
-		if count < 5 || count > 15 {
-			t.Errorf("Model %s appeared %d times, expected ~10", model, count)
+		if result.Model != wantModel {
+			t.Fatalf("call %d selected %q, want %q", i+1, result.Model, wantModel)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- start duplicate `model_name` round-robin selection from the first matching entry instead of the second
- make the regression test verify the exact selection order across repeated calls
- preserve the existing load-balancing behavior after the first pick

## Testing
- `go test ./pkg/config -run ''TestGetModelConfig_(RoundRobin|Concurrent|Found|NotFound|EmptyList)''`

Fixes #1153