### PR TITLE
fix(providers): handle nil input in GLM series tool_use blocks

### DIFF
--- a/pkg/providers/anthropic_messages/provider.go
+++ b/pkg/providers/anthropic_messages/provider.go
@@ -221,11 +221,17 @@ func buildRequestBody(
 
 			// Add tool_use blocks
 			for _, tc := range msg.ToolCalls {
+				// Handle nil Arguments (GLM-4 may return null input)
+				input := tc.Arguments
+				if input == nil {
+					input = map[string]any{}
+				}
+
 				toolUse := map[string]any{
 					"type":  "tool_use",
 					"id":    tc.ID,
 					"name":  tc.Name,
-					"input": tc.Arguments,
+					"input": input,
 				}
 				content = append(content, toolUse)
 			}


### PR DESCRIPTION
## 问题

Zhipu AI 的 GLM 系列模型在返回 tool_use 块时，可能会将 input 字段设置为 null，这会导致后续 API 请求失败并报错：
`ClaudeContentBlockToolResult object has no attribute id`

## 修复

- 添加对 tool call Arguments 字段的防御性 nil 检查
- 将 nil input 替换为空对象 `{}`，以符合 Anthropic 规范
- 防止 API 错误，同时保持与其他 provider 的向后兼容性

这是对 PR #1284 的后续修复。