### PR TITLE
feat:replace filename with local path in content for media refs

### DIFF
--- a/pkg/agent/loop_media.go
+++ b/pkg/agent/loop_media.go
@@ -53,6 +53,12 @@ func resolveMediaRefs(messages []providers.Message, store media.MediaStore, maxS
 				continue
 			}
 
+			if meta.Filename != "" && result[i].Content != "" {
+				oldPattern := meta.Filename + " [file]"
+				newPattern :=oldPattern + " PATH=" + localPath
+				result[i].Content = strings.ReplaceAll(result[i].Content, oldPattern, newPattern)
+			}
+
 			info, err := os.Stat(localPath)
 			if err != nil {
 				logger.WarnCF("agent", "Failed to stat media file", map[string]any{


### PR DESCRIPTION
## 📝 Description

Picoclaw can't recognize non - image files received from channels like Feishu. The reason is that the files are redirected, and the redirected address isn't passed to the large language model as content.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->PC
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->Windows 11
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->qianwen3.5-plus
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->Feishu

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.