### PR TITLE
fix: include TOOLS.md in agent context

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -227,6 +227,7 @@ func (cb *ContextBuilder) sourcePaths() []string {
 		filepath.Join(cb.workspace, "SOUL.md"),
 		filepath.Join(cb.workspace, "USER.md"),
 		filepath.Join(cb.workspace, "IDENTITY.md"),
+		filepath.Join(cb.workspace, "TOOLS.md"),
 		filepath.Join(cb.workspace, "memory", "MEMORY.md"),
 	}
 }
@@ -437,6 +438,7 @@ func (cb *ContextBuilder) LoadBootstrapFiles() string {
 		"SOUL.md",
 		"USER.md",
 		"IDENTITY.md",
+		"TOOLS.md",
 	}
 
 	var sb strings.Builder


### PR DESCRIPTION
## 📋 Summary

Fixes #1315

`TOOLS.md` was inherited from OpenClaw as a migrateable file but was never actually loaded into the agent context. This meant users could create `TOOLS.md` in their workspace to document custom tool usage instructions, but the content was never seen by the LLM.

## 🔄 Changes

- Added `TOOLS.md` to `LoadBootstrapFiles()` bootstrap list
- Added `TOOLS.md` to `sourcePaths()` for cache invalidation tracking

## ✅ Behavior

After this fix, when a user creates `TOOLS.md` in their workspace:

```markdown
## Custom Tool Instructions

When using the exec tool:
- Always run commands in dry-run mode first
- Specify timeout for long-running commands
```

The content will be automatically injected into the system prompt and visible to the LLM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)