### PR TITLE
fix(channels): harden all channels against unbounded read DoS

### DIFF
--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -636,11 +636,21 @@ func (c *FeishuChannel) downloadResource(
 		return ""
 	}
 
-	if _, copyErr := io.Copy(out, resp.File); copyErr != nil {
+	maxSize := int64(utils.MaxMediaDownloadSize)
+	written, copyErr := io.CopyN(out, resp.File, maxSize)
+	if copyErr != nil && copyErr != io.EOF {
 		out.Close()
 		os.Remove(localPath)
 		logger.ErrorCF("feishu", "Failed to write resource to file", map[string]any{
 			"error": copyErr.Error(),
+		})
+		return ""
+	}
+	if written >= maxSize {
+		out.Close()
+		os.Remove(localPath)
+		logger.ErrorCF("feishu", "Resource exceeds size limit, download aborted", map[string]any{
+			"limit_mb": maxSize / (1 << 20),
 		})
 		return ""
 	}

--- a/pkg/channels/line/line.go
+++ b/pkg/channels/line/line.go
@@ -663,7 +663,7 @@ func (c *LINEChannel) callAPI(ctx context.Context, endpoint string, payload any)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, err := io.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 		if err != nil {
 			return channels.ClassifySendError(resp.StatusCode, fmt.Errorf("reading LINE API error response: %w", err))
 		}

--- a/pkg/channels/matrix/matrix.go
+++ b/pkg/channels/matrix/matrix.go
@@ -765,9 +765,14 @@ func (c *MatrixChannel) downloadMedia(
 		}
 	}()
 
-	_, err = io.Copy(tmp, reader)
-	if err != nil {
+	// Limit media download to 50 MB to prevent disk exhaustion.
+	const maxMediaSize int64 = 50 << 20 // 50 MB
+	written, err := io.CopyN(tmp, reader, maxMediaSize)
+	if err != nil && err != io.EOF {
 		return "", err
+	}
+	if written >= maxMediaSize {
+		return "", fmt.Errorf("matrix media exceeds %d MB size limit", maxMediaSize/(1<<20))
 	}
 	if err = readerClose(); err != nil {
 		return "", fmt.Errorf("decrypt matrix media: %w", err)

--- a/pkg/channels/wecom/aibot.go
+++ b/pkg/channels/wecom/aibot.go
@@ -793,7 +793,7 @@ func (c *WeComAIBotChannel) sendViaResponseURL(responseURL, content string) erro
 		return nil
 	}
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return fmt.Errorf("reading response_url body: %w: %w", channels.ErrTemporary, err)
 	}

--- a/pkg/channels/wecom/app.go
+++ b/pkg/channels/wecom/app.go
@@ -320,8 +320,9 @@ func (c *WeComAppChannel) uploadMedia(ctx context.Context, accessToken, mediaTyp
 	}
 	defer resp.Body.Close()
 
+	const maxRespSize = 1 << 20 // 1 MB
 	if resp.StatusCode != http.StatusOK {
-		respBody, readErr := io.ReadAll(resp.Body)
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxRespSize))
 		if readErr != nil {
 			return "", channels.ClassifySendError(
 				resp.StatusCode,
@@ -379,8 +380,9 @@ func (c *WeComAppChannel) sendWeComMessage(ctx context.Context, accessToken stri
 	}
 	defer resp.Body.Close()
 
+	const maxSendRespSize = 1 << 20 // 1 MB
 	if resp.StatusCode != http.StatusOK {
-		respBody, readErr := io.ReadAll(resp.Body)
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxSendRespSize))
 		if readErr != nil {
 			return channels.ClassifySendError(
 				resp.StatusCode,
@@ -393,7 +395,7 @@ func (c *WeComAppChannel) sendWeComMessage(ctx context.Context, accessToken stri
 		)
 	}
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxSendRespSize))
 	if err != nil {
 		return fmt.Errorf("failed to read response: %w", err)
 	}
@@ -550,13 +552,18 @@ func (c *WeComAppChannel) handleMessageCallback(ctx context.Context, w http.Resp
 		return
 	}
 
-	// Read request body
-	body, err := io.ReadAll(r.Body)
+	// Read request body (limit to 4 MB to prevent memory exhaustion).
+	const maxBodySize = 4 << 20 // 4 MB
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
 		return
 	}
 	defer r.Body.Close()
