### PR TITLE
fix(providers): handle nil input in GLM series tool_use blocks

### DIFF
--- a/pkg/providers/anthropic_messages/provider.go
+++ b/pkg/providers/anthropic_messages/provider.go
@@ -221,11 +221,17 @@ func buildRequestBody(
 
 			// Add tool_use blocks
 			for _, tc := range msg.ToolCalls {
+				// Handle nil Arguments (GLM-4 may return null input)
+				input := tc.Arguments
+				if input == nil {
+					input = map[string]any{}
+				}
+
 				toolUse := map[string]any{
 					"type":  "tool_use",
 					"id":    tc.ID,
 					"name":  tc.Name,
-					"input": tc.Arguments,
+					"input": input,
 				}
 				content = append(content, toolUse)
 			}


### PR DESCRIPTION
## Problem

Zhipu AI's GLM series models may return tool_use blocks with null input field, which causes their API to reject subsequent requests with error:
`ClaudeContentBlockToolResult object has no attribute id`

## Solution

- Add defensive nil check for tool call Arguments field
- Replace nil input with empty object `{}` to comply with Anthropic spec
- Prevent API errors while maintaining backward compatibility with other providers

This is a follow-up fix to PR #1284.