### PR TITLE
fix(line): add request body size limit to webhook handler

### DIFF
--- a/pkg/channels/line/line.go
+++ b/pkg/channels/line/line.go
@@ -166,12 +166,18 @@ func (c *LINEChannel) webhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := io.ReadAll(r.Body)
+	// Limit request body to 4 MB to prevent memory exhaustion (DoS).
+	const maxBodySize = 4 << 20 // 4 MB
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
 	if err != nil {
 		logger.ErrorCF("line", "Failed to read request body", map[string]any{
 			"error": err.Error(),
 		})
 		http.Error(w, "Bad request", http.StatusBadRequest)
+		return
+	}
+	if len(body) > maxBodySize {
+		http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Add `io.LimitReader` with 4 MB cap to LINE webhook handler to prevent unauthenticated DoS via unbounded request body reads
- Reject oversized payloads with `413 Request Entity Too Large` before signature verification or JSON parsing
- Follows the same pattern already used by the WeCom channel (`pkg/channels/wecom/aibot.go`)

## Problem

The LINE webhook handler uses `io.ReadAll(r.Body)` without any size limit. Since the webhook endpoint must be internet-reachable, an attacker can send arbitrarily large POST bodies to exhaust memory and crash the process.

## Fix

```go
const maxBodySize = 4 << 20 // 4 MB
body, err := io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
// ... error handling ...
if len(body) > maxBodySize {
    http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
    return
}
```

The `maxBodySize+1` trick (read one byte more than the limit) allows distinguishing between a body that fits exactly vs. one that exceeds the limit, without silently truncating valid payloads.

## Test plan

- [ ] Verify normal LINE webhook events (< 4 MB) are processed correctly
- [ ] Verify oversized POST bodies return 413 status
- [ ] Verify `go vet` and `make lint` pass

Fixes #1407