### PR TITLE
fix(identity): prevent allowlist ID entries from matching usernames

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -59,6 +59,9 @@ func MatchAllowed(sender bus.SenderInfo, allowed string) bool {
 		}
 	}
 
+	// Keep track of explicit username format
+	isAtUsername := strings.HasPrefix(allowed, "@")
+
 	// Strip leading "@" for username matching
 	trimmed := strings.TrimPrefix(allowed, "@")
 
@@ -75,11 +78,9 @@ func MatchAllowed(sender bus.SenderInfo, allowed string) bool {
 		return true
 	}
 
-	// Match against Username
-	if sender.Username != "" {
-		if sender.Username == trimmed || sender.Username == allowedUser {
-			return true
-		}
+	// Match against Username only when explicitly requested via "@username"
+	if isAtUsername && sender.Username != "" && sender.Username == trimmed {
+		return true
 	}
 
 	// Match compound sender format against allowed parts

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -105,6 +105,16 @@ func TestMatchAllowed(t *testing.T) {
 			want:    true,
 		},
 		{
+			name: "plain entry does not match username",
+			sender: bus.SenderInfo{
+				Platform:   "discord",
+				PlatformID: "999999",
+				Username:   "123456",
+			},
+			allowed: "123456",
+			want:    false,
+		},
+		{
 			name:    "@username does not match",
 			sender:  telegramSender,
 			allowed: "@bob",
@@ -121,6 +131,16 @@ func TestMatchAllowed(t *testing.T) {
 			name:    "compound matches by username",
 			sender:  telegramSender,
 			allowed: "999|alice",
+			want:    true,
+		},
+		{
+			name: "compound matches by ID when username differs",
+			sender: bus.SenderInfo{
+				Platform:   "discord",
+				PlatformID: "123456",
+				Username:   "not123456",
+			},
+			allowed: "123456|alice",
 			want:    true,
 		},
 		{


### PR DESCRIPTION
## 📝 Description

where plain allowlist entries could also match sender.Username, enabling the reported bypass scenario. I then implemented a minimal fix so username matching is only allowed when the entry is explicitly @username, while plain entries continue matching PlatformID.

Preserved existing explicit username behavior for compound id|username entries and canonical matching flow, so backward-compatible formats still work without allowing implicit username matches from plain IDs.

Added regression tests covering the security case ("123456" must not match Username=="123456" when PlatformID differs) and a compound-format sanity case to ensure expected behavior is retained.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)