### PR TITLE
fix(nightly): reuse single nightly tag, no per-day tags

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,64 +9,37 @@ permissions:
   contents: read
 
 jobs:
-  create-tag:
-    name: Create Git Tag
+  nightly:
+    name: Nightly Build
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      tag: ${{ steps.version.outputs.tag }}
-      changelog: ${{ steps.version.outputs.changelog }}
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Generate and push tag
+      - name: Compute version
         id: version
         run: |
           DATE=$(date -u +%Y%m%d)
           SHA=$(git rev-parse --short=8 HEAD)
           BASE_VERSION=$(git describe --tags --match "v*" --exclude "*nightly*" --abbrev=0 2>/dev/null || true)
           if [ -z "$BASE_VERSION" ] || [ "$BASE_VERSION" = "v0.0.0" ]; then
-            TAG="v0.0.0-nightly.${DATE}.${SHA}"
+            VERSION="v0.0.0-nightly.${DATE}.${SHA}"
           else
-            TAG="${BASE_VERSION}-nightly.${DATE}.${SHA}"
+            VERSION="${BASE_VERSION}-nightly.${DATE}.${SHA}"
           fi
-          VERSION=$TAG
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "Tag $TAG already exists, reusing existing tag"
-          else
-            git tag -a "$TAG" -m "Nightly build $VERSION"
-          fi
-          git push origin "$TAG"
-          
-          COMPARE_URL="https://github.com/${{ github.repository }}/commits/${TAG}"
-          if [ -n "$BASE_VERSION" ] && [ "$BASE_VERSION" != "v0.0.0" ]; then
-            COMPARE_URL="https://github.com/${{ github.repository }}/compare/${BASE_VERSION}...${TAG}"
-          fi
-          echo "changelog=**Full Changelog**: $COMPARE_URL" >> "$GITHUB_OUTPUT"
-          
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
-  release:
-    name: GoReleaser Release
-    needs: create-tag
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Checkout tag
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.create-tag.outputs.tag }}
+          COMPARE_URL="https://github.com/${{ github.repository }}/commits/main"
+          if [ -n "$BASE_VERSION" ] && [ "$BASE_VERSION" != "v0.0.0" ]; then
+            COMPARE_URL="https://github.com/${{ github.repository }}/compare/${BASE_VERSION}...main"
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "changelog=**Full Changelog**: $COMPARE_URL" >> "$GITHUB_OUTPUT"
 
       - name: Setup Go from go.mod
         id: setup-go
@@ -95,6 +68,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create local tag for GoReleaser
+        run: git tag "${{ steps.version.outputs.version }}"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -106,6 +89,7 @@ jobs:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           DOCKERHUB_IMAGE_NAME: ${{ vars.DOCKERHUB_REPOSITORY }}
           GOVERSION: ${{ steps.setup-go.outputs.go-version }}
+          GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.version }}
           NIGHTLY_BUILD: "true"
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
           MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
@@ -113,92 +97,42 @@ jobs:
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
 
