### PR TITLE
fix(feishu): fix video upload failure by using correct message type a…

### DIFF
--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -770,14 +771,54 @@ func (c *FeishuChannel) sendFile(ctx context.Context, chatID string, file *os.Fi
 		feishuFileType = "mp4"
 	}
 
+	// For video files, extract metadata (thumbnail and duration) before upload
+	var durationPtr *int
+	var imageKey string
+	if fileType == "video" {
+		// Get actual file path from the *os.File object
+		videoPath := file.Name()
+		if videoPath != "" {
+			// Get video metadata (thumbnail and duration)
+			durationSec, thumbKey, err := c.prepareVideoMetadata(ctx, videoPath)
+			if err != nil {
+				logger.ErrorCF("feishu", "Failed to extract video metadata", map[string]any{
+					"error": err.Error(),
+				})
+				// Continue without metadata, durationPtr remains nil
+			} else {
+				// Convert duration to milliseconds for Feishu API
+				durationMs := int(durationSec * 1000)
+				durationPtr = &durationMs
+				imageKey = thumbKey
+				logger.InfoCF("feishu", "Extracted video metadata", map[string]any{
+					"duration_ms": durationMs,
+					"has_thumbnail": imageKey != "",
+				})
+			}
+		} else {
+			logger.ErrorCF("feishu", "Failed to get video file path", nil)
+		}
+	}
+
 	// Upload file to get file_key
