### PR TITLE
docs(zhipu): document glm coding plan endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,8 @@ This design also enables **multi-agent support** with flexible provider selectio
 | **Antigravity**     | `antigravity/`    | Google Cloud                                        | Custom    | OAuth only                                                       |
 | **GitHub Copilot**  | `github-copilot/` | `localhost:4321`                                    | gRPC      | -                                                                |
 
+> For Zhipu GLM Coding Plan, keep the model as `zhipu/<model>` and set `api_base` to `https://open.bigmodel.cn/api/coding/paas/v4`.
+
 #### Basic Configuration
 
 ```json
@@ -1070,6 +1072,12 @@ This design also enables **multi-agent support** with flexible provider selectio
     {
       "model_name": "glm-4.7",
       "model": "zhipu/glm-4.7",
+      "api_key": "your-zhipu-key"
+    },
+    {
+      "model_name": "glm-4.7-coding-plan",
+      "model": "zhipu/glm-4.7",
+      "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
       "api_key": "your-zhipu-key"
     }
   ],
@@ -1109,6 +1117,17 @@ This design also enables **multi-agent support** with flexible provider selectio
 {
   "model_name": "glm-4.7",
   "model": "zhipu/glm-4.7",
+  "api_key": "your-key"
+}
+```
+
+**智谱 AI (GLM Coding Plan)**
+
+```json
+{
+  "model_name": "glm-4.7-coding-plan",
+  "model": "zhipu/glm-4.7",
+  "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
   "api_key": "your-key"
 }
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -532,6 +532,8 @@ Agent 读取 HEARTBEAT.md
 | **Antigravity**     | `antigravity/`    | Google Cloud                                        | 自定义    | 仅 OAuth                                                          |
 | **GitHub Copilot**  | `github-copilot/` | `localhost:4321`                                    | gRPC      | -                                                                 |
 
+> 如果你使用智谱 GLM Coding Plan，请保持 `model` 为 `zhipu/<model>`，并将 `api_base` 改成 `https://open.bigmodel.cn/api/coding/paas/v4`。
+
 #### 基础配置示例
 
 ```json
@@ -555,6 +557,12 @@ Agent 读取 HEARTBEAT.md
     {
       "model_name": "glm-4.7",
       "model": "zhipu/glm-4.7",
+      "api_key": "your-zhipu-key"
+    },
+    {
+      "model_name": "glm-4.7-coding-plan",
+      "model": "zhipu/glm-4.7",
+      "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
       "api_key": "your-zhipu-key"
     }
   ],
@@ -594,6 +602,17 @@ Agent 读取 HEARTBEAT.md
 {
   "model_name": "glm-4.7",
   "model": "zhipu/glm-4.7",
+  "api_key": "your-key"
+}
+```
+
+**智谱 AI (GLM Coding Plan)**
+
+```json
+{
+  "model_name": "glm-4.7-coding-plan",
+  "model": "zhipu/glm-4.7",
+  "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
   "api_key": "your-key"
 }
 ```

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -66,6 +66,12 @@
       "api_base": "https://api1.example.com/v1"
     },
     {
+      "model_name": "glm-coding-plan",
+      "model": "zhipu/glm-4.7",
+      "api_key": "your-zhipu-key",
+      "api_base": "https://open.bigmodel.cn/api/coding/paas/v4"
+    },
+    {
       "model_name": "loadbalanced-gpt-5.4",
       "model": "openai/gpt-5.4",
       "api_key": "sk-key2",


### PR DESCRIPTION
## Summary
- document the dedicated GLM Coding Plan endpoint in both README variants
- add copy-paste examples that keep the model slug as `zhipu/<model>` while switching `api_base`
- add a `glm-coding-plan` sample entry to `config.example.json` without regressing newer examples

## Testing
- jq empty config/config.example.json
- git diff --check origin/main...HEAD

Closes #1652