### PR TITLE
docker(launcher): include Node.js runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ docker compose -f docker/docker-compose.yml --profile gateway down
 ### Launcher Mode (Web Console)
 
 The `launcher` image includes all three binaries (`picoclaw`, `picoclaw-launcher`, `picoclaw-launcher-tui`) and starts the web console by default, which provides a browser-based UI for configuration and chat.
+It also ships with a Node.js runtime so npm-based MCP servers and scripts can run inside the launcher container without rebuilding the image.
 
 ```bash
 docker compose -f docker/docker-compose.yml --profile launcher up -d

--- a/docker/Dockerfile.goreleaser.launcher
+++ b/docker/Dockerfile.goreleaser.launcher
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM node:24-alpine3.23
 
 ARG TARGETPLATFORM
 

--- a/docker/launcher_dockerfile_test.go
+++ b/docker/launcher_dockerfile_test.go
@@ -1,0 +1,25 @@
+package docker
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLauncherDockerfileIncludesNodeRuntime(t *testing.T) {
+	data, err := os.ReadFile("Dockerfile.goreleaser.launcher")
+	if err != nil {
+		t.Fatalf("read Dockerfile.goreleaser.launcher: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "FROM node:") {
+		t.Fatalf("launcher Dockerfile should use a Node.js runtime base image, got:\n%s", content)
+	}
+	if !strings.Contains(content, "COPY $TARGETPLATFORM/picoclaw-launcher /usr/local/bin/picoclaw-launcher") {
+		t.Fatal("launcher Dockerfile should still copy the launcher binary")
+	}
+	if !strings.Contains(content, "ENTRYPOINT [\"picoclaw-launcher\"]") {
+		t.Fatal("launcher Dockerfile should keep picoclaw-launcher as the entrypoint")
+	}
+}


### PR DESCRIPTION
## Summary\n- switch the goreleaser launcher image from plain Alpine to the same Node-based runtime family used by the full image\n- document that the launcher container now includes Node.js for npm-based MCP servers and scripts\n- add a regression test that asserts the launcher Dockerfile keeps using a Node runtime base image\n\n## Testing\n- go test ./docker\n\n## Notes\n- I could not run docker build locally because Docker is not installed in this environment.\n\nCloses #1371