### PR TITLE
Fix unbounded memory usage in matrix media download (#1405)

### DIFF
--- a/pkg/channels/matrix/matrix.go
+++ b/pkg/channels/matrix/matrix.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"html"
+	"io"
 	"mime"
 	"net/url"
 	"os"
@@ -12,7 +13,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"io"
 
 	"github.com/gomarkdown/markdown"
 	mdhtml "github.com/gomarkdown/markdown/html"
@@ -732,7 +732,6 @@ func (c *MatrixChannel) downloadMedia(
 	if err != nil {
 		return "", err
 	}
-	
 	defer resp.Body.Close()
 	data, err := io.ReadAll(io.LimitReader(resp.Body, int64(maxMediaSize)+1))
 	if err != nil {
@@ -740,7 +739,7 @@ func (c *MatrixChannel) downloadMedia(
 	}
 
 	if len(data) > maxMediaSize {
-    	return "", fmt.Errorf("media exceeds size limit of %d bytes", maxMediaSize)
+		return "", fmt.Errorf("media exceeds size limit of %d bytes", maxMediaSize)
 	}
 
 	// Encrypted attachments put URL in msgEvt.File and require client-side decryption.


### PR DESCRIPTION
## 📝 Description
Replace `DownloadBytes` with `Download` + `io.LimitReader` to cap matrix media 
downloads at 100MB. Previously, `DownloadBytes` loaded the entire file into RAM 
with no size limit, which could cause OOM crashes from large or malicious files 
sent via federated Matrix servers that have no upload size restrictions.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## 🔗 Related Issue
Fixes #1405

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://pkg.go.dev/io#LimitReader
- **Reasoning:** `DownloadBytes` internally calls `Download` then `io.ReadAll(resp.Body)` 
  with no size cap. By using `Download` directly with `io.LimitReader`, we cap RAM usage 
  at 100MB and reject oversized files before writing to disk. Matrix is a federated 
  protocol — servers outside our control may have no upload size limits.

## 🧪 Test Environment
- **Hardware:** MacBook Air
- **OS:** macOS
- **Model/Provider:** N/A
- **Channels:** Matrix


## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.

