### PR TITLE
fix(web): serve SVG with image/svg+xml

### DIFF
--- a/web/backend/embed.go
+++ b/web/backend/embed.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"io/fs"
 	"log"
+	"mime"
 	"net/http"
 	"path"
 	"strings"
@@ -14,6 +15,10 @@ var frontendFS embed.FS
 
 // registerEmbedRoutes sets up the HTTP handler to serve the embedded frontend files
 func registerEmbedRoutes(mux *http.ServeMux) {
+	if err := mime.AddExtensionType(".svg", "image/svg+xml"); err != nil {
+		log.Printf("Warning: failed to register SVG MIME type: %v", err)
+	}
+
 	// Attempt to get the subdirectory 'dist' where Vite usually builds
 	subFS, err := fs.Sub(frontendFS, "dist")
 	if err != nil {

--- a/web/backend/embed_test.go
+++ b/web/backend/embed_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"mime"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,5 +30,18 @@ func TestMissingAssetStays404(t *testing.T) {
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestRegisterEmbedRoutesRegistersSVGContentType(t *testing.T) {
+	if err := mime.AddExtensionType(".svg", "image/svg"); err != nil {
+		t.Fatalf("AddExtensionType() seed error: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	registerEmbedRoutes(mux)
+
+	if got := mime.TypeByExtension(".svg"); got != "image/svg+xml" {
+		t.Fatalf("TypeByExtension(.svg) = %q, want %q", got, "image/svg+xml")
 	}
 }


### PR DESCRIPTION
## 📝 Description

Register `.svg` as `image/svg+xml` before serving embedded frontend assets so browsers receive the standards-compliant MIME type for SVG resources.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1410

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1410
- **Reasoning:** Go can report `.svg` as `image/svg` on some platforms, so the embedded static server now forces the correct `image/svg+xml` mapping before requests are served.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows 11
- **Model/Provider:** N/A
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- `go test ./web/backend -run 'Test(UnknownAPIPathStays404|MissingAssetStays404|RegisterEmbedRoutesRegistersSVGContentType)' -count=1`

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.