### PR TITLE
build: use WEB_GO for web targets and preserve backend dist directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ LDFLAGS=-X $(CONFIG_PKG).Version=$(VERSION) -X $(CONFIG_PKG).GitCommit=$(GIT_COM
 
 # Go variables
 GO?=CGO_ENABLED=0 go
+WEB_GO?=$(GO)
 GOFLAGS?=-v -tags stdjson
 
 # Patch MIPS LE ELF e_flags (offset 36) for NaN2008-only kernels (e.g. Ingenic X2600).
@@ -79,6 +80,7 @@ ifeq ($(UNAME_S),Linux)
 	endif
 else ifeq ($(UNAME_S),Darwin)
 	PLATFORM=darwin
+	WEB_GO=CGO_ENABLED=1 go
 	ifeq ($(UNAME_M),x86_64)
 		ARCH=amd64
 	else ifeq ($(UNAME_M),arm64)
@@ -119,7 +121,7 @@ build-launcher:
 		echo "Building frontend..."; \
 		cd web/frontend && pnpm install && pnpm build:backend; \
 	fi
-	@$(GO) build $(GOFLAGS) -o $(BUILD_DIR)/picoclaw-launcher-$(PLATFORM)-$(ARCH) ./web/backend
+	@$(WEB_GO) build $(GOFLAGS) -o $(BUILD_DIR)/picoclaw-launcher-$(PLATFORM)-$(ARCH) ./web/backend
 	@ln -sf picoclaw-launcher-$(PLATFORM)-$(ARCH) $(BUILD_DIR)/picoclaw-launcher
 	@echo "Build complete: $(BUILD_DIR)/picoclaw-launcher"
 
@@ -219,7 +221,9 @@ clean:
 
 ## vet: Run go vet for static analysis
 vet: generate
-	@$(GO) vet ./...
+	@packages="$$(go list ./...)" && \
+		$(GO) vet $$(printf '%s\n' "$$packages" | grep -v '^github.com/sipeed/picoclaw/web/')
+	@cd web/backend && $(WEB_GO) vet ./...
 
 ## test: Test Go code
 test: generate

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,16 +1,17 @@
 .PHONY: dev dev-frontend dev-backend build test lint clean
 
+# Go variables
+GO?=CGO_ENABLED=0 go
+WEB_GO?=$(GO)
+GOFLAGS?=-v -tags stdjson
+
 # Version
 VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 GIT_COMMIT=$(shell git rev-parse --short=8 HEAD 2>/dev/null || echo "dev")
 BUILD_TIME=$(shell date +%FT%T%z)
-GO_VERSION=$(shell $(GO) version | awk '{print $$3}')
+GO_VERSION=$(shell $(WEB_GO) version | awk '{print $$3}')
 CONFIG_PKG=github.com/sipeed/picoclaw/pkg/config
 LDFLAGS=-X $(CONFIG_PKG).Version=$(VERSION) -X $(CONFIG_PKG).GitCommit=$(GIT_COMMIT) -X $(CONFIG_PKG).BuildTime=$(BUILD_TIME) -X $(CONFIG_PKG).GoVersion=$(GO_VERSION) -s -w
-
-# Go variables
-GO?=CGO_ENABLED=0 go
-GOFLAGS?=-v -tags stdjson
 
 
 # OS detection
@@ -37,7 +38,7 @@ ifeq ($(UNAME_S),Linux)
 	endif
 else ifeq ($(UNAME_S),Darwin)
 	PLATFORM=darwin
-	GO=CGO_ENABLED=1 go
+	WEB_GO=CGO_ENABLED=1 go
 	ifeq ($(UNAME_M),x86_64)
 		ARCH=amd64
 	else ifeq ($(UNAME_M),arm64)
@@ -69,21 +70,21 @@ dev-frontend:
 
 # Start backend dev server
 dev-backend:
-	cd backend && ${GO} run  -ldflags "$(LDFLAGS)" .
+	cd backend && ${WEB_GO} run -ldflags "$(LDFLAGS)" .
 
 # Build frontend and embed into Go binary
 build:
 	cd frontend && pnpm build:backend
-	cd backend && ${GO} build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o picoclaw-web .
+	cd backend && ${WEB_GO} build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o picoclaw-web .
 
 # Run all tests
 test:
-	cd backend && ${GO} test ./...
+	cd backend && ${WEB_GO} test ./...
 	cd frontend && pnpm lint
 
 # Lint and format
 lint:
-	cd backend && ${GO} vet ./...
+	cd backend && ${WEB_GO} vet ./...
 	cd frontend && pnpm check
 
 # Clean build artifacts

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "build:backend": "tsc -b && vite build --outDir ../backend/dist --emptyOutDir",
+    "build:backend": "tsc -b && vite build --outDir ../backend/dist --emptyOutDir && node ./scripts/ensure-backend-gitkeep.cjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "format": "prettier --check .",

--- a/web/frontend/scripts/ensure-backend-gitkeep.cjs
+++ b/web/frontend/scripts/ensure-backend-gitkeep.cjs
@@ -1,0 +1,9 @@
+const fs = require("node:fs")
+const path = require("node:path")
+
+const gitkeepPath = path.resolve(__dirname, "../../backend/dist/.gitkeep")
+const gitkeepContents =
+  "# Keep the embedded web backend dist directory in version control.\n"
+
+fs.mkdirSync(path.dirname(gitkeepPath), { recursive: true })
+fs.writeFileSync(gitkeepPath, gitkeepContents)


### PR DESCRIPTION
## 📝 Description

Separate the web Go toolchain from the default project Go toolchain so web targets can enable CGO on Darwin without affecting the rest of the repository. This also preserves `web/backend/dist` after frontend backend builds by recreating `.gitkeep`, so the embedded output directory remains tracked.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A (internal build/tooling change)
- **Reasoning:** Keep the default root `GO` toolchain unchanged while allowing web-specific build, test, and vet commands to use `CGO_ENABLED=1` on Darwin. Also restore `web/backend/dist/.gitkeep` after `vite build --emptyOutDir` so the embedded backend output directory stays tracked in git.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** macOS
- **Model/Provider:** N/A (build tooling change)
- **Channels:** N/A (build tooling change)


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```text
make check
- Go test suite passed
- web/backend tests passed with CGO-enabled web toolchain
- frontend eslint passed
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
