### PR TITLE
feat: add Novita provider integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@
 # GEMINI_API_KEY=xxx
 # MODELSCOPE_API_KEY=xxx
 # CLAUDE_CODE_OAUTH=xxx
+# NOVITA_API_KEY=sk-xxx
 # ── Chat Channel ──────────────────────────
 # TELEGRAM_BOT_TOKEN=123456:ABC...
 # DISCORD_BOT_TOKEN=xxx

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -523,6 +523,7 @@ type ProvidersConfig struct {
 	Cerebras      ProviderConfig       `json:"cerebras"`
 	Vivgrid       ProviderConfig       `json:"vivgrid"`
 	VolcEngine    ProviderConfig       `json:"volcengine"`
+	Novita        ProviderConfig       `json:"novita"`
 	GitHubCopilot ProviderConfig       `json:"github_copilot"`
 	Antigravity   ProviderConfig       `json:"antigravity"`
 	Qwen          ProviderConfig       `json:"qwen"`
@@ -552,6 +553,7 @@ func (p ProvidersConfig) IsEmpty() bool {
 		p.Cerebras.APIKey == "" && p.Cerebras.APIBase == "" &&
 		p.Vivgrid.APIKey == "" && p.Vivgrid.APIBase == "" &&
 		p.VolcEngine.APIKey == "" && p.VolcEngine.APIBase == "" &&
+		p.Novita.APIKey == "" && p.Novita.APIBase == "" &&
 		p.GitHubCopilot.APIKey == "" && p.GitHubCopilot.APIBase == "" &&
 		p.Antigravity.APIKey == "" && p.Antigravity.APIBase == "" &&
 		p.Qwen.APIKey == "" && p.Qwen.APIBase == "" &&

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -377,6 +377,26 @@ func DefaultConfig() *Config {
 				APIKey:    "",
 			},
 
+			// Novita AI - https://novita.ai
+			{
+				ModelName: "deepseek-v3.2",
+				Model:     "novita/deepseek/deepseek-v3.2",
+				APIBase:   "https://api.novita.ai/openai",
+				APIKey:    "",
+			},
+			{
+				ModelName: "glm-5",
+				Model:     "novita/zai-org/glm-5",
+				APIBase:   "https://api.novita.ai/openai",
+				APIKey:    "",
+			},
+			{
+				ModelName: "minimax-m2.5",
+				Model:     "novita/minimax/minimax-m2.5",
+				APIBase:   "https://api.novita.ai/openai",
+				APIKey:    "",
+			},
+
 			// VLLM (local) - http://localhost:8000
 			{
 				ModelName: "local-model",

--- a/pkg/providers/factory.go
+++ b/pkg/providers/factory.go
@@ -230,6 +230,15 @@ func resolveProviderSelection(cfg *config.Config) (providerSelection, error) {
 					sel.apiBase = "https://api.longcat.chat/openai"
 				}
 			}
+		case "novita":
+			if cfg.Providers.Novita.APIKey != "" {
+				sel.apiKey = cfg.Providers.Novita.APIKey
+				sel.apiBase = cfg.Providers.Novita.APIBase
+				sel.proxy = cfg.Providers.Novita.Proxy
+				if sel.apiBase == "" {
+					sel.apiBase = "https://api.novita.ai/openai"
+				}
+			}
 		case "github_copilot", "copilot":
 			sel.providerType = providerTypeGitHubCopilot
 			if cfg.Providers.GitHubCopilot.APIBase != "" {
@@ -367,6 +376,13 @@ func resolveProviderSelection(cfg *config.Config) (providerSelection, error) {
 			sel.proxy = cfg.Providers.LongCat.Proxy
 			if sel.apiBase == "" {
 				sel.apiBase = "https://api.longcat.chat/openai"
+			}
+		case (strings.Contains(lowerModel, "novita") || strings.HasPrefix(model, "novita/")) && cfg.Providers.Novita.APIKey != "":
+			sel.apiKey = cfg.Providers.Novita.APIKey
+			sel.apiBase = cfg.Providers.Novita.APIBase
+			sel.proxy = cfg.Providers.Novita.Proxy
+			if sel.apiBase == "" {
+				sel.apiBase = "https://api.novita.ai/openai"
 			}
 		case cfg.Providers.VLLM.APIBase != "":
 			sel.apiKey = cfg.Providers.VLLM.APIKey

--- a/pkg/providers/factory_test.go
+++ b/pkg/providers/factory_test.go
@@ -190,6 +190,17 @@ func TestResolveProviderSelection(t *testing.T) {
 			wantProxy:   "http://127.0.0.1:7890",
 		},
 		{
+			name: "explicit novita provider uses defaults",
+			setup: func(cfg *config.Config) {
+				cfg.Agents.Defaults.Provider = "novita"
+				cfg.Providers.Novita.APIKey = "novita-key"
+				cfg.Providers.Novita.Proxy = "http://127.0.0.1:7890"
+			},
+			wantType:    providerTypeHTTPCompat,
+			wantAPIBase: "https://api.novita.ai/openai",
+			wantProxy:   "http://127.0.0.1:7890",
+		},
+		{
 			name: "longcat model fallback uses longcat base default",
 			setup: func(cfg *config.Config) {
 				cfg.Agents.Defaults.Model = "longcat/LongCat-Flash-Thinking"
@@ -197,6 +208,15 @@ func TestResolveProviderSelection(t *testing.T) {
 			},
 			wantType:    providerTypeHTTPCompat,
 			wantAPIBase: "https://api.longcat.chat/openai",
+		},
+		{
+			name: "novita model fallback uses novita base default",
+			setup: func(cfg *config.Config) {
+				cfg.Agents.Defaults.Model = "novita/deepseek/deepseek-v3.2"
+				cfg.Providers.Novita.APIKey = "novita-key"
+			},
+			wantType:    providerTypeHTTPCompat,
+			wantAPIBase: "https://api.novita.ai/openai",
 		},
 		{
 			name: "missing keys returns model config error",


### PR DESCRIPTION
## Summary
Add Novita provider integration to PicoClaw.

## Changes
- Added Novita OpenAI-compatible provider in `pkg/providers/factory.go`
- Added Novita config struct in `pkg/config/config.go`
- Added Novita models to default config in `pkg/config/defaults.go`:
  - `novita/deepseek/deepseek-v3.2` (default)
  - `novita/zai-org/glm-5`
  - `novita/minimax/minimax-m2.5`
- Added `NOVITA_API_KEY` to `.env.example`

## API Endpoint
- Base URL: `https://api.novita.ai/openai`

## Model IDs
- `deepseek/deepseek-v3.2` (DEFAULT)
- `zai-org/glm-5`
- `minimax/minimax-m2.5`