### PR TITLE
feat(logger): make time format configurable via config.json

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -510,6 +510,9 @@
   "voice": {
     "echo_transcription": false
   },
+  "logger": {
+    "time_format": "15:04:05"
+  },
   "gateway": {
     "host": "127.0.0.1",
     "port": 18790

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/caarlos0/env/v11"
 
 	"github.com/sipeed/picoclaw/pkg/fileutil"
+	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
 // rrCounter is a global counter for round-robin load balancing across models.
@@ -74,6 +75,10 @@ func (f *FlexibleStringSlice) UnmarshalText(text []byte) error {
 	return nil
 }
 
+type LoggerConfig struct {
+	TimeFormat string `json:"time_format,omitempty"`
+}
+
 type Config struct {
 	Agents    AgentsConfig    `json:"agents"`
 	Bindings  []AgentBinding  `json:"bindings,omitempty"`
@@ -86,6 +91,7 @@ type Config struct {
 	Heartbeat HeartbeatConfig `json:"heartbeat"`
 	Devices   DevicesConfig   `json:"devices"`
 	Voice     VoiceConfig     `json:"voice"`
+	Logger    LoggerConfig    `json:"logger,omitempty"`
 	// BuildInfo contains build-time version information
 	BuildInfo BuildInfo `json:"build_info,omitempty"`
 }
@@ -852,6 +858,11 @@ func LoadConfig(path string) (*Config, error) {
 	// Validate model_list for uniqueness and required fields
 	if err := cfg.ValidateModelList(); err != nil {
 		return nil, err
+	}
+
+	// Apply logger configuration if present
+	if cfg.Logger.TimeFormat != "" {
+		logger.SetTimeFormat(cfg.Logger.TimeFormat)
 	}
 
 	return cfg, nil

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -44,12 +44,25 @@ func init() {
 
 		consoleWriter := zerolog.ConsoleWriter{
 			Out:        os.Stdout,
-			TimeFormat: "15:04:05", // TODO: make it configurable???
+			TimeFormat: "15:04:05",
 		}
 
 		logger = zerolog.New(consoleWriter).With().Timestamp().Logger()
 		fileLogger = zerolog.Logger{}
 	})
+}
+
+// SetTimeFormat updates the logger's time format dynamically at runtime.
+func SetTimeFormat(format string) {
+	if format == "" {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	logger = zerolog.New(zerolog.ConsoleWriter{
+		Out:        os.Stdout,
+		TimeFormat: format,
+	}).With().Timestamp().Logger()
 }
 
 func SetLevel(level LogLevel) {


### PR DESCRIPTION
## 📝 Description

Users can now configure the logger's time format through config.json instead of using the hardcoded default.

**Changes:**
- `pkg/logger/logger.go`: Added `SetTimeFormat()` function for runtime configuration
- `pkg/config/config.go`: Added `LoggerConfig` struct and wired it into `LoadConfig()`
- `config/config.example.json`: Added logger configuration example

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context
- **Reference URL:**
- **Reasoning:** Thread-safe runtime configuration using mutex protection. Backward-compatible with default time format "15:04:05".

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows 11
- **Model/Provider:** N/A
- **Channels:** N/A (provider-level change)


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

**Test Results:**
```
=== RUN   TestLoadConfig_OpenAIWebSearchDefaultsTrueWhenUnset
--- PASS: TestLoadConfig_OpenAIWebSearchDefaultsTrueWhenUnset (0.01s)
=== RUN   TestLoadConfig_ExecAllowRemoteDefaultsTrueWhenUnset
--- PASS: TestLoadConfig_ExecAllowRemoteDefaultsTrueWhenUnset (0.00s)
=== RUN   TestLoadConfig_OpenAIWebSearchCanBeDisabled
--- PASS: TestLoadConfig_OpenAIWebSearchCanBeDisabled (0.01s)
=== RUN   TestLoadConfig_WebToolsProxy
--- PASS: TestLoadConfig_WebToolsProxy (0.01s)
PASS
ok      github.com/sipeed/picoclaw/pkg/config   1.125s
```

With config.json containing:
```json
{
  "logger": {
    "time_format": "2006-01-02 15:04:05"
  }
}
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
