### PR TITLE
fix(onboard): embed workspace templates from repo root

### DIFF
--- a/cmd/picoclaw/internal/onboard/command.go
+++ b/cmd/picoclaw/internal/onboard/command.go
@@ -1,14 +1,8 @@
 package onboard
 
 import (
-	"embed"
-
 	"github.com/spf13/cobra"
 )
-
-//go:generate cp -r ../../../../workspace .
-//go:embed workspace
-var embeddedFiles embed.FS
 
 func NewOnboardCommand() *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/picoclaw/internal/onboard/helpers.go
+++ b/cmd/picoclaw/internal/onboard/helpers.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	picoclaw "github.com/sipeed/picoclaw"
 	"github.com/sipeed/picoclaw/cmd/picoclaw/internal"
 	"github.com/sipeed/picoclaw/pkg/config"
 )
@@ -47,20 +48,20 @@ func onboard() {
 }
 
 func createWorkspaceTemplates(workspace string) {
-	err := copyEmbeddedToTarget(workspace)
+	err := copyEmbeddedToTarget(picoclaw.EmbeddedWorkspace, workspace)
 	if err != nil {
 		fmt.Printf("Error copying workspace templates: %v\n", err)
 	}
 }
 
-func copyEmbeddedToTarget(targetDir string) error {
+func copyEmbeddedToTarget(source fs.FS, targetDir string) error {
 	// Ensure target directory exists
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		return fmt.Errorf("Failed to create target directory: %w", err)
 	}
 
 	// Walk through all files in embed.FS
-	err := fs.WalkDir(embeddedFiles, "workspace", func(path string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(source, "workspace", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -71,7 +72,7 @@ func copyEmbeddedToTarget(targetDir string) error {
 		}
 
 		// Read embedded file
-		data, err := embeddedFiles.ReadFile(path)
+		data, err := fs.ReadFile(source, path)
 		if err != nil {
 			return fmt.Errorf("Failed to read embedded file %s: %w", path, err)
 		}

--- a/cmd/picoclaw/internal/onboard/helpers_test.go
+++ b/cmd/picoclaw/internal/onboard/helpers_test.go
@@ -4,12 +4,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	picoclaw "github.com/sipeed/picoclaw"
 )
 
 func TestCopyEmbeddedToTargetUsesAgentsMarkdown(t *testing.T) {
 	targetDir := t.TempDir()
 
-	if err := copyEmbeddedToTarget(targetDir); err != nil {
+	if err := copyEmbeddedToTarget(picoclaw.EmbeddedWorkspace, targetDir); err != nil {
 		t.Fatalf("copyEmbeddedToTarget() error = %v", err)
 	}
 

--- a/embedded_workspace.go
+++ b/embedded_workspace.go
@@ -1,0 +1,8 @@
+package picoclaw
+
+import "embed"
+
+// EmbeddedWorkspace bundles the default workspace templates used by `picoclaw onboard`.
+//
+//go:embed workspace
+var EmbeddedWorkspace embed.FS


### PR DESCRIPTION
## Summary
- embed the default workspace templates from the repository root instead of relying on a generated copy inside the onboard package
- make onboard template copying accept an injected `fs.FS`, which keeps the test path explicit
- restore clean-checkout builds for `cmd/picoclaw/internal/onboard` on Windows

## Testing
- `go test ./cmd/picoclaw/internal/onboard`
- `go test ./cmd/picoclaw -run TestMain`

Fixes #1348