### PR TITLE
#434 is missing NetBSD support for picoclaw-launcher{-tui}

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,6 +65,7 @@ builds:
       - windows
       - darwin
       - freebsd
+      - netbsd
     goarch:
       - amd64
       - arm64
@@ -82,6 +83,12 @@ builds:
     ignore:
       - goos: windows
         goarch: arm
+      - goos: netbsd
+        goarch: s390x
+      - goos: netbsd
+        goarch: mips64
+      - goos: netbsd
+        goarch: arm
 
   - id: picoclaw-launcher-tui
     binary: picoclaw-launcher-tui
@@ -96,6 +103,7 @@ builds:
       - windows
       - darwin
       - freebsd
+      - netbsd
     goarch:
       - amd64
       - arm64
@@ -112,6 +120,12 @@ builds:
     main: ./cmd/picoclaw-launcher-tui
     ignore:
       - goos: windows
+        goarch: arm
+      - goos: netbsd
+        goarch: s390x
+      - goos: netbsd
+        goarch: mips64
+      - goos: netbsd
         goarch: arm
 
 dockers_v2:


### PR DESCRIPTION

## 📝 Description

PR #434 has just been merged but as it was requested a month ago, `picoclaw-launcher` and `picoclaw-launcher-tui` weren't present at that time. This PR adds them to the released files.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

Not related to an issue

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/pull/434
- **Reasoning:** the previous pull request was done a month ago, `picoclaw-launcher` and `picoclaw-launcher-tui` did not exist

## 🧪 Test Environment
- **Hardware:** microVM (Linux/KVM) running on an AMD Ryzen 5 5600X
- **OS:** NetBSD/smolBSD 11
- **Model/Provider:** qwen3.5-35b-q3/llama.cpp
- **Channels:** Telegram, IRC


## 📸 Evidence (Optional)

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [N/A] I have updated the documentation accordingly.