### PR TITLE
fix(line): limit webhook request body size to prevent DoS

### DIFF
--- a/pkg/channels/line/line.go
+++ b/pkg/channels/line/line.go
@@ -32,6 +32,10 @@ const (
 	lineBotInfoEndpoint  = lineAPIBase + "/info"
 	lineLoadingEndpoint  = lineAPIBase + "/chat/loading/start"
 	lineReplyTokenMaxAge = 25 * time.Second
+
+	// Limit request body to prevent memory exhaustion (DoS).
+	// LINE webhook payloads are typically a few KB; 1 MiB is generous.
+	maxWebhookBodySize = 1 << 20 // 1 MiB
 )
 
 type replyTokenEntry struct {
@@ -166,9 +170,6 @@ func (c *LINEChannel) webhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Limit request body to prevent memory exhaustion (DoS).
-	// LINE webhook payloads are typically a few KB; 1 MB is generous.
-	const maxWebhookBodySize = 1 << 20 // 1 MB
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxWebhookBodySize+1))
 	if err != nil {
 		logger.ErrorCF("line", "Failed to read request body", map[string]any{

--- a/pkg/channels/line/line_test.go
+++ b/pkg/channels/line/line_test.go
@@ -11,9 +11,38 @@ import (
 func TestWebhookRejectsOversizedBody(t *testing.T) {
 	ch := &LINEChannel{}
 
-	// Create a body larger than maxWebhookBodySize (1 MB)
-	oversized := bytes.Repeat([]byte("A"), (1<<20)+1)
+	oversized := bytes.Repeat([]byte("A"), maxWebhookBodySize+1)
 	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(oversized))
+	rec := httptest.NewRecorder()
+
+	ch.webhookHandler(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected status %d, got %d", http.StatusRequestEntityTooLarge, rec.Code)
+	}
+}
+
+func TestWebhookAcceptsMaxBodySize(t *testing.T) {
+	ch := &LINEChannel{}
+
+	body := bytes.Repeat([]byte("A"), maxWebhookBodySize)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	ch.webhookHandler(rec, req)
+
+	// Missing signature should be rejected, but the body size should not trigger 413.
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+	}
+}
+
+func TestWebhookRejectsOversizedBodyBeforeSignatureCheck(t *testing.T) {
+	ch := &LINEChannel{}
+
+	oversized := bytes.Repeat([]byte("A"), maxWebhookBodySize+1)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(oversized))
+	req.Header.Set("X-Line-Signature", "invalidsignature")
 	rec := httptest.NewRecorder()
 
 	ch.webhookHandler(rec, req)


### PR DESCRIPTION
## Summary
- Add `io.LimitReader` (1 MB cap) to the LINE webhook handler to prevent unauthenticated memory exhaustion via oversized POST requests
- Reject oversized requests with `413 Request Entity Too Large` before signature verification
- Follow the same pattern used in the WeCom channel (`io.LimitReader` + overflow check)
- Add webhook handler tests (body size limit, method check, signature validation)

Fixes #1407

## Test plan
- [x] `TestWebhookRejectsOversizedBody` — verifies 413 for body > 1 MB
- [x] `TestWebhookRejectsNonPostMethod` — verifies 405 for non-POST
- [x] `TestWebhookRejectsInvalidSignature` — verifies 403 for bad signature
- [x] All 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)