### PR TITLE
docs(zhipu): document glm coding plan endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,8 @@ This design also enables **multi-agent support** with flexible provider selectio
 | **Antigravity**     | `antigravity/`    | Google Cloud                                        | Custom    | OAuth only                                                       |
 | **GitHub Copilot**  | `github-copilot/` | `localhost:4321`                                    | gRPC      | -                                                                |
 
+> For Zhipu GLM Coding Plan, keep the model as `zhipu/<model>` and set `api_base` to `https://open.bigmodel.cn/api/coding/paas/v4`.
+
 #### Basic Configuration
 
 ```json
@@ -1055,6 +1057,12 @@ This design also enables **multi-agent support** with flexible provider selectio
     {
       "model_name": "glm-4.7",
       "model": "zhipu/glm-4.7",
+      "api_key": "your-zhipu-key"
+    },
+    {
+      "model_name": "glm-4.7-coding-plan",
+      "model": "zhipu/glm-4.7",
+      "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
       "api_key": "your-zhipu-key"
     }
   ],
@@ -1084,6 +1092,17 @@ This design also enables **multi-agent support** with flexible provider selectio
 {
   "model_name": "glm-4.7",
   "model": "zhipu/glm-4.7",
+  "api_key": "your-key"
+}
+```
+
+**智谱 AI (GLM Coding Plan)**
+
+```json
+{
+  "model_name": "glm-4.7-coding-plan",
+  "model": "zhipu/glm-4.7",
+  "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
   "api_key": "your-key"
 }
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -520,6 +520,8 @@ Agent 读取 HEARTBEAT.md
 | **Antigravity**     | `antigravity/`    | Google Cloud                                        | 自定义    | 仅 OAuth                                                          |
 | **GitHub Copilot**  | `github-copilot/` | `localhost:4321`                                    | gRPC      | -                                                                 |
 
+> 如果你使用智谱 GLM Coding Plan，请保持 `model` 为 `zhipu/<model>`，并将 `api_base` 改成 `https://open.bigmodel.cn/api/coding/paas/v4`。
+
 #### 基础配置示例
 
 ```json
@@ -538,6 +540,12 @@ Agent 读取 HEARTBEAT.md
     {
       "model_name": "glm-4.7",
       "model": "zhipu/glm-4.7",
+      "api_key": "your-zhipu-key"
+    },
+    {
+      "model_name": "glm-4.7-coding-plan",
+      "model": "zhipu/glm-4.7",
+      "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
       "api_key": "your-zhipu-key"
     }
   ],
@@ -567,6 +575,17 @@ Agent 读取 HEARTBEAT.md
 {
   "model_name": "glm-4.7",
   "model": "zhipu/glm-4.7",
+  "api_key": "your-key"
+}
+```
+
+**智谱 AI (GLM Coding Plan)**
+
+```json
+{
+  "model_name": "glm-4.7-coding-plan",
+  "model": "zhipu/glm-4.7",
+  "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
   "api_key": "your-key"
 }
 ```

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -36,6 +36,12 @@
       "api_key": "sk-your-deepseek-key"
     },
     {
+      "model_name": "glm-coding-plan",
+      "model": "zhipu/glm-4.7",
+      "api_key": "your-zhipu-key",
+      "api_base": "https://open.bigmodel.cn/api/coding/paas/v4"
+    },
+    {
       "model_name": "loadbalanced-gpt4",
       "model": "openai/gpt-5.2",
       "api_key": "sk-key1",


### PR DESCRIPTION
## Summary
- document the dedicated Zhipu GLM Coding Plan `api_base`
- add copy-paste examples in both English and Chinese READMEs
- include a Coding Plan model entry in `config.example.json`

## Problem
Current docs and examples only show Zhipu's general OpenAI-compatible endpoint:

`https://open.bigmodel.cn/api/paas/v4`

That makes it easy for users to point PicoClaw at the balance-based endpoint even when they intend to use GLM Coding Plan, which uses:

`https://open.bigmodel.cn/api/coding/paas/v4`

## Solution
Clarify in the provider docs that GLM Coding Plan still uses `zhipu/<model>` but needs the Coding Plan base URL, and add explicit configuration examples users can copy directly.

## Verification
- `jq empty config/config.example.json`
- `git diff --check`

Closes #1652
