### PR TITLE
fix(agent): resolve light model aliases before LLM calls

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1405,12 +1405,13 @@ func (al *AgentLoop) selectCandidates(
 
 	logger.InfoCF("agent", "Model routing: light model selected",
 		map[string]any{
-			"agent_id":    agent.ID,
-			"light_model": agent.Router.LightModel(),
-			"score":       score,
-			"threshold":   agent.Router.Threshold(),
+			"agent_id":             agent.ID,
+			"light_model":          agent.Router.LightModel(),
+			"resolved_light_model": agent.LightCandidates[0].Model,
+			"score":                score,
+			"threshold":            agent.Router.Threshold(),
 		})
-	return agent.LightCandidates, agent.Router.LightModel()
+	return agent.LightCandidates, agent.LightCandidates[0].Model
 }
 
 // maybeSummarize triggers summarization if the session history exceeds thresholds.

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -575,6 +575,35 @@ func TestProcessMessage_SwitchModelShowModelConsistency(t *testing.T) {
 	}
 }
 
+func TestSelectCandidates_UsesResolvedLightModelID(t *testing.T) {
+	al := &AgentLoop{}
+	agent := &AgentInstance{
+		ID:    "main",
+		Model: "heavy-alias",
+		Router: routing.New(routing.RouterConfig{
+			LightModel: "light-alias",
+			Threshold:  1.0,
+		}),
+		Candidates: []providers.FallbackCandidate{
+			{Provider: "openai", Model: "gpt-4o"},
+		},
+		LightCandidates: []providers.FallbackCandidate{
+			{Provider: "openai", Model: "qwen2.5:3b"},
+		},
+	}
+
+	candidates, model := al.selectCandidates(agent, "hi", nil)
+	if len(candidates) != 1 {
+		t.Fatalf("len(candidates) = %d, want 1", len(candidates))
+	}
+	if candidates[0].Model != "qwen2.5:3b" {
+		t.Fatalf("candidate model = %q, want %q", candidates[0].Model, "qwen2.5:3b")
+	}
+	if model != "qwen2.5:3b" {
+		t.Fatalf("model = %q, want %q", model, "qwen2.5:3b")
+	}
+}
+
 // TestToolResult_SilentToolDoesNotSendUserMessage verifies silent tools don't trigger outbound
 func TestToolResult_SilentToolDoesNotSendUserMessage(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "agent-test-*")


### PR DESCRIPTION
Fixes #1297.

- use the resolved model_list candidate when light routing is selected
- keep logs explicit about alias vs resolved model
- add a regression test for routed light model IDs