### PR TITLE
fix(spawn): use target agent model

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -224,6 +224,17 @@ func registerSharedTools(
 			if cfg.Tools.IsToolEnabled("subagent") {
 				subagentManager := tools.NewSubagentManager(provider, agent.Model, agent.Workspace)
 				subagentManager.SetLLMOptions(agent.MaxTokens, agent.Temperature)
+				subagentManager.SetAgentModelResolver(func(targetAgentID string) (string, bool) {
+					target, ok := registry.GetAgent(targetAgentID)
+					if !ok {
+						return "", false
+					}
+					model := strings.TrimSpace(target.Model)
+					if model == "" {
+						return "", false
+					}
+					return model, true
+				})
 				spawnTool := tools.NewSpawnTool(subagentManager)
 				currentAgentID := agentID
 				spawnTool.SetAllowlistChecker(func(targetAgentID string) bool {

--- a/pkg/tools/spawn_test.go
+++ b/pkg/tools/spawn_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSpawnTool_Execute_EmptyTask(t *testing.T) {
@@ -75,5 +76,47 @@ func TestSpawnTool_Execute_NilManager(t *testing.T) {
 	}
 	if !strings.Contains(result.ForLLM, "Subagent manager not configured") {
 		t.Errorf("Error message should mention manager not configured, got: %s", result.ForLLM)
+	}
+}
+
+func TestSpawnTool_ExecuteAsync_UsesTargetAgentModel(t *testing.T) {
+	provider := &MockLLMProvider{}
+	manager := NewSubagentManager(provider, "caller-model", "/tmp/test")
+	manager.SetAgentModelResolver(func(agentID string) (string, bool) {
+		if agentID == "analyst" {
+			return "target-model", true
+		}
+		return "", false
+	})
+	tool := NewSpawnTool(manager)
+
+	done := make(chan struct{})
+	ctx := WithToolContext(context.Background(), "cli", "direct")
+	args := map[string]any{
+		"task":     "Write a haiku about coding",
+		"agent_id": "analyst",
+	}
+
+	result := tool.ExecuteAsync(ctx, args, func(context.Context, *ToolResult) {
+		close(done)
+	})
+	if result == nil {
+		t.Fatal("Result should not be nil")
+	}
+	if result.IsError {
+		t.Fatalf("Expected success for valid task, got error: %s", result.ForLLM)
+	}
+	if !result.Async {
+		t.Fatal("SpawnTool should return async result")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("spawn callback was not invoked")
+	}
+
+	if provider.lastModel != "target-model" {
+		t.Fatalf("lastModel = %q, want %q", provider.lastModel, "target-model")
 	}
 }

--- a/pkg/tools/subagent.go
+++ b/pkg/tools/subagent.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,6 +27,7 @@ type SubagentManager struct {
 	mu             sync.RWMutex
 	provider       providers.LLMProvider
 	defaultModel   string
+	agentModelFor  func(string) (string, bool)
 	workspace      string
 	tools          *ToolRegistry
 	maxIterations  int
@@ -59,6 +61,13 @@ func (sm *SubagentManager) SetLLMOptions(maxTokens int, temperature float64) {
 	sm.hasMaxTokens = true
 	sm.temperature = temperature
 	sm.hasTemperature = true
+}
+
+// SetAgentModelResolver resolves the effective model for a targeted subagent.
+func (sm *SubagentManager) SetAgentModelResolver(resolve func(string) (string, bool)) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.agentModelFor = resolve
 }
 
 // SetTools sets the tool registry for subagent execution.
@@ -142,12 +151,20 @@ After completing the task, provide a clear summary of what was done.`
 	// Run tool loop with access to tools
 	sm.mu.RLock()
 	tools := sm.tools
+	model := sm.defaultModel
+	agentModelFor := sm.agentModelFor
 	maxIter := sm.maxIterations
 	maxTokens := sm.maxTokens
 	temperature := sm.temperature
 	hasMaxTokens := sm.hasMaxTokens
 	hasTemperature := sm.hasTemperature
 	sm.mu.RUnlock()
+
+	if task.AgentID != "" && agentModelFor != nil {
+		if resolvedModel, ok := agentModelFor(task.AgentID); ok && strings.TrimSpace(resolvedModel) != "" {
+			model = strings.TrimSpace(resolvedModel)
+		}
+	}
 
 	var llmOptions map[string]any
 	if hasMaxTokens || hasTemperature {
@@ -162,7 +179,7 @@ After completing the task, provide a clear summary of what was done.`
 
 	loopResult, err := RunToolLoop(ctx, ToolLoopConfig{
 		Provider:      sm.provider,
-		Model:         sm.defaultModel,
+		Model:         model,
 		Tools:         tools,
 		MaxIterations: maxIter,
 		LLMOptions:    llmOptions,

--- a/pkg/tools/subagent_tool_test.go
+++ b/pkg/tools/subagent_tool_test.go
@@ -11,6 +11,7 @@ import (
 // MockLLMProvider is a test implementation of LLMProvider
 type MockLLMProvider struct {
 	lastOptions map[string]any
+	lastModel   string
 }
 
 func (m *MockLLMProvider) Chat(
@@ -21,6 +22,7 @@ func (m *MockLLMProvider) Chat(
 	options map[string]any,
 ) (*providers.LLMResponse, error) {
 	m.lastOptions = options
+	m.lastModel = model
 	// Find the last user message to generate a response
 	for i := len(messages) - 1; i >= 0; i-- {
 		if messages[i].Role == "user" {
@@ -66,6 +68,34 @@ func TestSubagentManager_SetLLMOptions_AppliesToRunToolLoop(t *testing.T) {
 	}
 	if provider.lastOptions["temperature"] != 0.6 {
 		t.Fatalf("temperature = %v, want %v", provider.lastOptions["temperature"], 0.6)
+	}
+}
+
+func TestSubagentManager_RunTask_UsesResolvedTargetAgentModel(t *testing.T) {
+	provider := &MockLLMProvider{}
+	manager := NewSubagentManager(provider, "caller-model", "/tmp/test")
+	manager.SetAgentModelResolver(func(agentID string) (string, bool) {
+		if agentID == "analyst" {
+			return "target-model", true
+		}
+		return "", false
+	})
+
+	task := &SubagentTask{
+		ID:            "subagent-1",
+		Task:          "Do something",
+		AgentID:       "analyst",
+		OriginChannel: "cli",
+		OriginChatID:  "direct",
+	}
+
+	manager.runTask(context.Background(), task, nil)
+
+	if provider.lastModel != "target-model" {
+		t.Fatalf("lastModel = %q, want %q", provider.lastModel, "target-model")
+	}
+	if task.Status != "completed" {
+		t.Fatalf("task.Status = %q, want %q", task.Status, "completed")
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

When `spawn` receives an `agent_id`, resolve that target agent's configured model before running the subagent tool loop instead of always reusing the caller model.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1322

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1322
- **Reasoning:** `SubagentManager` now accepts an agent-model resolver, and the agent loop wires it to the registry so targeted subagents can run with their own configured model while still falling back to the caller model when no target model is resolved.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows 11
- **Model/Provider:** N/A
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- `go test ./pkg/tools -run 'Test(SubagentManager_SetLLMOptions_AppliesToRunToolLoop|SubagentManager_RunTask_UsesResolvedTargetAgentModel|SpawnTool_ExecuteAsync_UsesTargetAgentModel|SpawnTool_Execute_ValidTask|SpawnTool_Execute_EmptyTask|SpawnTool_Execute_NilManager)' -count=1`
- `go test ./pkg/agent -run TestHandleCommand -count=1`

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.