### PR TITLE
docs(cron): show how to view scheduled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1409,6 +1409,20 @@ PicoClaw supports scheduled reminders and recurring tasks through the `cron` too
 * **Recurring tasks**: "Remind me every 2 hours" → triggers every 2 hours
 * **Cron expressions**: "Remind me at 9am daily" → uses cron expression
 
+To view your scheduled tasks:
+
+```bash
+picoclaw cron list
+```
+
+Useful follow-up commands:
+
+```bash
+picoclaw cron disable 1   # pause job 1
+picoclaw cron enable 1    # resume job 1
+picoclaw cron remove 1    # delete job 1
+```
+
 Jobs are stored in `~/.picoclaw/workspace/cron/` and processed automatically.
 
 ## 🤝 Contribute & Roadmap

--- a/cmd/picoclaw/internal/cron/command.go
+++ b/cmd/picoclaw/internal/cron/command.go
@@ -16,7 +16,14 @@ func NewCronCommand() *cobra.Command {
 		Use:     "cron",
 		Aliases: []string{"c"},
 		Short:   "Manage scheduled tasks",
-		Args:    cobra.NoArgs,
+		Long: `Manage scheduled tasks.
+
+Use 'picoclaw cron list' to view all jobs currently scheduled in your workspace.`,
+		Example: `picoclaw cron list
+picoclaw cron add "Daily standup" "0 9 * * 1-5"
+picoclaw cron disable 1
+picoclaw cron remove 1`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},

--- a/cmd/picoclaw/internal/cron/command_test.go
+++ b/cmd/picoclaw/internal/cron/command_test.go
@@ -14,6 +14,8 @@ func TestNewCronCommand(t *testing.T) {
 	require.NotNil(t, cmd)
 
 	assert.Equal(t, "Manage scheduled tasks", cmd.Short)
+	assert.Contains(t, cmd.Long, "picoclaw cron list")
+	assert.Contains(t, cmd.Example, "picoclaw cron list")
 
 	assert.Len(t, cmd.Aliases, 1)
 	assert.True(t, cmd.HasAlias("c"))
@@ -46,6 +48,9 @@ func TestNewCronCommand(t *testing.T) {
 
 		assert.Len(t, subcmd.Aliases, 0)
 		assert.False(t, subcmd.Hidden)
+		if subcmd.Name() == "list" {
+			assert.Contains(t, subcmd.Example, "picoclaw cron list")
+		}
 
 		assert.False(t, subcmd.HasSubCommands())
 

--- a/cmd/picoclaw/internal/cron/list.go
+++ b/cmd/picoclaw/internal/cron/list.go
@@ -4,9 +4,10 @@ import "github.com/spf13/cobra"
 
 func newListCommand(storePath func() string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List all scheduled jobs",
-		Args:  cobra.NoArgs,
+		Use:     "list",
+		Short:   "List all scheduled jobs",
+		Example: `picoclaw cron list`,
+		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cronListCmd(storePath())
 			return nil


### PR DESCRIPTION
## 📝 Description

Answer issue #1501 directly in both the README and CLI help.

**Changes:**
- Add an explicit `picoclaw cron list` example to the README section about scheduled tasks
- Document the related `disable`, `enable`, and `remove` commands in the same section
- Add help text/examples to the `picoclaw cron` root command and `picoclaw cron list`
- Extend cron command tests to cover the new help text

## 🔗 Related Issue
Fixes #1501

## 🧪 Verification
- `go test ./cmd/picoclaw/internal/cron`
