### PR TITLE
fix(config): preserve legacy provider model aliases

### DIFF
--- a/pkg/config/migration.go
+++ b/pkg/config/migration.go
@@ -419,6 +419,7 @@ func ConvertProvidersToModelList(cfg *Config) []ModelConfig {
 		// Check if this is the user's configured provider
 		if slices.Contains(m.providerNames, userProvider) && userModel != "" {
 			// Use the user's configured model instead of default
+			mc.ModelName = userModel
 			mc.Model = buildModelWithProtocol(m.protocol, userModel)
 		} else if userProvider == "" && userModel != "" && !legacyModelNameApplied {
 			// Legacy config: no explicit provider field but model is specified

--- a/pkg/config/migration_test.go
+++ b/pkg/config/migration_test.go
@@ -281,6 +281,10 @@ func TestConvertProvidersToModelList_PreservesUserModel_OpenAI(t *testing.T) {
 		t.Fatalf("len(result) = %d, want 1", len(result))
 	}
 
+	if result[0].ModelName != "gpt-4-turbo" {
+		t.Errorf("ModelName = %q, want %q", result[0].ModelName, "gpt-4-turbo")
+	}
+
 	if result[0].Model != "openai/gpt-4-turbo" {
 		t.Errorf("Model = %q, want %q", result[0].Model, "openai/gpt-4-turbo")
 	}
@@ -329,8 +333,40 @@ func TestConvertProvidersToModelList_PreservesUserModel_Qwen(t *testing.T) {
 		t.Fatalf("len(result) = %d, want 1", len(result))
 	}
 
+	if result[0].ModelName != "qwen-plus" {
+		t.Errorf("ModelName = %q, want %q", result[0].ModelName, "qwen-plus")
+	}
+
 	if result[0].Model != "qwen/qwen-plus" {
 		t.Errorf("Model = %q, want %q", result[0].Model, "qwen/qwen-plus")
+	}
+}
+
+func TestConvertProvidersToModelList_PreservesUserModelName_Ollama(t *testing.T) {
+	cfg := &Config{
+		Agents: AgentsConfig{
+			Defaults: AgentDefaults{
+				Provider: "ollama",
+				Model:    "llama3.2",
+			},
+		},
+		Providers: ProvidersConfig{
+			Ollama: ProviderConfig{
+				APIBase: "http://localhost:11434/v1",
+			},
+		},
+	}
+
+	result := ConvertProvidersToModelList(cfg)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if result[0].ModelName != "llama3.2" {
+		t.Fatalf("ModelName = %q, want %q", result[0].ModelName, "llama3.2")
+	}
+	if result[0].Model != "ollama/llama3.2" {
+		t.Fatalf("Model = %q, want %q", result[0].Model, "ollama/llama3.2")
 	}
 }
 

--- a/pkg/providers/factory_test.go
+++ b/pkg/providers/factory_test.go
@@ -324,6 +324,24 @@ func TestCreateProviderReturnsClaudeProviderForAnthropicOAuth(t *testing.T) {
 	// TODO: Test custom APIBase when createClaudeAuthProvider supports it
 }
 
+func TestCreateProvider_LegacyOllamaProviderUsesUserModelAlias(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Agents.Defaults.Provider = "ollama"
+	cfg.Agents.Defaults.Model = "llama3.2"
+	cfg.Providers.Ollama.APIBase = "http://localhost:11434/v1"
+
+	provider, modelID, err := CreateProvider(cfg)
+	if err != nil {
+		t.Fatalf("CreateProvider() error = %v", err)
+	}
+	if provider == nil {
+		t.Fatal("CreateProvider() returned nil provider")
+	}
+	if modelID != "llama3.2" {
+		t.Fatalf("modelID = %q, want %q", modelID, "llama3.2")
+	}
+}
+
 func TestCreateProviderReturnsCodexProviderForOpenAIOAuth(t *testing.T) {
 	// TODO: This test requires openai protocol to support auth_method: "oauth"
 	// which is not yet implemented in the new factory_provider.go


### PR DESCRIPTION
Fixes #958.

- preserve the user model alias when migrating legacy providers config
- cover legacy ollama selection with regression tests
- ensure CreateProvider resolves the migrated alias correctly