### PR TITLE
feat: wire image_model config to agent loop for vision-capable models

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -47,6 +47,11 @@ type AgentInstance struct {
 	// LightCandidates holds the resolved provider candidates for the light model.
 	// Pre-computed at agent creation to avoid repeated model_list lookups at runtime.
 	LightCandidates []providers.FallbackCandidate
+	// ImageModel holds the configured image model name from config.
+	ImageModel string
+	// ImageModelCandidates holds the resolved provider candidates for the image model.
+	// Pre-computed at agent creation to avoid repeated model_list lookups at runtime.
+	ImageModelCandidates []providers.FallbackCandidate
 }
 
 // NewAgentInstance creates an agent instance from config.
@@ -214,6 +219,21 @@ func NewAgentInstance(
 		}
 	}
 
+	// Image model setup: pre-resolve image model candidates at creation time
+	// to avoid repeated model_list lookups when processing image attachments.
+	var imageModelCandidates []providers.FallbackCandidate
+	imageModel := defaults.ImageModel
+	if imageModel != "" {
+		imageModelCfg := providers.ModelConfig{Primary: imageModel, Fallbacks: defaults.ImageModelFallbacks}
+		resolved := providers.ResolveCandidatesWithLookup(imageModelCfg, defaults.Provider, resolveFromModelList)
+		if len(resolved) > 0 {
+			imageModelCandidates = resolved
+		} else {
+			log.Printf("image_model %q not found in model_list — image attachments will use primary model",
+				imageModel)
+		}
+	}
+
 	return &AgentInstance{
 		ID:                        agentID,
 		Name:                      agentName,
@@ -236,6 +256,8 @@ func NewAgentInstance(
 		Candidates:                candidates,
 		Router:                    router,
 		LightCandidates:           lightCandidates,
+		ImageModel:                imageModel,
+		ImageModelCandidates:      imageModelCandidates,
 	}
 }
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1004,7 +1004,7 @@ func (al *AgentLoop) runLLMIteration(
 	// selectCandidates evaluates routing once and the decision is sticky for
 	// all tool-follow-up iterations within the same turn so that a multi-step
 	// tool chain doesn't switch models mid-way through.
-	activeCandidates, activeModel := al.selectCandidates(agent, opts.UserMessage, messages)
+	activeCandidates, activeModel := al.selectCandidates(agent, opts.UserMessage, messages, opts.Media)
 
 	for iteration < agent.MaxIterations {
 		iteration++
@@ -1406,6 +1406,9 @@ func (al *AgentLoop) runLLMIteration(
 // message scores below the complexity threshold, it returns the light model
 // candidates instead of the primary ones.
 //
+// If the message contains media attachments (images) and an image_model is
+// configured, the image model candidates are returned instead.
+//
 // The returned (candidates, model) pair is used for all LLM calls within one
 // turn — tool follow-up iterations use the same tier as the initial call so
 // that a multi-step tool chain doesn't switch models mid-way.
@@ -1413,7 +1416,19 @@ func (al *AgentLoop) selectCandidates(
 	agent *AgentInstance,
 	userMsg string,
 	history []providers.Message,
+	media []string,
 ) (candidates []providers.FallbackCandidate, model string) {
+	// If image_model is configured and there are media attachments, route to image model
+	if len(media) > 0 && agent.ImageModel != "" && len(agent.ImageModelCandidates) > 0 {
+		logger.InfoCF("agent", "Image model routing: media attachments detected",
+			map[string]any{
+				"agent_id":    agent.ID,
+				"image_model": agent.ImageModel,
+				"media_count": len(media),
+			})
+		return agent.ImageModelCandidates, agent.ImageModel
+	}
+
 	if agent.Router == nil || len(agent.LightCandidates) == 0 {
 		return agent.Candidates, agent.Model
 	}


### PR DESCRIPTION
## Summary
- Add ImageModel and ImageModelCandidates fields to AgentInstance
- Resolve image_model candidates at agent creation time
- Route to image_model when media attachments are detected in selectCandidates

## Problem
The image_model field in agents.defaults is accepted in config.json but has no effect. Image messages are always sent to the primary model_name, even when image_model points to a vision-capable model.

## Solution
1. Added ImageModel and ImageModelCandidates fields to AgentInstance struct
2. At agent creation time, pre-resolve image_model candidates (similar to light_model)
3. Modified selectCandidates to check for media attachments and route to image_model when present

## Testing
The fix follows the same pattern as light_model routing which is already tested.

Fixes issue #1578