-	uploadReq := larkim.NewCreateFileReqBuilder().
+	uploadReqBuilder := larkim.NewCreateFileReqBuilder().
 		Body(larkim.NewCreateFileReqBodyBuilder().
 			FileType(feishuFileType).
 			FileName(filename).
 			File(file).
-			Build()).
-		Build()
+			Build())
+
+	// Set duration for video/audio files if available
+	if durationPtr != nil && *durationPtr > 0 {
+		uploadReqBuilder = uploadReqBuilder.Body(larkim.NewCreateFileReqBodyBuilder().
+			FileType(feishuFileType).
+			FileName(filename).
+			File(file).
+			Duration(*durationPtr).
+			Build())
+	}
+
+	uploadReq := uploadReqBuilder.Build()
 
 	uploadResp, err := c.client.Im.V1.File.Create(ctx, uploadReq)
 	if err != nil {
@@ -792,13 +833,33 @@ func (c *FeishuChannel) sendFile(ctx context.Context, chatID string, file *os.Fi
 
 	fileKey := *uploadResp.Data.FileKey
 
-	// Send file message
-	content, _ := json.Marshal(map[string]string{"file_key": fileKey})
+	// Send file message with appropriate message type
+	var msgType string
+	switch fileType {
+	case "audio":
+		msgType = larkim.MsgTypeAudio
+	case "video":
+		msgType = larkim.MsgTypeMedia
+	default:
+		msgType = larkim.MsgTypeFile
+	}
+
+	var content []byte
+	// For video messages, include image_key if thumbnail was extracted
+	if fileType == "video" && imageKey != "" {
+		content, _ = json.Marshal(map[string]string{
+			"file_key":  fileKey,
+			"image_key": imageKey,
+		})
+	} else {
+		content, _ = json.Marshal(map[string]string{"file_key": fileKey})
+	}
+
 	req := larkim.NewCreateMessageReqBuilder().
 		ReceiveIdType(larkim.ReceiveIdTypeChatId).
 		Body(larkim.NewCreateMessageReqBodyBuilder().
 			ReceiveId(chatID).
-			MsgType(larkim.MsgTypeFile).
+			MsgType(msgType).
 			Content(string(content)).
 			Build()).
 		Build()
@@ -811,6 +872,76 @@ func (c *FeishuChannel) sendFile(ctx context.Context, chatID string, file *os.Fi
 		return fmt.Errorf("feishu file send api error (code=%d msg=%s)", resp.Code, resp.Msg)
 	}
 	return nil
+}
+
+// prepareVideoMetadata extracts a thumbnail from video, uploads it, and gets duration.
+// Returns duration (in seconds), image_key, and any error.
+func (c *FeishuChannel) prepareVideoMetadata(ctx context.Context, videoPath string) (int64, string, error) {
+	// Check if video file exists
+	if _, err := os.Stat(videoPath); os.IsNotExist(err) {
+		return 0, "", fmt.Errorf("video file does not exist: %s", videoPath)
+	}
+
+	// Extract thumbnail from video (first frame at 0.5 seconds)
+	thumbPath := videoPath + ".thumb.jpg"
+	defer func() {
+		os.Remove(thumbPath)
+	}()
+
+	// Use ffmpeg to extract thumbnail
+	cmd := exec.Command("ffmpeg", "-i", videoPath, "-ss", "0.5", "-vframes", "1", "-q:v", "2", "-y", thumbPath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return 0, "", fmt.Errorf("ffmpeg thumbnail extraction failed: %w, output: %s", err, string(output))
+	}
+
+	// Verify thumbnail was created
+	if _, err := os.Stat(thumbPath); os.IsNotExist(err) {
+		return 0, "", fmt.Errorf("thumbnail file was not created: %s", thumbPath)
+	}
+
+	// Open thumbnail file for upload
+	thumbFile, err := os.Open(thumbPath)
+	if err != nil {
+		return 0, "", fmt.Errorf("open thumbnail: %w", err)
+	}
+	defer thumbFile.Close()
+
+	// Upload thumbnail to get image_key
+	uploadReq := larkim.NewCreateImageReqBuilder().
+		Body(larkim.NewCreateImageReqBodyBuilder().
+			ImageType("message").
+			Image(thumbFile).
+			Build()).
+		Build()
+
+	uploadResp, err := c.client.Im.V1.Image.Create(ctx, uploadReq)
+	if err != nil {
+		return 0, "", fmt.Errorf("thumbnail upload: %w", err)
+	}
+	if !uploadResp.Success() {
+		return 0, "", fmt.Errorf("thumbnail upload api error (code=%d msg=%s)", uploadResp.Code, uploadResp.Msg)
+	}
+	if uploadResp.Data == nil || uploadResp.Data.ImageKey == nil {
+		return 0, "", fmt.Errorf("no image_key returned")
+	}
+	imageKey := *uploadResp.Data.ImageKey
+
+	// Get video duration using ffprobe (in seconds as float)
+	cmd = exec.Command("ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", videoPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, imageKey, fmt.Errorf("ffprobe duration failed: %w, output: %s", err, string(output))
+	}
+
+	// Parse duration (float in seconds)
+	var duration float64
+	if _, err := fmt.Sscanf(string(output), "%f", &duration); err != nil {
+		return 0, imageKey, fmt.Errorf("parse duration: %w", err)
+	}
+
+	// Return duration in seconds (will be converted to milliseconds in sendFile)
+	durationSec := int64(duration)
+	return durationSec, imageKey, nil
 }
 
 func extractFeishuSenderID(sender *larkim.EventSender) string {


### PR DESCRIPTION
…nd metadata

Previously, video files were sent using MsgTypeFile instead of MsgTypeMedia, causing upload to succeed but message display to fail. This fix:
- Uses MsgTypeMedia for video and MsgTypeAudio for audio messages
- Extracts video thumbnail and duration via ffmpeg/ffprobe before upload
- Includes image_key (thumbnail) and duration in video message content

## 📝 Description

Fix video file upload to Feishu failing to display properly. Previously, video files were sent using `MsgTypeFile` instead of
  `MsgTypeMedia`, causing the upload to succeed but the message to display incorrectly. This PR also extracts video thumbnail and duration
  metadata before upload to ensure proper rendering.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)

## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
  - **Reference URL:** [Feishu Open API - Send Message](https://open.feishu.cn/document/server-docs/im-v1/message/create)
  - **Reasoning:**
    - Video messages must use `MsgTypeMedia` (not `MsgTypeFile`) per Feishu API spec
    - `MsgTypeMedia` requires `image_key` (thumbnail) and `duration` fields
    - Used `ffmpeg` to extract thumbnail at 0.5s and `ffprobe` to get video duration

## 🧪 Test Environment
- **Hardware:** Raspberry Pi 4 Model B Rev 1.4
- **OS:** Debian GNU/Linux 13 (trixie) (aarch64)
- **Model/Provider:** zhipu/glm-4.7
- **Channels:** Feishu


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

2026/03/14 21:15:18 [2026-03-14T13:15:18Z] [INFO] feishu: Feishu message received {sender_id=5ac85cg3, chat_id=oc_3d30ec03d888531a998b06d80d70eca5, message_id=om_x100b5461b89600a4c12c42c6959784d, preview=拍个照}
2026/03/14 21:15:18 [2026-03-14T13:15:18Z] [INFO] agent: Processing message from feishu:feishu:5ac85cg3: 拍个照 {chat_id=oc_3d30ec03d888531a998b06d80d70eca5, sender_id=feishu:5ac85cg3, session_key=, channel=feishu}
2026/03/14 21:15:18 [2026-03-14T13:15:18Z] [INFO] agent: Routed message {agent_id=main, scope_key=agent:main:feishu:direct:5ac85cg3, session_key=agent:main:feishu:direct:5ac85cg3, matched_by=default, route_agent=main, route_channel=feishu}
2026/03/14 21:15:20 [2026-03-14T13:15:20Z] [INFO] agent: LLM requested tool calls {agent_id=main, tools=[exec], count=1, iteration=1}
2026/03/14 21:15:21 [2026-03-14T13:15:21Z] [INFO] agent: Tool call: exec({"command":"libcamera-still -o /tmp/photo.jpg --width 1280 --height 720 --timeout 1 2\u003e\u00261"}) {iteration=1, agent_id=main, tool=exec}
2026/03/14 21:15:21 [2026-03-14T13:15:21Z] [INFO] tool: Tool execution started {tool=exec, args=map[command:libcamera-still -o /tmp/photo.jpg --width 1280 --height 720 --timeout 1 2>&1]}
2026/03/14 21:15:21 [2026-03-14T13:15:21Z] [ERROR] tool: Tool execution failed {tool=exec, duration=4, error=sh: 1: libcamera-still: not found

Exit code: exit status 127}
2026/03/14 21:15:22 [2026-03-14T13:15:22Z] [INFO] agent: LLM requested tool calls {tools=[exec], count=1, iteration=2, agent_id=main}
2026/03/14 21:15:23 [2026-03-14T13:15:23Z] [INFO] agent: Tool call: exec({"command":"fswebcam -r 1280x720 --no-banner /tmp/photo.jpg 2\u003e\u00261"}) {agent_id=main, tool=exec, iteration=2}
2026/03/14 21:15:23 [2026-03-14T13:15:23Z] [INFO] tool: Tool execution started {tool=exec, args=map[command:fswebcam -r 1280x720 --no-banner /tmp/photo.jpg 2>&1]}
2026/03/14 21:15:23 [2026-03-14T13:15:23Z] [ERROR] tool: Tool execution failed {tool=exec, duration=2, error=sh: 1: fswebcam: not found

Exit code: exit status 127}
2026/03/14 21:15:24 [2026-03-14T13:15:24Z] [INFO] agent: LLM requested tool calls {iteration=3, agent_id=main, tools=[exec], count=1}
2026/03/14 21:15:24 [2026-03-14T13:15:24Z] [INFO] agent: Tool call: exec({"command":"ffmpeg -f v4l2 -i /dev/video0 -frames:v 1 -y /tmp/photo.jpg 2\u003e\u00261 | head -20"}) {agent_id=main, tool=exec, iteration=3}
2026/03/14 21:15:24 [2026-03-14T13:15:24Z] [INFO] tool: Tool execution started {tool=exec, args=map[command:ffmpeg -f v4l2 -i /dev/video0 -frames:v 1 -y /tmp/photo.jpg 2>&1 | head -20]}
2026/03/14 21:15:31 [2026-03-14T13:15:31Z] [INFO] tool: Tool execution completed {duration_ms=7528, result_length=2431, tool=exec}
2026/03/14 21:15:43 [2026-03-14T13:15:43Z] [INFO] agent: LLM requested tool calls {agent_id=main, tools=[exec], count=1, iteration=4}
2026/03/14 21:15:43 [2026-03-14T13:15:43Z] [INFO] agent: Tool call: exec({"command":"ls -lh /tmp/photo.jpg \u0026\u0026 file /tmp/photo.jpg"}) {agent_id=main, tool=exec, iteration=4}
2026/03/14 21:15:43 [2026-03-14T13:15:43Z] [INFO] tool: Tool execution started {tool=exec, args=map[command:ls -lh /tmp/photo.jpg && file /tmp/photo.jpg]}
2026/03/14 21:15:44 [2026-03-14T13:15:44Z] [INFO] tool: Tool execution completed {tool=exec, duration_ms=215, result_length=147}
2026/03/14 21:15:45 [2026-03-14T13:15:45Z] [INFO] agent: LLM requested tool calls {iteration=5, agent_id=main, tools=[send_file], count=1}
2026/03/14 21:15:45 [2026-03-14T13:15:45Z] [INFO] agent: Tool call: send_file({"path":"/tmp/photo.jpg"}) {agent_id=main, tool=send_file, iteration=5}
2026/03/14 21:15:45 [2026-03-14T13:15:45Z] [INFO] tool: Tool execution started {tool=send_file, args=map[path:/tmp/photo.jpg]}
2026/03/14 21:15:45 [2026-03-14T13:15:45Z] [INFO] tool: Tool execution completed {tool=send_file, duration_ms=0, result_length=29}
2026/03/14 21:15:47 [2026-03-14T13:15:47Z] [INFO] agent: LLM response without tool calls (direct answer) {agent_id=main, iteration=6, content_chars=236}
2026/03/14 21:15:47 [2026-03-14T13:15:47Z] [INFO] agent: Response: 📸 照片已拍摄并发送！

- **分辨率**: 640x480
- **格式**: JPEG (19KB)
- **设备**: /dev/video0 (USB 摄像头)

这次成功绕过了之前的权限限制。需要我调整拍摄参数（如分辨率）... {agent_id=main, session_key=agent:main:feishu:direct:5ac85cg3, iterations=6, final_length=236}
2026/03/14 21:15:47 [2026-03-14T13:15:47Z] [INFO] agent: Published outbound response {channel=feishu, chat_id=oc_3d30ec03d888531a998b06d80d70eca5, content_len=236}

</details>

  ## ☑️ Checklist
  - [x] My code/docs follow the style of this project.
  - [x] I have performed a self-review of my own changes.
  - [ ] I have updated the documentation accordingly.