### PR TITLE
fix(heartbeat): ignore untouched default template

### DIFF
--- a/pkg/heartbeat/service.go
+++ b/pkg/heartbeat/service.go
@@ -26,6 +26,7 @@ import (
 const (
 	minIntervalMinutes     = 5
 	defaultIntervalMinutes = 30
+	userTasksMarker        = "Add your heartbeat tasks below this line:"
 )
 
 // HeartbeatHandler is the function type for handling heartbeat.
@@ -232,7 +233,7 @@ func (hs *HeartbeatService) buildPrompt() string {
 	}
 
 	content := string(data)
-	if len(content) == 0 {
+	if !heartbeatHasUserTasks(content) {
 		return ""
 	}
 
@@ -282,6 +283,32 @@ Add your heartbeat tasks below this line:
 	} else {
 		hs.logInfof("Created default HEARTBEAT.md template")
 	}
+}
+
+func heartbeatHasUserTasks(content string) bool {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return false
+	}
+
+	markerIdx := strings.Index(content, userTasksMarker)
+	if markerIdx < 0 {
+		return true
+	}
+
+	tasksSection := content[markerIdx+len(userTasksMarker):]
+	for _, line := range strings.Split(tasksSection, "\n") {
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmedLine, "#") {
+			continue
+		}
+		return true
+	}
+
+	return false
 }
 
 // sendResponse sends the heartbeat response to the last channel

--- a/pkg/heartbeat/service_test.go
+++ b/pkg/heartbeat/service_test.go
@@ -3,6 +3,7 @@ package heartbeat
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -201,5 +202,49 @@ func TestHeartbeatFilePath(t *testing.T) {
 	expectedPath := filepath.Join(tmpDir, "HEARTBEAT.md")
 	if _, err := os.Stat(expectedPath); os.IsNotExist(err) {
 		t.Errorf("Expected HEARTBEAT.md at %s, but it doesn't exist", expectedPath)
+	}
+}
+
+func TestBuildPrompt_DefaultTemplateStaysIdle(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "heartbeat-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	hs := NewHeartbeatService(tmpDir, 30, true)
+	hs.createDefaultHeartbeatTemplate()
+
+	if prompt := hs.buildPrompt(); prompt != "" {
+		t.Fatalf("buildPrompt() = %q, want empty prompt for untouched default template", prompt)
+	}
+}
+
+func TestBuildPrompt_UserTasksAfterMarkerProducePrompt(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "heartbeat-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	hs := NewHeartbeatService(tmpDir, 30, true)
+	hs.createDefaultHeartbeatTemplate()
+
+	path := filepath.Join(tmpDir, "HEARTBEAT.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read HEARTBEAT.md: %v", err)
+	}
+	updated := string(data) + "\n- Check unread Feishu messages\n"
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		t.Fatalf("Failed to update HEARTBEAT.md: %v", err)
+	}
+
+	prompt := hs.buildPrompt()
+	if prompt == "" {
+		t.Fatal("buildPrompt() = empty, want non-empty prompt when user tasks are present")
+	}
+	if !strings.Contains(prompt, "Check unread Feishu messages") {
+		t.Fatalf("prompt = %q, want user task content", prompt)
 	}
 }


### PR DESCRIPTION
## Summary
- treat the generated HEARTBEAT.md template as idle until the user adds tasks below the marker
- stop sending the example/instructions block to the LLM as a real heartbeat prompt
- add regression tests for the untouched-template and user-task cases

Closes #1561

## Testing
- go test ./pkg/heartbeat ./pkg/config
