### PR TITLE
fix(channels): stop stale typing loops on overwrite

### DIFF
--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -127,7 +127,12 @@ func (m *Manager) SendPlaceholder(ctx context.Context, channel, chatID string) b
 // Implements PlaceholderRecorder.
 func (m *Manager) RecordTypingStop(channel, chatID string, stop func()) {
 	key := channel + ":" + chatID
-	m.typingStops.Store(key, typingEntry{stop: stop, createdAt: time.Now()})
+	entry := typingEntry{stop: stop, createdAt: time.Now()}
+	if previous, loaded := m.typingStops.Swap(key, entry); loaded {
+		if oldEntry, ok := previous.(typingEntry); ok && oldEntry.stop != nil {
+			oldEntry.stop()
+		}
+	}
 }
 
 // RecordReactionUndo registers a reaction undo function for later invocation.

--- a/pkg/channels/manager_test.go
+++ b/pkg/channels/manager_test.go
@@ -616,6 +616,37 @@ func TestRecordTypingStop_ConcurrentSafe(t *testing.T) {
 	wg.Wait()
 }
 
+func TestRecordTypingStop_ReplacesExistingStop(t *testing.T) {
+	m := newTestManager()
+	var oldStopCalls int
+	var newStopCalls int
+
+	m.RecordTypingStop("test", "123", func() {
+		oldStopCalls++
+	})
+
+	m.RecordTypingStop("test", "123", func() {
+		newStopCalls++
+	})
+
+	if oldStopCalls != 1 {
+		t.Fatalf("expected previous typing stop to be called once when replaced, got %d", oldStopCalls)
+	}
+	if newStopCalls != 0 {
+		t.Fatalf("expected replacement typing stop to stay active until preSend, got %d calls", newStopCalls)
+	}
+
+	msg := bus.OutboundMessage{Channel: "test", ChatID: "123", Content: "hello"}
+	m.preSend(context.Background(), "test", msg, &mockChannel{})
+
+	if newStopCalls != 1 {
+		t.Fatalf("expected replacement typing stop to be called by preSend, got %d", newStopCalls)
+	}
+	if oldStopCalls != 1 {
+		t.Fatalf("expected previous typing stop to not be called again, got %d", oldStopCalls)
+	}
+}
+
 func TestSendWithRetry_PreSendEditsPlaceholder(t *testing.T) {
 	m := newTestManager()
 	var sendCalled bool


### PR DESCRIPTION
## Summary
- stop the previous typing loop immediately when the same channel/chat registers a replacement stop function
- keep the replacement stop callback active until the response is sent
- add a regression test for repeated typing registration on the same chat

## Testing
- `go test ./pkg/channels -run ''Test(PreSend_TypingStopCalled|RecordTypingStop|TypingStopJanitorEviction)''`

Fixes #1323
Fixes #1212