### PR TITLE
fix(qq): propagate account binding metadata

### DIFF
--- a/pkg/channels/qq/qq.go
+++ b/pkg/channels/qq/qq.go
@@ -422,7 +422,9 @@ func (c *QQChannel) handleC2CMessage() event.C2CMessageEventHandler {
 		// Reset msg_seq counter for new inbound message.
 		c.msgSeqCounters.Store(senderID, new(atomic.Uint64))
 
-		metadata := map[string]string{}
+		metadata := map[string]string{
+			"account_id": senderID,
+		}
 
 		sender := bus.SenderInfo{
 			Platform:    "qq",
@@ -494,7 +496,8 @@ func (c *QQChannel) handleGroupATMessage() event.GroupATMessageEventHandler {
 		c.msgSeqCounters.Store(data.GroupID, new(atomic.Uint64))
 
 		metadata := map[string]string{
-			"group_id": data.GroupID,
+			"account_id": senderID,
+			"group_id":   data.GroupID,
 		}
 
 		sender := bus.SenderInfo{

--- a/pkg/channels/qq/qq_test.go
+++ b/pkg/channels/qq/qq_test.go
@@ -1,0 +1,51 @@
+package qq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tencent-connect/botgo/dto"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/channels"
+	"github.com/sipeed/picoclaw/pkg/config"
+)
+
+func newTestQQChannel() (*QQChannel, *bus.MessageBus) {
+	messageBus := bus.NewMessageBus()
+	ch := &QQChannel{
+		BaseChannel: channels.NewBaseChannel("qq", config.QQConfig{}, messageBus, nil),
+		ctx:         context.Background(),
+		dedup:       make(map[string]time.Time),
+		done:        make(chan struct{}),
+	}
+	return ch, messageBus
+}
+
+func TestHandleC2CMessage_PublishesAccountIDMetadata(t *testing.T) {
+	ch, messageBus := newTestQQChannel()
+
+	handler := ch.handleC2CMessage()
+	err := handler(nil, &dto.WSC2CMessageData{
+		ID:      "msg-1",
+		Content: "hello",
+		Author: &dto.User{
+			ID: "7750283E123456",
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleC2CMessage() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	inbound, ok := messageBus.ConsumeInbound(ctx)
+	if !ok {
+		t.Fatal("expected inbound message to be published")
+	}
+	if inbound.Metadata["account_id"] != "7750283E123456" {
+		t.Fatalf("account_id = %q, want %q", inbound.Metadata["account_id"], "7750283E123456")
+	}
+}


### PR DESCRIPTION
## Summary
- propagate QQ sender IDs into inbound account binding metadata
- keep group messages aligned by exposing the same account_id field
- add a regression test for C2C inbound routing metadata

Closes #1242.