### PR TITLE
fix(config): disable remote exec by default

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -384,10 +384,10 @@ func TestDefaultConfig_OpenAIWebSearchEnabled(t *testing.T) {
 	}
 }
 
-func TestDefaultConfig_ExecAllowRemoteEnabled(t *testing.T) {
+func TestDefaultConfig_ExecAllowRemoteDisabled(t *testing.T) {
 	cfg := DefaultConfig()
-	if !cfg.Tools.Exec.AllowRemote {
-		t.Fatal("DefaultConfig().Tools.Exec.AllowRemote should be true")
+	if cfg.Tools.Exec.AllowRemote {
+		t.Fatal("DefaultConfig().Tools.Exec.AllowRemote should be false")
 	}
 }
 
@@ -407,7 +407,7 @@ func TestLoadConfig_OpenAIWebSearchDefaultsTrueWhenUnset(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_ExecAllowRemoteDefaultsTrueWhenUnset(t *testing.T) {
+func TestLoadConfig_ExecAllowRemoteDefaultsFalseWhenUnset(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
 	if err := os.WriteFile(configPath, []byte(`{"tools":{"exec":{"enable_deny_patterns":true}}}`), 0o600); err != nil {
@@ -418,8 +418,8 @@ func TestLoadConfig_ExecAllowRemoteDefaultsTrueWhenUnset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfig() error: %v", err)
 	}
-	if !cfg.Tools.Exec.AllowRemote {
-		t.Fatal("tools.exec.allow_remote should remain true when unset in config file")
+	if cfg.Tools.Exec.AllowRemote {
+		t.Fatal("tools.exec.allow_remote should remain false when unset in config file")
 	}
 }
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -449,7 +449,7 @@ func DefaultConfig() *Config {
 					Enabled: true,
 				},
 				EnableDenyPatterns: true,
-				AllowRemote:        true,
+				AllowRemote:        false,
 				TimeoutSeconds:     60,
 			},
 			Skills: SkillsToolsConfig{

--- a/pkg/migrate/sources/openclaw/openclaw_config_test.go
+++ b/pkg/migrate/sources/openclaw/openclaw_config_test.go
@@ -290,7 +290,7 @@ func TestConvertToPicoClaw(t *testing.T) {
 	}
 }
 
-func TestToStandardConfig_ExecAllowRemoteDefaultsTrue(t *testing.T) {
+func TestToStandardConfig_ExecAllowRemoteDefaultsFalse(t *testing.T) {
 	cfg := (&PicoClawConfig{
 		Tools: ToolsConfig{
 			Exec: ExecConfig{
@@ -299,8 +299,8 @@ func TestToStandardConfig_ExecAllowRemoteDefaultsTrue(t *testing.T) {
 		},
 	}).ToStandardConfig()
 
-	if !cfg.Tools.Exec.AllowRemote {
-		t.Fatal("ToStandardConfig() should preserve the default tools.exec.allow_remote=true")
+	if cfg.Tools.Exec.AllowRemote {
+		t.Fatal("ToStandardConfig() should preserve the default tools.exec.allow_remote=false")
 	}
 }
 

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -322,6 +322,24 @@ func TestShellTool_RemoteChannelBlockedByDefault(t *testing.T) {
 	}
 }
 
+func TestShellTool_DefaultConfigBlocksRemoteChannels(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	tool, err := NewExecToolWithConfig("", false, cfg)
+	if err != nil {
+		t.Fatalf("NewExecToolWithConfig() error: %v", err)
+	}
+	ctx := WithToolContext(context.Background(), "telegram", "chat-1")
+	result := tool.Execute(ctx, map[string]any{"command": "echo hi"})
+
+	if !result.IsError {
+		t.Fatal("expected remote-channel exec to be blocked by default config")
+	}
+	if !strings.Contains(result.ForLLM, "restricted to internal channels") {
+		t.Errorf("expected 'restricted to internal channels' message, got: %s", result.ForLLM)
+	}
+}
+
 // TestShellTool_InternalChannelAllowed verifies exec is allowed for internal channels
 func TestShellTool_InternalChannelAllowed(t *testing.T) {
 	cfg := &config.Config{}


### PR DESCRIPTION
## Summary
- change the default `tools.exec.allow_remote` setting to false
- update config and migration tests to match the new fail-closed default
- add a regression test proving the default config blocks exec from remote channels

## Testing
- go test ./pkg/config ./pkg/tools ./pkg/migrate/sources/openclaw

Closes #1525