### PR TITLE
fix(agent): clarify that skills are not callable tools

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -145,7 +145,9 @@ func (cb *ContextBuilder) BuildSystemPrompt() string {
 	if skillsSummary != "" {
 		parts = append(parts, fmt.Sprintf(`# Skills
 
-The following skills extend your capabilities. To use a skill, read its SKILL.md file using the read_file tool.
+The following skills extend your capabilities. Skills are documents, not callable tools.
+To use a skill, read its SKILL.md file using the read_file tool.
+Never invoke a skill name directly as a tool or function call, and do not rewrite skill names (for example, do not turn "skill-vetter" into "skill_vetter").
 
 %s`, skillsSummary))
 	}

--- a/pkg/agent/context_cache_test.go
+++ b/pkg/agent/context_cache_test.go
@@ -268,6 +268,34 @@ func TestCacheStability(t *testing.T) {
 	}
 }
 
+func TestBuildSystemPrompt_SkillsAreNotCallableTools(t *testing.T) {
+	tmpDir := setupWorkspace(t, map[string]string{
+		"skills/skill-vetter/SKILL.md": `---
+name: skill-vetter
+description: Vet installed skills for security.
+---
+
+# Skill Vetter
+
+Review skills before installing them.
+`,
+	})
+	defer os.RemoveAll(tmpDir)
+
+	cb := NewContextBuilder(tmpDir)
+	prompt := cb.BuildSystemPrompt()
+
+	if !strings.Contains(prompt, "Skills are documents, not callable tools.") {
+		t.Fatalf("system prompt should explain that skills are not tools: %q", prompt)
+	}
+	if !strings.Contains(prompt, `do not turn "skill-vetter" into "skill_vetter"`) {
+		t.Fatalf("system prompt should warn against rewriting hyphenated skill names: %q", prompt)
+	}
+	if !strings.Contains(prompt, "<name>skill-vetter</name>") {
+		t.Fatalf("system prompt should still list the installed skill: %q", prompt)
+	}
+}
+
 // TestNewFileCreationInvalidatesCache verifies that creating a source file that
 // did not exist when the cache was built triggers a cache rebuild.
 // This catches the "from nothing to something" edge case that the old


### PR DESCRIPTION
## Summary
- make the system prompt explicitly state that skills are documents, not callable tool names
- tell the model to use read_file on SKILL.md instead of invoking a skill name directly
- add a regression test for hyphenated skill names like `skill-vetter`

## Testing
- go test ./pkg/agent

Closes #1533