### PR TITLE
fix(cron): honor schedule time zones

### DIFF
--- a/pkg/cron/service.go
+++ b/pkg/cron/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -286,6 +287,14 @@ func (cs *CronService) computeNextRun(schedule *CronSchedule, nowMS int64) *int6
 
 		// Use gronx to calculate next run time
 		now := time.UnixMilli(nowMS)
+		if tz := strings.TrimSpace(schedule.TZ); tz != "" {
+			loc, err := time.LoadLocation(tz)
+			if err != nil {
+				log.Printf("[cron] failed to load timezone %q: %v", tz, err)
+			} else {
+				now = now.In(loc)
+			}
+		}
 		nextTime, err := gronx.NextTickAfter(schedule.Expr, now, false)
 		if err != nil {
 			log.Printf("[cron] failed to compute next run for expr '%s': %v", schedule.Expr, err)

--- a/pkg/cron/service_test.go
+++ b/pkg/cron/service_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 )
 
 func TestSaveStore_FilePermissions(t *testing.T) {
@@ -31,6 +32,48 @@ func TestSaveStore_FilePermissions(t *testing.T) {
 	if perm != 0o600 {
 		t.Errorf("cron store has permission %04o, want 0600", perm)
 	}
+}
+
+func TestComputeNextRun_UsesScheduleTimeZone(t *testing.T) {
+	cs := NewCronService(filepath.Join(t.TempDir(), "cron", "jobs.json"), nil)
+	now := time.Date(2026, time.March, 13, 12, 30, 0, 0, time.UTC).UnixMilli()
+	baseline := cs.computeNextRun(&CronSchedule{Kind: "cron", Expr: "0 9 * * *"}, now)
+	if baseline == nil {
+		t.Fatal("baseline computeNextRun() returned nil")
+	}
+
+	t.Run("uses explicit timezone", func(t *testing.T) {
+		next := cs.computeNextRun(&CronSchedule{
+			Kind: "cron",
+			Expr: "0 9 * * *",
+			TZ:   "America/New_York",
+		}, now)
+		if next == nil {
+			t.Fatal("computeNextRun() returned nil")
+		}
+
+		wantNext := time.Date(2026, time.March, 13, 13, 0, 0, 0, time.UTC).UnixMilli()
+		if *next != wantNext {
+			t.Fatalf("computeNextRun() = %d, want %d", *next, wantNext)
+		}
+		if *next == *baseline {
+			t.Fatal("explicit timezone should change the computed next run for this fixture")
+		}
+	})
+
+	t.Run("falls back to baseline on invalid timezone", func(t *testing.T) {
+		next := cs.computeNextRun(&CronSchedule{
+			Kind: "cron",
+			Expr: "0 9 * * *",
+			TZ:   "Mars/OlympusMons",
+		}, now)
+		if next == nil {
+			t.Fatal("computeNextRun() returned nil")
+		}
+		if *next != *baseline {
+			t.Fatalf("computeNextRun() = %d, want baseline %d", *next, *baseline)
+		}
+	})
 }
 
 func int64Ptr(v int64) *int64 {


### PR DESCRIPTION
## 📝 Description

Honor `schedule.tz` when computing the next run time for cron expressions so scheduled jobs execute in the intended timezone instead of always following the process default timezone.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1044

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1044
- **Reasoning:** `computeNextRun()` now loads `schedule.TZ`, evaluates the cron expression in that location, and keeps the existing baseline behavior when the timezone is empty or invalid.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows 11
- **Model/Provider:** N/A
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- `go test ./pkg/cron -run 'Test(SaveStore_FilePermissions|ComputeNextRun_UsesScheduleTimeZone)' -count=1`

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.