### PR TITLE
docs: document claude-cli and codex-cli providers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,6 +1040,8 @@ This design also enables **multi-agent support** with flexible provider selectio
 | **LongCat**         | `longcat/`        | `https://api.longcat.chat/openai`                   | OpenAI    | [Get Key](https://longcat.chat/platform)                         |
 | **Antigravity**     | `antigravity/`    | Google Cloud                                        | Custom    | OAuth only                                                       |
 | **GitHub Copilot**  | `github-copilot/` | `localhost:4321`                                    | gRPC      | -                                                                |
+| **Claude CLI**      | `claude-cli/`     | Local (`claude` binary in PATH)                     | CLI       | Uses existing `claude` CLI session                               |
+| **Codex CLI**       | `codex-cli/`      | Local (`codex` binary in PATH)                     | CLI       | Uses existing `codex` CLI session                                |
 
 #### Basic Configuration
 
@@ -1135,6 +1137,30 @@ This design also enables **multi-agent support** with flexible provider selectio
 {
   "model_name": "llama3",
   "model": "ollama/llama3"
+}
+```
+
+**Claude CLI (subscription-based, no API key required)**
+
+Uses the locally installed `claude` CLI binary, authenticating with your existing Claude subscription (Pro, Teams, or Enterprise). No API key is needed.
+
+```json
+{
+  "model_name": "claude-code",
+  "model": "claude-cli/claude-code"
+}
+```
+
+> The model ID `claude-code` is a special sentinel that tells PicoClaw **not** to pass a `--model` flag, letting the CLI use whichever model it is currently configured with. Using any other model ID (e.g. `claude-cli/claude-sonnet-4-5`) will pass `--model <id>` to the CLI.
+
+**Codex CLI (subscription-based, no API key required)**
+
+Uses the locally installed `codex` CLI binary with your existing OpenAI subscription.
+
+```json
+{
+  "model_name": "codex",
+  "model": "codex-cli/codex"
 }
 ```
 


### PR DESCRIPTION
## Summary

- Adds `claude-cli` and `codex-cli` to the supported vendors table
- Adds vendor-specific configuration examples for both CLI providers
- Documents the `claude-code` sentinel model ID and why it's needed

## Details

The `claude-cli` and `codex-cli` protocols allow users with active Claude or OpenAI subscriptions to use PicoClaw **without an API key**, by delegating inference to the locally installed `claude` or `codex` CLI binaries. These providers were already implemented in the code but were undocumented, making them effectively invisible to users.

### The `claude-code` sentinel

When configuring `claude-cli`, the model ID portion of the `model` field is passed as `--model <id>` to the CLI. Using `claude-code` as the model ID is a special case: it suppresses the `--model` flag entirely, letting the CLI use its own configured default. Without this documentation, users would naturally try `claude-cli/claude-cli` or similar, which causes the CLI to fail with:

```
There's an issue with the selected model (claude-cli). It may not exist or you may not have access to it.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)