### PR TITLE
fix: prevent safety guard from blocking commands containing URLs

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -81,6 +81,9 @@ var (
 	// absolutePathPattern matches absolute file paths in commands (Unix and Windows).
 	absolutePathPattern = regexp.MustCompile(`[A-Za-z]:\\[^\\\"']+|/[^\s\"']+`)
 
+	// urlPattern matches HTTP(S) URLs to exclude them from path safety checks.
+	urlPattern = regexp.MustCompile(`https?://[^\s\"']+`)
+
 	// safePaths are kernel pseudo-devices that are always safe to reference in
 	// commands, regardless of workspace restriction. They contain no user data
 	// and cannot cause destructive writes.
@@ -373,7 +376,11 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 			return ""
 		}
 
-		matches := absolutePathPattern.FindAllString(cmd, -1)
+		// Remove URLs from the command before matching paths to avoid false positives.
+		// For example, "agent-browser open https://github.com" should not trigger
+		// a path safety check on the URL's path component.
+		cmdWithoutURLs := urlPattern.ReplaceAllString(cmd, "")
+		matches := absolutePathPattern.FindAllString(cmdWithoutURLs, -1)
 
 		for _, raw := range matches {
 			p, err := filepath.Abs(raw)


### PR DESCRIPTION
## 📋 Summary

Fixes #1203

The workspace safety guard was incorrectly blocking commands containing URLs because the `absolutePathPattern` regex was matching URL path components (e.g., `//github.com`) as absolute file paths.

## 🔄 Changes

- Added `urlPattern` regex to match HTTP(S) URLs
- Modified path safety check to strip URLs from commands before checking for absolute paths
- Preserves all existing safety checks for actual file system paths

## ✅ Test Case

Before this fix:
```
agent-browser open https://github.com
# ❌ Blocked: Command blocked by safety guard (path outside working dir)
```

After this fix:
```
agent-browser open https://github.com
# ✅ Works correctly
```

Real file paths are still properly checked:
```
cat /etc/passwd
# ❌ Still blocked when outside workspace
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)