-  update-rolling:
-    name: Update Rolling Nightly
-    needs: [create-tag, release]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Update nightly release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.create-tag.outputs.tag }}
-          TITLE: ${{ needs.create-tag.outputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          CHANGELOG='${{ needs.create-tag.outputs.changelog }}'
+          CHANGELOG='${{ steps.version.outputs.changelog }}'
           NOTES=$(cat <<EOF
-          Nightly build for **${TITLE}**
-          
+          Nightly build for **${VERSION}**
+
           This is an automated build and may be unstable. Use with caution.
-          
+
           ${CHANGELOG}
           EOF
           )
-          
-          # Download assets from the newly created release if it exists,
-          # otherwise fall back to using locally built dist/ artifacts.
-          mkdir -p build
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Downloading assets from GitHub release for $TAG..."
-            gh release download "$TAG" --dir build
-          else
-            echo "GitHub release for $TAG not found; falling back to local dist/ artifacts..."
-            if [ -d "dist" ]; then
-              cp -R dist/* build/
-            else
-              echo "Error: no GitHub release for $TAG and no local dist/ directory found." >&2
-              exit 1
-            fi
-          fi
-          
-          # Delete existing nightly release and tag to avoid conflicts
-          echo "Deleting existing nightly release and tag..."
-          gh release delete nightly --cleanup-tag -y || true
-          git push origin :refs/tags/nightly || true
-          
+
+          # Delete existing nightly release and tag
+          gh release delete nightly --cleanup-tag -y 2>/dev/null || true
+
+          # Force-update nightly tag to current HEAD
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa nightly -m "Nightly build ${VERSION}"
+          git push origin nightly
+
+          # Collect release artifacts from goreleaser dist/
+          ASSETS=()
+          for f in dist/*.tar.gz dist/*.zip dist/*.deb dist/*.rpm dist/checksums.txt; do
+            [ -f "$f" ] && ASSETS+=("$f")
+          done
+
+          # Create nightly release (prerelease, NOT latest)
           gh release create nightly \
             --title "Nightly Build" \
             --notes "$NOTES" \
             --target "${{ github.sha }}" \
             --prerelease \
-            build/*
+            --latest=false \
+            "${ASSETS[@]}"
 
-          echo "Cleaning up old nightly releases (keeping only the most recent)..."
-          gh release list --limit 100 --json tagName -q '.[].tagName | select(contains("-nightly."))' | tail -n +2 | while read -r old_tag; do
-            if [ -n "$old_tag" ] && [ "$old_tag" != "$TAG" ]; then
-              echo "Deleting old nightly release: $old_tag"
-              gh release delete "$old_tag" --cleanup-tag -y || true
-            fi
-          done
-          
-          echo "Cleaning up old 'vX.X.X-nightly...' Docker images on GHCR..."
-          OWNER="${{ github.repository_owner }}"
-          PACKAGE_NAME="${{ github.event.repository.name }}"
-          
-          # Check if owner is an organization or user
-          ORG_TEST=$(gh api -H "Accept: application/vnd.github+json" /orgs/$OWNER 2>/dev/null || true)
-          if echo "$ORG_TEST" | grep -q '"login"'; then
-            ACCOUNT_TYPE="orgs"
-          else
-            ACCOUNT_TYPE="users"
-          fi
-          
-          PACKAGE_URL="/${ACCOUNT_TYPE}/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
-          OLD_NIGHTLY_VERSIONS=$(gh api --paginate -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "$PACKAGE_URL" \
-            --jq ". | map(select(any(.metadata.container.tags[]; contains(\"-nightly.\") and (. != \"nightly\") and (. != \"$TAG\")))) | .[].id" 2>/dev/null || true)
-            
-          for version_id in $OLD_NIGHTLY_VERSIONS; do
-            if [ -n "$version_id" ]; then
-              echo "Deleting Docker image version ID: $version_id"
-              gh api -X DELETE -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "/${ACCOUNT_TYPE}/${OWNER}/packages/container/${PACKAGE_NAME}/versions/$version_id" || true
-            fi
-          done

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -116,9 +116,9 @@ dockers_v2:
       - picoclaw
     images:
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/picoclaw"
-      - '{{ if not (isEnvSet "NIGHTLY_BUILD") }}docker.io/{{ .Env.DOCKERHUB_IMAGE_NAME }}{{ end }}'
+      - 'docker.io/{{ .Env.DOCKERHUB_IMAGE_NAME }}'
     tags:
-      - "{{ .Tag }}"
+      - '{{ if isEnvSet "NIGHTLY_BUILD" }}nightly{{ else }}{{ .Tag }}{{ end }}'
       - '{{ if isEnvSet "NIGHTLY_BUILD" }}nightly{{ else }}latest{{ end }}'
     platforms:
       - linux/amd64
@@ -133,9 +133,9 @@ dockers_v2:
       - picoclaw-launcher-tui
     images:
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/picoclaw"
-      - '{{ if not (isEnvSet "NIGHTLY_BUILD") }}docker.io/{{ .Env.DOCKERHUB_IMAGE_NAME }}{{ end }}'
+      - 'docker.io/{{ .Env.DOCKERHUB_IMAGE_NAME }}'
     tags:
-      - "{{ .Tag }}-launcher"
+      - '{{ if isEnvSet "NIGHTLY_BUILD" }}nightly-launcher{{ else }}{{ .Tag }}-launcher{{ end }}'
       - '{{ if isEnvSet "NIGHTLY_BUILD" }}nightly-launcher{{ else }}launcher{{ end }}'
     platforms:
       - linux/amd64
@@ -215,6 +215,7 @@ changelog:
 #      lzma: true
 
 release:
+  disable: '{{ isEnvSet "NIGHTLY_BUILD" }}'
   footer: >-
 
     ---


### PR DESCRIPTION
## 📝 Description

- Disable goreleaser GitHub release for nightly (Docker still pushed)
- Use GORELEASER_CURRENT_TAG with local-only tag for version/validation
- Force-update single `nightly` git tag instead of creating per-day tags
- Docker tags use only `nightly`/`nightly-launcher`, no per-day versions
- Set --latest=false on nightly release to avoid occupying latest
- Simplify workflow from 3 jobs to 1 job, remove all cleanup steps

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.