### PR TITLE
fix(logger): append fields to fileEvent instead of event in file logger block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/tencent-connect/botgo v0.2.1
 	go.mau.fi/whatsmeow v0.0.0-20260219150138-7ae702b1eed4
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/term v0.40.0
 	golang.org/x/time v0.14.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -59,7 +60,6 @@ require (
 	go.mau.fi/libsignal v0.2.1 // indirect
 	go.mau.fi/util v0.9.6 // indirect
 	golang.org/x/exp v0.0.0-20260212183809-81e46e3db34a // indirect
-	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
@@ -90,7 +90,7 @@ require (
 	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/arch v0.24.0 // indirect
-	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/crypto v0.48.0
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -209,7 +209,7 @@ func logMessage(level LogLevel, component string, message string, fields map[str
 			fileEvent.Str("component", component)
 		}
 
-		appendFields(event, fields)
+		appendFields(fileEvent, fields)
 		fileEvent.Msg(message)
 	}
 


### PR DESCRIPTION
## 📝 Description

**Bug**: In `pkg/logger/logger.go`, the file-logger branch of `logMessage` called `appendFields(event, fields)` after `event.Msg(message)` had already finalised the console event. Fields never reached the file log output.

**Fix**: One-line correction — pass `fileEvent` to `appendFields` in the file logger block.

```
// Before (bug)
appendFields(event, fields)   // event already consumed; fields silently dropped
fileEvent.Msg(message)

// After (fix)
appendFields(fileEvent, fields)
fileEvent.Msg(message)
```

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** `pkg/logger/logger.go` — `logMessage` function
- **Reasoning:** `zerolog.Event` is a write-once, send-on-`Msg` object. Once `event.Msg()` is called, the event is dispatched and pooled; appending fields to it afterwards is a no-op. The file logger must use its own `fileEvent` throughout.

## 🧪 Test Environment
- **Hardware:** N/A
- **OS:** N/A
- **Model/Provider:** N/A
- **Channels:** N/A


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.