### PR TITLE
fix(agent): route image messages through image_model

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -40,6 +40,8 @@ type AgentInstance struct {
 	Subagents                 *config.SubagentsConfig
 	SkillsFilter              []string
 	Candidates                []providers.FallbackCandidate
+	ImageModel                string
+	ImageCandidates           []providers.FallbackCandidate
 
 	// Router is non-nil when model routing is configured and the light model
 	// was successfully resolved. It scores each incoming message and decides
@@ -170,6 +172,12 @@ func NewAgentInstance(
 	// Resolve fallback candidates
 	candidates := resolveModelCandidates(cfg, defaults.Provider, model, fallbacks)
 
+	imageModel := strings.TrimSpace(defaults.ImageModel)
+	var imageCandidates []providers.FallbackCandidate
+	if imageModel != "" {
+		imageCandidates = resolveModelCandidates(cfg, defaults.Provider, imageModel, defaults.ImageModelFallbacks)
+	}
+
 	// Model routing setup: pre-resolve light model candidates at creation time
 	// to avoid repeated model_list lookups on every incoming message.
 	var router *routing.Router
@@ -222,6 +230,8 @@ func NewAgentInstance(
 		Subagents:                 subagents,
 		SkillsFilter:              skillsFilter,
 		Candidates:                candidates,
+		ImageModel:                imageModel,
+		ImageCandidates:           imageCandidates,
 		Router:                    router,
 		LightCandidates:           lightCandidates,
 		LightProvider:             lightProvider,

--- a/pkg/agent/instance_test.go
+++ b/pkg/agent/instance_test.go
@@ -165,6 +165,50 @@ func TestNewAgentInstance_ResolveCandidatesFromModelListAlias(t *testing.T) {
 	}
 }
 
+func TestNewAgentInstance_ResolveImageCandidatesFromModelListAlias(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "agent-instance-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:           tmpDir,
+				ModelName:           "text-main",
+				ImageModel:          "vision-main",
+				ImageModelFallbacks: []string{"vision-backup"},
+			},
+		},
+		ModelList: []*config.ModelConfig{
+			{
+				ModelName: "vision-main",
+				Model:     "gemini/gemini-2.5-flash-lite",
+			},
+			{
+				ModelName: "vision-backup",
+				Model:     "anthropic/claude-3-7-sonnet",
+			},
+		},
+	}
+
+	agent := NewAgentInstance(nil, &cfg.Agents.Defaults, cfg, &mockProvider{})
+
+	if agent.ImageModel != "vision-main" {
+		t.Fatalf("ImageModel = %q, want %q", agent.ImageModel, "vision-main")
+	}
+	if len(agent.ImageCandidates) != 2 {
+		t.Fatalf("len(ImageCandidates) = %d, want 2", len(agent.ImageCandidates))
+	}
+	if agent.ImageCandidates[0].Provider != "gemini" || agent.ImageCandidates[0].Model != "gemini-2.5-flash-lite" {
+		t.Fatalf("first image candidate = %+v, want gemini/gemini-2.5-flash-lite", agent.ImageCandidates[0])
+	}
+	if agent.ImageCandidates[1].Provider != "anthropic" || agent.ImageCandidates[1].Model != "claude-3-7-sonnet" {
+		t.Fatalf("second image candidate = %+v, want anthropic/claude-3-7-sonnet", agent.ImageCandidates[1])
+	}
+}
+
 func TestNewAgentInstance_AllowsMediaTempDirForReadListAndExec(t *testing.T) {
 	workspace := t.TempDir()
 	mediaDir := media.TempDir()

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1683,10 +1683,19 @@ func (al *AgentLoop) runTurn(ctx context.Context, ts *turnState) (turnResult, er
 		ts.recordPersistedMessage(rootMsg)
 	}
 
+	currentTurnResolved := resolveMediaRefs([]providers.Message{
+		{Role: "user", Media: append([]string(nil), ts.media...)},
+	}, al.mediaStore, maxMediaSize)
+	var currentTurnMedia []string
+	if len(currentTurnResolved) > 0 {
+		currentTurnMedia = currentTurnResolved[0].Media
+	}
+
 	activeCandidates, activeModel, usedLight, useImageFallback := al.selectCandidates(
 		ts.agent,
 		ts.userMessage,
 		messages,
+		currentTurnMedia,
 	)
 	activeProvider := ts.agent.Provider
 	if usedLight && ts.agent.LightProvider != nil {
@@ -2764,8 +2773,9 @@ func (al *AgentLoop) selectCandidates(
 	agent *AgentInstance,
 	userMsg string,
 	history []providers.Message,
+	currentTurnMedia []string,
 ) (candidates []providers.FallbackCandidate, model string, usedLight bool, useImageFallback bool) {
-	if hasImageMedia(history) && len(agent.ImageCandidates) > 0 {
+	if hasImageMediaRefs(currentTurnMedia) && len(agent.ImageCandidates) > 0 {
 		logger.InfoCF("agent", "Image model selected",
 			map[string]any{
 				"agent_id":    agent.ID,
@@ -2798,12 +2808,10 @@ func (al *AgentLoop) selectCandidates(
 	return agent.LightCandidates, resolvedCandidateModel(agent.LightCandidates, agent.Router.LightModel()), true, false
 }
 
-func hasImageMedia(messages []providers.Message) bool {
-	for _, msg := range messages {
-		for _, ref := range msg.Media {
-			if strings.HasPrefix(strings.ToLower(ref), "data:image/") {
-				return true
-			}
+func hasImageMediaRefs(mediaRefs []string) bool {
+	for _, ref := range mediaRefs {
+		if strings.HasPrefix(strings.ToLower(ref), "data:image/") {
+			return true
 		}
 	}
 	return false

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1683,7 +1683,11 @@ func (al *AgentLoop) runTurn(ctx context.Context, ts *turnState) (turnResult, er
 		ts.recordPersistedMessage(rootMsg)
 	}
 
-	activeCandidates, activeModel, usedLight := al.selectCandidates(ts.agent, ts.userMessage, messages)
+	activeCandidates, activeModel, usedLight, useImageFallback := al.selectCandidates(
+		ts.agent,
+		ts.userMessage,
+		messages,
+	)
 	activeProvider := ts.agent.Provider
 	if usedLight && ts.agent.LightProvider != nil {
 		activeProvider = ts.agent.LightProvider
@@ -1905,13 +1909,19 @@ turnLoop:
 			defer al.activeRequests.Done()
 
 			if len(activeCandidates) > 1 && al.fallback != nil {
-				fbResult, fbErr := al.fallback.Execute(
-					providerCtx,
-					activeCandidates,
-					func(ctx context.Context, provider, model string) (*providers.LLMResponse, error) {
-						return activeProvider.Chat(ctx, messagesForCall, toolDefsForCall, model, llmOpts)
-					},
+				runCandidate := func(ctx context.Context, provider, model string) (*providers.LLMResponse, error) {
+					return activeProvider.Chat(ctx, messagesForCall, toolDefsForCall, model, llmOpts)
+				}
+
+				var (
+					fbResult *providers.FallbackResult
+					fbErr    error
 				)
+				if useImageFallback {
+					fbResult, fbErr = al.fallback.ExecuteImage(providerCtx, activeCandidates, runCandidate)
+				} else {
+					fbResult, fbErr = al.fallback.Execute(providerCtx, activeCandidates, runCandidate)
+				}
 				if fbErr != nil {
 					return nil, fbErr
 				}
@@ -2754,9 +2764,17 @@ func (al *AgentLoop) selectCandidates(
 	agent *AgentInstance,
 	userMsg string,
 	history []providers.Message,
-) (candidates []providers.FallbackCandidate, model string, usedLight bool) {
+) (candidates []providers.FallbackCandidate, model string, usedLight bool, useImageFallback bool) {
+	if hasImageMedia(history) && len(agent.ImageCandidates) > 0 {
+		logger.InfoCF("agent", "Image model selected",
+			map[string]any{
+				"agent_id":    agent.ID,
+				"image_model": agent.ImageModel,
+			})
+		return agent.ImageCandidates, resolvedCandidateModel(agent.ImageCandidates, agent.ImageModel), false, true
+	}
 	if agent.Router == nil || len(agent.LightCandidates) == 0 {
-		return agent.Candidates, resolvedCandidateModel(agent.Candidates, agent.Model), false
+		return agent.Candidates, resolvedCandidateModel(agent.Candidates, agent.Model), false, false
 	}
 
 	_, usedLight, score := agent.Router.SelectModel(userMsg, history, agent.Model)
@@ -2767,7 +2785,7 @@ func (al *AgentLoop) selectCandidates(
 				"score":     score,
 				"threshold": agent.Router.Threshold(),
 			})
-		return agent.Candidates, resolvedCandidateModel(agent.Candidates, agent.Model), false
+		return agent.Candidates, resolvedCandidateModel(agent.Candidates, agent.Model), false, false
 	}
 
 	logger.InfoCF("agent", "Model routing: light model selected",
@@ -2777,7 +2795,18 @@ func (al *AgentLoop) selectCandidates(
 			"score":       score,
 			"threshold":   agent.Router.Threshold(),
 		})
-	return agent.LightCandidates, resolvedCandidateModel(agent.LightCandidates, agent.Router.LightModel()), true
+	return agent.LightCandidates, resolvedCandidateModel(agent.LightCandidates, agent.Router.LightModel()), true, false
+}
+
+func hasImageMedia(messages []providers.Message) bool {
+	for _, msg := range messages {
+		for _, ref := range msg.Media {
+			if strings.HasPrefix(strings.ToLower(ref), "data:image/") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // maybeSummarize triggers summarization if the session history exceeds thresholds.

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -526,7 +526,7 @@ func TestSelectCandidates_DoesNotUseImageModelForHistoricalImages(t *testing.T) 
 	}
 
 	agent := NewAgentInstance(nil, &cfg.Agents.Defaults, cfg, &mockProvider{})
-	candidates, model, useImageFallback := (&AgentLoop{}).selectCandidates(
+	candidates, model, usedLight, useImageFallback := (&AgentLoop{}).selectCandidates(
 		agent,
 		"text-only follow-up",
 		[]providers.Message{
@@ -537,6 +537,9 @@ func TestSelectCandidates_DoesNotUseImageModelForHistoricalImages(t *testing.T) 
 		nil,
 	)
 
+	if usedLight {
+		t.Fatal("did not expect light-model routing for text-only current turn")
+	}
 	if useImageFallback {
 		t.Fatal("expected image fallback to be disabled for text-only current turn")
 	}

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -91,6 +91,33 @@ func (r *recordingProvider) GetDefaultModel() string {
 	return "mock-model"
 }
 
+type imageFallbackProbeProvider struct {
+	calls []string
+}
+
+func (p *imageFallbackProbeProvider) Chat(
+	ctx context.Context,
+	messages []providers.Message,
+	tools []providers.ToolDefinition,
+	model string,
+	opts map[string]any,
+) (*providers.LLMResponse, error) {
+	p.calls = append(p.calls, model)
+	if model == "gemini-2.5-flash-lite" {
+		// This error is non-retriable in text fallback Execute(), but should still
+		// fail over in ExecuteImage() which only treats image size/dimension as terminal.
+		return nil, fmt.Errorf("string should match pattern")
+	}
+	return &providers.LLMResponse{
+		Content:   "image fallback ok",
+		ToolCalls: []providers.ToolCall{},
+	}, nil
+}
+
+func (p *imageFallbackProbeProvider) GetDefaultModel() string {
+	return "image-fallback-probe"
+}
+
 func newTestAgentLoop(
 	t *testing.T,
 ) (al *AgentLoop, cfg *config.Config, msgBus *bus.MessageBus, provider *mockProvider, cleanup func()) {
@@ -617,6 +644,54 @@ func TestRunAgentLoop_DoesNotUseImageModelWhenOnlyHistoryHasImages(t *testing.T)
 	}
 	if provider.lastModel != "gpt-5.4" {
 		t.Fatalf("second run provider lastModel = %q, want %q", provider.lastModel, "gpt-5.4")
+	}
+}
+
+func TestRunAgentLoop_UsesImageFallbackExecutionForImageCandidates(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:           tmpDir,
+				ModelName:           "text-main",
+				ImageModel:          "vision-main",
+				ImageModelFallbacks: []string{"vision-backup"},
+				MaxTokens:           4096,
+				MaxToolIterations:   5,
+			},
+		},
+		ModelList: []*config.ModelConfig{
+			{ModelName: "text-main", Model: "openai/gpt-5.4"},
+			{ModelName: "vision-main", Model: "gemini/gemini-2.5-flash-lite"},
+			{ModelName: "vision-backup", Model: "anthropic/claude-3-7-sonnet"},
+		},
+	}
+
+	msgBus := bus.NewMessageBus()
+	provider := &imageFallbackProbeProvider{}
+	al := NewAgentLoop(cfg, msgBus, provider)
+	agent := al.registry.GetDefaultAgent()
+
+	resp, err := al.runAgentLoop(context.Background(), agent, processOptions{
+		SessionKey:      "image-fallback-session",
+		Channel:         "telegram",
+		ChatID:          "chat-1",
+		UserMessage:     "describe this image",
+		Media:           []string{"data:image/png;base64,AAAA"},
+		DefaultResponse: "fallback",
+		SendResponse:    false,
+	})
+	if err != nil {
+		t.Fatalf("runAgentLoop returned error: %v", err)
+	}
+	if resp != "image fallback ok" {
+		t.Fatalf("response = %q, want %q", resp, "image fallback ok")
+	}
+	if len(provider.calls) != 2 {
+		t.Fatalf("provider calls = %d, want 2", len(provider.calls))
+	}
+	if provider.calls[0] != "gemini-2.5-flash-lite" || provider.calls[1] != "claude-3-7-sonnet" {
+		t.Fatalf("provider calls = %v, want [gemini-2.5-flash-lite claude-3-7-sonnet]", provider.calls)
 	}
 }
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -462,6 +462,7 @@ func TestSelectCandidates_UsesImageModelWhenImageMediaPresent(t *testing.T) {
 		[]providers.Message{
 			{Role: "user", Content: "describe this image", Media: []string{"data:image/png;base64,AAAA"}},
 		},
+		[]string{"data:image/png;base64,AAAA"},
 	)
 
 	if usedLight {
@@ -478,6 +479,48 @@ func TestSelectCandidates_UsesImageModelWhenImageMediaPresent(t *testing.T) {
 	}
 	if candidates[0].Provider != "gemini" || candidates[0].Model != "gemini-2.5-flash-lite" {
 		t.Fatalf("candidate = %+v, want gemini/gemini-2.5-flash-lite", candidates[0])
+	}
+}
+
+func TestSelectCandidates_DoesNotUseImageModelForHistoricalImages(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:  tmpDir,
+				ModelName:  "text-main",
+				ImageModel: "vision-main",
+			},
+		},
+		ModelList: []*config.ModelConfig{
+			{ModelName: "text-main", Model: "openai/gpt-5.4"},
+			{ModelName: "vision-main", Model: "gemini/gemini-2.5-flash-lite"},
+		},
+	}
+
+	agent := NewAgentInstance(nil, &cfg.Agents.Defaults, cfg, &mockProvider{})
+	candidates, model, useImageFallback := (&AgentLoop{}).selectCandidates(
+		agent,
+		"text-only follow-up",
+		[]providers.Message{
+			{Role: "user", Content: "earlier image", Media: []string{"data:image/png;base64,AAAA"}},
+			{Role: "assistant", Content: "previous response"},
+			{Role: "user", Content: "current text-only turn"},
+		},
+		nil,
+	)
+
+	if useImageFallback {
+		t.Fatal("expected image fallback to be disabled for text-only current turn")
+	}
+	if model != "gpt-5.4" {
+		t.Fatalf("model = %q, want %q", model, "gpt-5.4")
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("len(candidates) = %d, want 1", len(candidates))
+	}
+	if candidates[0].Provider != "openai" || candidates[0].Model != "gpt-5.4" {
+		t.Fatalf("candidate = %+v, want openai/gpt-5.4", candidates[0])
 	}
 }
 
@@ -518,6 +561,62 @@ func TestRunAgentLoop_UsesImageModelForImageMessages(t *testing.T) {
 	}
 	if provider.lastModel != "gemini-2.5-flash-lite" {
 		t.Fatalf("provider lastModel = %q, want %q", provider.lastModel, "gemini-2.5-flash-lite")
+	}
+}
+
+func TestRunAgentLoop_DoesNotUseImageModelWhenOnlyHistoryHasImages(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				ModelName:         "text-main",
+				ImageModel:        "vision-main",
+				MaxTokens:         4096,
+				MaxToolIterations: 5,
+			},
+		},
+		ModelList: []*config.ModelConfig{
+			{ModelName: "text-main", Model: "openai/gpt-5.4"},
+			{ModelName: "vision-main", Model: "gemini/gemini-2.5-flash-lite"},
+		},
+	}
+
+	msgBus := bus.NewMessageBus()
+	provider := &mockProvider{}
+	al := NewAgentLoop(cfg, msgBus, provider)
+	agent := al.registry.GetDefaultAgent()
+
+	sessionKey := "image-history-session"
+	_, err := al.runAgentLoop(context.Background(), agent, processOptions{
+		SessionKey:      sessionKey,
+		Channel:         "telegram",
+		ChatID:          "chat-1",
+		UserMessage:     "describe this image",
+		Media:           []string{"data:image/png;base64,AAAA"},
+		DefaultResponse: "fallback",
+		SendResponse:    false,
+	})
+	if err != nil {
+		t.Fatalf("first runAgentLoop returned error: %v", err)
+	}
+	if provider.lastModel != "gemini-2.5-flash-lite" {
+		t.Fatalf("first run provider lastModel = %q, want %q", provider.lastModel, "gemini-2.5-flash-lite")
+	}
+
+	_, err = al.runAgentLoop(context.Background(), agent, processOptions{
+		SessionKey:      sessionKey,
+		Channel:         "telegram",
+		ChatID:          "chat-1",
+		UserMessage:     "now answer text only",
+		DefaultResponse: "fallback",
+		SendResponse:    false,
+	})
+	if err != nil {
+		t.Fatalf("second runAgentLoop returned error: %v", err)
+	}
+	if provider.lastModel != "gpt-5.4" {
+		t.Fatalf("second run provider lastModel = %q, want %q", provider.lastModel, "gpt-5.4")
 	}
 }
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -439,6 +439,88 @@ func TestRecordLastChatID(t *testing.T) {
 	}
 }
 
+func TestSelectCandidates_UsesImageModelWhenImageMediaPresent(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:  tmpDir,
+				ModelName:  "text-main",
+				ImageModel: "vision-main",
+			},
+		},
+		ModelList: []*config.ModelConfig{
+			{ModelName: "text-main", Model: "openai/gpt-5.4"},
+			{ModelName: "vision-main", Model: "gemini/gemini-2.5-flash-lite"},
+		},
+	}
+
+	agent := NewAgentInstance(nil, &cfg.Agents.Defaults, cfg, &mockProvider{})
+	candidates, model, usedLight, useImageFallback := (&AgentLoop{}).selectCandidates(
+		agent,
+		"describe this image",
+		[]providers.Message{
+			{Role: "user", Content: "describe this image", Media: []string{"data:image/png;base64,AAAA"}},
+		},
+	)
+
+	if usedLight {
+		t.Fatal("did not expect light-model routing for image-only selection")
+	}
+	if !useImageFallback {
+		t.Fatal("expected image fallback to be selected")
+	}
+	if model != "gemini-2.5-flash-lite" {
+		t.Fatalf("model = %q, want %q", model, "gemini-2.5-flash-lite")
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("len(candidates) = %d, want 1", len(candidates))
+	}
+	if candidates[0].Provider != "gemini" || candidates[0].Model != "gemini-2.5-flash-lite" {
+		t.Fatalf("candidate = %+v, want gemini/gemini-2.5-flash-lite", candidates[0])
+	}
+}
+
+func TestRunAgentLoop_UsesImageModelForImageMessages(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				ModelName:         "text-main",
+				ImageModel:        "vision-main",
+				MaxTokens:         4096,
+				MaxToolIterations: 5,
+			},
+		},
+		ModelList: []*config.ModelConfig{
+			{ModelName: "text-main", Model: "openai/gpt-5.4"},
+			{ModelName: "vision-main", Model: "gemini/gemini-2.5-flash-lite"},
+		},
+	}
+
+	msgBus := bus.NewMessageBus()
+	provider := &mockProvider{}
+	al := NewAgentLoop(cfg, msgBus, provider)
+	agent := al.registry.GetDefaultAgent()
+
+	_, err := al.runAgentLoop(context.Background(), agent, processOptions{
+		SessionKey:      "image-session",
+		Channel:         "telegram",
+		ChatID:          "chat-1",
+		UserMessage:     "describe this image",
+		Media:           []string{"data:image/png;base64,AAAA"},
+		DefaultResponse: "fallback",
+		SendResponse:    false,
+	})
+	if err != nil {
+		t.Fatalf("runAgentLoop returned error: %v", err)
+	}
+	if provider.lastModel != "gemini-2.5-flash-lite" {
+		t.Fatalf("provider lastModel = %q, want %q", provider.lastModel, "gemini-2.5-flash-lite")
+	}
+}
+
 func TestNewAgentLoop_StateInitialized(t *testing.T) {
 	// Create temp workspace
 	tmpDir, err := os.MkdirTemp("", "agent-test-*")

--- a/pkg/agent/mock_provider_test.go
+++ b/pkg/agent/mock_provider_test.go
@@ -6,7 +6,9 @@ import (
 	"github.com/sipeed/picoclaw/pkg/providers"
 )
 
-type mockProvider struct{}
+type mockProvider struct {
+	lastModel string
+}
 
 func (m *mockProvider) Chat(
 	ctx context.Context,
@@ -15,6 +17,7 @@ func (m *mockProvider) Chat(
 	model string,
 	opts map[string]any,
 ) (*providers.LLMResponse, error) {
+	m.lastModel = model
 	return &providers.LLMResponse{
 		Content:   "Mock response",
 		ToolCalls: []providers.ToolCall{},


### PR DESCRIPTION
## 📝 Description

Route image-bearing messages through `agents.defaults.image_model` instead of always using the primary `model_name`.

This wires `image_model` and `image_model_fallbacks` into agent startup, makes the agent loop prefer the image model whenever the current turn includes image media, and uses the image-specific fallback path for multimodal requests.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1578

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1578
- **Reasoning:** `ImageModel` and `ImageModelFallbacks` existed in config, but `selectCandidates()` never consumed them, so image messages still went through the primary text model and failed on providers without `image_url` support.

## 🧪 Test Environment
- **Hardware:** x86_64 PC
- **OS:** Linux
- **Model/Provider:** unit-test mock provider with model list aliases
- **Channels:** agent unit tests / simulated Telegram-style image input

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```bash
go test ./pkg/agent -run 'Test(NewAgentInstance_ResolveImageCandidatesFromModelListAlias|SelectCandidates_UsesImageModelWhenImageMediaPresent|RunAgentLoop_UsesImageModelForImageMessages)$'
go test ./pkg/agent
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