+	if len(body) > maxBodySize {
+		http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
 
 	// Parse XML to get encrypted message
 	var encryptedMsg struct {
@@ -697,7 +704,7 @@ func (c *WeComAppChannel) refreshAccessToken() error {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return fmt.Errorf("failed to read response: %w", err)
 	}

--- a/pkg/channels/wecom/bot.go
+++ b/pkg/channels/wecom/bot.go
@@ -253,13 +253,18 @@ func (c *WeComBotChannel) handleMessageCallback(ctx context.Context, w http.Resp
 		return
 	}
 
-	// Read request body
-	body, err := io.ReadAll(r.Body)
+	// Read request body (limit to 4 MB to prevent memory exhaustion).
+	const maxBodySize = 4 << 20 // 4 MB
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
 		return
 	}
 	defer r.Body.Close()
+	if len(body) > maxBodySize {
+		http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
 
 	// Parse XML to get encrypted message
 	var encryptedMsg struct {
@@ -452,8 +457,9 @@ func (c *WeComBotChannel) sendWebhookReply(ctx context.Context, userID, content 
 	}
 	defer resp.Body.Close()
 
+	const maxRespSize = 1 << 20 // 1 MB
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxRespSize))
 		if readErr != nil {
 			return channels.ClassifySendError(
 				resp.StatusCode,
@@ -466,7 +472,7 @@ func (c *WeComBotChannel) sendWebhookReply(ctx context.Context, userID, content 
 		)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRespSize))
 	if err != nil {
 		return fmt.Errorf("failed to read response: %w", err)
 	}

--- a/pkg/utils/media.go
+++ b/pkg/utils/media.go
@@ -48,12 +48,17 @@ func SanitizeFilename(filename string) string {
 	return base
 }
 
+// MaxMediaDownloadSize is the upper bound for media file downloads (50 MB).
+// Prevents disk exhaustion from oversized or malicious attachments.
+const MaxMediaDownloadSize = 50 << 20
+
 // DownloadOptions holds optional parameters for downloading files
 type DownloadOptions struct {
 	Timeout      time.Duration
 	ExtraHeaders map[string]string
 	LoggerPrefix string
 	ProxyURL     string
+	MaxSize      int64 // 0 = use MaxMediaDownloadSize default
 }
 
 // DownloadFile downloads a file from URL to a local temp directory.
@@ -134,11 +139,24 @@ func DownloadFile(urlStr, filename string, opts DownloadOptions) string {
 	}
 	defer out.Close()
 
-	if _, err := io.Copy(out, resp.Body); err != nil {
+	maxSize := opts.MaxSize
+	if maxSize <= 0 {
+		maxSize = MaxMediaDownloadSize
+	}
+	written, err := io.CopyN(out, resp.Body, maxSize)
+	if err != nil && err != io.EOF {
 		out.Close()
 		os.Remove(localPath)
 		logger.ErrorCF(opts.LoggerPrefix, "Failed to write file", map[string]any{
 			"error": err.Error(),
+		})
+		return ""
+	}
+	if written >= maxSize {
+		out.Close()
+		os.Remove(localPath)
+		logger.ErrorCF(opts.LoggerPrefix, "File exceeds size limit, download aborted", map[string]any{
+			"limit_mb": maxSize / (1 << 20),
 		})
 		return ""
 	}


### PR DESCRIPTION
## Summary

Systematic security sweep across all channel implementations to cap unbounded `io.ReadAll` and `io.Copy` calls that allow remote memory or disk exhaustion. Fixes the same class of vulnerability in 7 files across 3 risk tiers.

## Problem

Multiple channel handlers read request bodies, API responses, and media files without any size limits. An attacker (or compromised API endpoint) can trigger out-of-memory crashes or fill the `/tmp` partition:

- **Inbound webhooks**: WeCom bot and app handlers use bare `io.ReadAll(r.Body)` — internet-facing, unauthenticated, attacker-controlled
- **Outbound API responses**: Error and success responses from WeCom, LINE APIs read without bounds — exploitable via MITM or compromised endpoint
- **Media downloads**: `utils.DownloadFile()` (used by 6 channels), Matrix `DownloadBytes`, and Feishu `downloadResource` write to disk/memory without size caps

## Changes

### Tier 1 — Inbound webhooks (4 MB cap, matches `wecom/aibot.go` pattern)

| File | Function | Fix |
|------|----------|-----|
| `wecom/bot.go` | `handleMessageCallback()` | `io.LimitReader` + 413 reject |
| `wecom/app.go` | `handleMessageCallback()` | `io.LimitReader` + 413 reject |

### Tier 2 — Outbound API responses (1 MB cap)

| File | Function | Fix |
|------|----------|-----|
| `wecom/bot.go` | `sendWeComMessage()` | `io.LimitReader` on error + success reads |
| `wecom/app.go` | `uploadToWeComMedia()` | `io.LimitReader` on error read |
| `wecom/app.go` | `sendWeComMessage()` | `io.LimitReader` on error + success reads |
| `wecom/app.go` | `refreshAccessToken()` | `io.LimitReader` on token response |
| `wecom/aibot.go` | `postToResponseURL()` | `io.LimitReader` on error read |
| `line/line.go` | `sendLineMessage()` | `io.LimitReader` on error read |

### Tier 3 — Media downloads (50 MB cap, prevents disk exhaustion)

| File | Function | Fix | Protects |
|------|----------|-----|----------|
| `utils/media.go` | `DownloadFile()` | `io.CopyN` replaces `io.Copy` | Telegram, Slack, Discord, LINE, Feishu, OneBot |
| `matrix/matrix.go` | `downloadMedia()` | Size check after `DownloadBytes` | Matrix |
| `feishu/feishu_64.go` | `downloadResource()` | `io.CopyN` replaces `io.Copy` | Feishu |

## Size limit rationale

- **4 MB** for webhooks: Matches the existing `wecom/aibot.go` limit. Webhook JSON/XML payloads are typically < 100 KB. 4 MB provides generous headroom.
- **1 MB** for API responses: Error responses and token refreshes should never exceed a few KB. 1 MB is extremely generous.
- **50 MB** for media: Accommodates legitimate video/audio attachments while preventing GB-scale disk exhaustion. Configurable via `DownloadOptions.MaxSize`.

## Test plan

- [ ] `go vet ./pkg/channels/... ./pkg/utils/...` — clean
- [ ] `make lint` — clean
- [ ] Verify WeCom bot/app webhooks accept normal messages (< 4 MB)
- [ ] Verify oversized webhook POST returns 413
- [ ] Verify media downloads succeed for files < 50 MB
- [ ] Verify oversized media downloads are aborted and temp files cleaned up

Fixes #1405