### PR TITLE
fix(qq): include account_id metadata for bindings

### DIFF
--- a/pkg/channels/qq/qq.go
+++ b/pkg/channels/qq/qq.go
@@ -422,7 +422,9 @@ func (c *QQChannel) handleC2CMessage() event.C2CMessageEventHandler {
 		// Reset msg_seq counter for new inbound message.
 		c.msgSeqCounters.Store(senderID, new(atomic.Uint64))
 
-		metadata := map[string]string{}
+		metadata := map[string]string{
+			"account_id": senderID,
+		}
 
 		sender := bus.SenderInfo{
 			Platform:    "qq",
@@ -494,7 +496,8 @@ func (c *QQChannel) handleGroupATMessage() event.GroupATMessageEventHandler {
 		c.msgSeqCounters.Store(data.GroupID, new(atomic.Uint64))
 
 		metadata := map[string]string{
-			"group_id": data.GroupID,
+			"account_id": senderID,
+			"group_id":   data.GroupID,
 		}
 
 		sender := bus.SenderInfo{

--- a/pkg/channels/qq/qq_test.go
+++ b/pkg/channels/qq/qq_test.go
@@ -1,0 +1,44 @@
+package qq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tencent-connect/botgo/dto"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/channels"
+)
+
+func TestHandleC2CMessage_IncludesAccountIDMetadata(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	ch := &QQChannel{
+		BaseChannel: channels.NewBaseChannel("qq", nil, messageBus, nil),
+		dedup:       make(map[string]time.Time),
+		done:        make(chan struct{}),
+		ctx:         context.Background(),
+	}
+
+	err := ch.handleC2CMessage()(nil, &dto.WSC2CMessageData{
+		ID:      "msg-1",
+		Content: "hello",
+		Author: &dto.User{
+			ID: "7750283E123456",
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleC2CMessage() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	inbound, ok := messageBus.ConsumeInbound(ctx)
+	if !ok {
+		t.Fatal("expected inbound message")
+	}
+	if inbound.Metadata["account_id"] != "7750283E123456" {
+		t.Fatalf("account_id metadata = %q, want %q", inbound.Metadata["account_id"], "7750283E123456")
+	}
+}


### PR DESCRIPTION
## Summary
- populate inbound QQ message metadata with ccount_id so bindings.match.account_id resolves correctly
- cover both C2C and group @message flows with the same metadata path
- add a regression test for C2C inbound handling

Fixes #1242

## Test plan
- go test ./pkg/channels/qq -run TestHandleC2CMessage_IncludesAccountIDMetadata -count=1