### PR TITLE
feat(web):Add option to control access to local/private IPs

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -328,7 +328,8 @@
         "search_engine": "search_std",
         "max_results": 5
       },
-      "fetch_limit_bytes": 10485760
+      "fetch_limit_bytes": 10485760,
+      "allow_private_hosts": false
     },
     "cron": {
       "enabled": true,

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -114,6 +114,9 @@ func registerSharedTools(
 	registry *AgentRegistry,
 	provider providers.LLMProvider,
 ) {
+	// Apply global settings that affect tool behavior.
+	tools.SetAllowPrivateWebFetchHosts(cfg.Tools.Web.AllowPrivateHosts)
+
 	for _, agentID := range registry.ListAgentIDs() {
 		agent, ok := registry.GetAgent(agentID)
 		if !ok {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -692,6 +692,9 @@ type WebToolsConfig struct {
 	// For authenticated proxies, prefer HTTP_PROXY/HTTPS_PROXY env vars instead of embedding credentials in config.
 	Proxy           string `json:"proxy,omitempty"             env:"PICOCLAW_TOOLS_WEB_PROXY"`
 	FetchLimitBytes int64  `json:"fetch_limit_bytes,omitempty" env:"PICOCLAW_TOOLS_WEB_FETCH_LIMIT_BYTES"`
+	// AllowPrivateHosts controls whether web_fetch may connect to local/private IPs.
+	// Defaults to false to reduce SSRF exposure.
+	AllowPrivateHosts bool `json:"allow_private_hosts" env:"PICOCLAW_TOOLS_WEB_ALLOW_PRIVATE_HOSTS"`
 }
 
 type CronToolsConfig struct {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -395,6 +395,7 @@ func DefaultConfig() *Config {
 				},
 				Proxy:           "",
 				FetchLimitBytes: 10 * 1024 * 1024, // 10MB by default
+				AllowPrivateHosts: false,
 				Brave: BraveConfig{
 					Enabled:    false,
 					APIKey:     "",

--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -823,6 +823,12 @@ func NewWebFetchTool(maxChars int, fetchLimitBytes int64) (*WebFetchTool, error)
 // This is false in normal runtime to reduce SSRF exposure, and tests can override it temporarily.
 var allowPrivateWebFetchHosts atomic.Bool
 
+// SetAllowPrivateWebFetchHosts configures whether the web_fetch tool may access local/private IPs.
+// This is normally false to reduce SSRF attack surface.
+func SetAllowPrivateWebFetchHosts(allow bool) {
+	allowPrivateWebFetchHosts.Store(allow)
+}
+
 func NewWebFetchToolWithProxy(maxChars int, proxy string, fetchLimitBytes int64) (*WebFetchTool, error) {
 	if maxChars <= 0 {
 		maxChars = defaultMaxChars


### PR DESCRIPTION
Add option to control access to local/private IPs

## 📝 Description

This PR introduces a configuration option to toggle access to local/private IP addresses. While the core logic for handling private networks exists, this "master switch" allows users to explicitly enable or disable access to internal hosts based on their security or networking requirements.

## 🗣️ Type of Change
- [ ] ✨ New feature (non-breaking change which adds functionality)

## 🤖 AI Code Generation
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** Raspberry Pi 4B
- **OS:** Docker
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
</details>

🧩  Use It
Set in your config:

"tools": {  "web": {    "allow_private_hosts": true  }}
Or via env var:

PICOCLAW_TOOLS_WEB_ALLOW_PRIVATE_HOSTS=true

Then Compose.yml ：

    environment:
      - HTTP_PROXY=xxx
      - HTTPS_PROXY=xxx
      - ALL_PROXY=xxx
      - NO_PROXY=localhost,127.0.0.1,host.docker.internal,172.16.0.0/12,192.168.0.0/16,10.0.0.0/8

## ☑️ Checklist
- [ ] My code/docs follow the style of this project.
- [ ] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.