### PR TITLE
fix(claude_cli): surface stdout in error when CLI exits non-zero

### DIFF
--- a/pkg/providers/claude_cli_provider.go
+++ b/pkg/providers/claude_cli_provider.go
@@ -50,10 +50,18 @@ func (p *ClaudeCliProvider) Chat(
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		if stderrStr := stderr.String(); stderrStr != "" {
+		stderrStr := strings.TrimSpace(stderr.String())
+		stdoutStr := strings.TrimSpace(stdout.String())
+		switch {
+		case stderrStr != "" && stdoutStr != "":
+			return nil, fmt.Errorf("claude cli error: %w\nstderr: %s\nstdout: %s", err, stderrStr, stdoutStr)
+		case stderrStr != "":
 			return nil, fmt.Errorf("claude cli error: %s", stderrStr)
+		case stdoutStr != "":
+			return nil, fmt.Errorf("claude cli error: %w\noutput: %s", err, stdoutStr)
+		default:
+			return nil, fmt.Errorf("claude cli error: %w", err)
 		}
-		return nil, fmt.Errorf("claude cli error: %w", err)
 	}
 
 	return p.parseClaudeCliResponse(stdout.String())


### PR DESCRIPTION
## Problem

When the `claude` CLI exits with a non-zero status code, the provider only checked `stderr` for an error message — but the Claude CLI writes its error output to **stdout**, not stderr. This meant the actual failure reason was silently discarded and callers only saw:

```
claude cli error: exit status 1
```

with no further context, making these failures nearly impossible to diagnose.

## Fix

Updated the error handling in `ClaudeCliProvider.Chat` to capture and include both `stderr` and `stdout` in the error message when the CLI exits non-zero:

- If both stderr and stdout have content, both are included
- If only one has content, that is included
- Falls back to the bare exit error if neither has output

## Why this matters

Users running picoclaw with the `claude-cli` protocol (i.e. shelling out to the `claude` binary) had no way to see errors like authentication failures, permission errors, or invalid arguments — all of which the claude CLI reports via stdout. This fix makes those failures immediately visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)