### PR TITLE
feat(provider): add per-model cooldown scope option

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -185,6 +185,10 @@ func NewAgentInstance(
 				logger.WarnCF("agent", "Routing light model config invalid; routing disabled",
 					map[string]any{"light_model": rc.LightModel, "agent_id": agentID, "error": err.Error()})
 			} else {
+				// Reuse the resolved candidate's canonical provider/model form so
+				// routing init stays aligned with model-list resolution behavior.
+				lightModelCfg.Model = providers.ModelKey(resolved[0].Provider, resolved[0].Model)
+
 				lp, _, err := providers.CreateProviderFromConfig(lightModelCfg)
 				if err != nil {
 					logger.WarnCF("agent", "Routing light model provider init failed; routing disabled",

--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -167,8 +167,9 @@ func NewAgentInstance(
 		summarizeTokenPercent = 75
 	}
 
-	// Resolve fallback candidates
+	// Resolve fallback candidates.
 	candidates := resolveModelCandidates(cfg, defaults.Provider, model, fallbacks)
+	candidates = applyCooldownKeys(cfg, candidates)
 
 	// Model routing setup: pre-resolve light model candidates at creation time
 	// to avoid repeated model_list lookups on every incoming message.
@@ -192,7 +193,7 @@ func NewAgentInstance(
 						LightModel: rc.LightModel,
 						Threshold:  rc.Threshold,
 					})
-					lightCandidates = resolved
+					lightCandidates = applyCooldownKeys(cfg, resolved)
 					lightProvider = lp
 				}
 			}
@@ -225,6 +226,64 @@ func NewAgentInstance(
 		Router:                    router,
 		LightCandidates:           lightCandidates,
 		LightProvider:             lightProvider,
+	}
+}
+
+func applyCooldownKeys(cfg *config.Config, candidates []providers.FallbackCandidate) []providers.FallbackCandidate {
+	if len(candidates) == 0 {
+		return candidates
+	}
+
+	resolved := make([]providers.FallbackCandidate, len(candidates))
+	copy(resolved, candidates)
+
+	for i := range resolved {
+		resolved[i].CooldownKey = resolveCooldownKey(cfg, resolved[i])
+	}
+
+	return resolved
+}
+
+func resolveCooldownKey(cfg *config.Config, candidate providers.FallbackCandidate) string {
+	if candidate.Provider == "" {
+		return ""
+	}
+
+	if cfg != nil && candidateUsesPerModelCooldown(cfg, candidate) {
+		return providers.ModelKey(candidate.Provider, candidate.Model)
+	}
+
+	return candidate.Provider
+}
+
+func candidateUsesPerModelCooldown(cfg *config.Config, candidate providers.FallbackCandidate) bool {
+	if cfg == nil {
+		return false
+	}
+
+	candidateKey := providers.ModelKey(candidate.Provider, candidate.Model)
+	for i := range cfg.ModelList {
+		ref := providers.ParseModelRef(cfg.ModelList[i].Model, "openai")
+		if ref == nil {
+			continue
+		}
+		if providers.ModelKey(ref.Provider, ref.Model) != candidateKey {
+			continue
+		}
+		if normalizeCooldownStrategy(cfg.ModelList[i].CooldownStrategy) == "model" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func normalizeCooldownStrategy(strategy string) string {
+	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(strategy)), "_", "-") {
+	case "model", "per-model":
+		return "model"
+	default:
+		return "provider"
 	}
 }
 

--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/sipeed/picoclaw/pkg/config"
@@ -239,7 +240,7 @@ func applyCooldownKeys(cfg *config.Config, candidates []providers.FallbackCandid
 	copy(resolved, candidates)
 
 	for i := range resolved {
-		resolved[i].CooldownKey = resolveCooldownKey(strategyLookup, resolved[i])
+		resolved[i].CooldownKey = resolveCooldownKey(strategyLookup, resolved[i], resolved)
 	}
 
 	return resolved
@@ -267,7 +268,11 @@ func buildCooldownStrategyLookup(cfg *config.Config) map[string]string {
 	return strategyLookup
 }
 
-func resolveCooldownKey(strategyLookup map[string]string, candidate providers.FallbackCandidate) string {
+func resolveCooldownKey(
+	strategyLookup map[string]string,
+	candidate providers.FallbackCandidate,
+	candidates []providers.FallbackCandidate,
+) string {
 	if strings.TrimSpace(candidate.Provider) == "" {
 		if strings.TrimSpace(candidate.Model) == "" {
 			return ""
@@ -276,11 +281,54 @@ func resolveCooldownKey(strategyLookup map[string]string, candidate providers.Fa
 	}
 
 	candidateKey := providers.ModelKey(candidate.Provider, candidate.Model)
+	if belongsToMultiKeySet(candidate, candidates) {
+		return candidateKey
+	}
 	if strategyLookup[candidateKey] == "model" {
 		return candidateKey
 	}
 
 	return candidate.Provider
+}
+
+func belongsToMultiKeySet(
+	candidate providers.FallbackCandidate,
+	candidates []providers.FallbackCandidate,
+) bool {
+	provider := providers.NormalizeProvider(candidate.Provider)
+	model := strings.ToLower(strings.TrimSpace(candidate.Model))
+	if provider == "" || model == "" {
+		return false
+	}
+
+	baseModel, isReplica := multiKeyBaseModel(model)
+	if isReplica {
+		return true
+	}
+
+	for _, other := range candidates {
+		if providers.NormalizeProvider(other.Provider) != provider {
+			continue
+		}
+		otherBase, otherIsReplica := multiKeyBaseModel(other.Model)
+		if otherIsReplica && otherBase == baseModel {
+			return true
+		}
+	}
+
+	return false
+}
+
+func multiKeyBaseModel(model string) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	idx := strings.LastIndex(normalized, "__key_")
+	if idx <= 0 {
+		return normalized, false
+	}
+	if _, err := strconv.Atoi(normalized[idx+len("__key_"):]); err != nil {
+		return normalized, false
+	}
+	return normalized[:idx], true
 }
 
 // resolveAgentWorkspace determines the workspace directory for an agent.

--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -234,57 +234,53 @@ func applyCooldownKeys(cfg *config.Config, candidates []providers.FallbackCandid
 		return candidates
 	}
 
+	strategyLookup := buildCooldownStrategyLookup(cfg)
 	resolved := make([]providers.FallbackCandidate, len(candidates))
 	copy(resolved, candidates)
 
 	for i := range resolved {
-		resolved[i].CooldownKey = resolveCooldownKey(cfg, resolved[i])
+		resolved[i].CooldownKey = resolveCooldownKey(strategyLookup, resolved[i])
 	}
 
 	return resolved
 }
 
-func resolveCooldownKey(cfg *config.Config, candidate providers.FallbackCandidate) string {
-	if candidate.Provider == "" {
-		return ""
+func buildCooldownStrategyLookup(cfg *config.Config) map[string]string {
+	if cfg == nil || len(cfg.ModelList) == 0 {
+		return nil
 	}
 
-	if cfg != nil && candidateUsesPerModelCooldown(cfg, candidate) {
-		return providers.ModelKey(candidate.Provider, candidate.Model)
-	}
-
-	return candidate.Provider
-}
-
-func candidateUsesPerModelCooldown(cfg *config.Config, candidate providers.FallbackCandidate) bool {
-	if cfg == nil {
-		return false
-	}
-
-	candidateKey := providers.ModelKey(candidate.Provider, candidate.Model)
+	strategyLookup := make(map[string]string, len(cfg.ModelList))
 	for i := range cfg.ModelList {
 		ref := providers.ParseModelRef(cfg.ModelList[i].Model, "openai")
 		if ref == nil {
 			continue
 		}
-		if providers.ModelKey(ref.Provider, ref.Model) != candidateKey {
+
+		strategy := config.NormalizeCooldownStrategy(cfg.ModelList[i].CooldownStrategy)
+		if strategy == "" {
 			continue
 		}
-		if normalizeCooldownStrategy(cfg.ModelList[i].CooldownStrategy) == "model" {
-			return true
-		}
+		strategyLookup[providers.ModelKey(ref.Provider, ref.Model)] = strategy
 	}
 
-	return false
+	return strategyLookup
 }
 
-func normalizeCooldownStrategy(strategy string) string {
-	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(strategy)), "_", "-") {
-	case "model", "per-model":
-		return "model"
-	default:
-		return "provider"
+func resolveCooldownKey(strategyLookup map[string]string, candidate providers.FallbackCandidate) string {
+	if strings.TrimSpace(candidate.Provider) == "" {
+		if strings.TrimSpace(candidate.Model) == "" {
+			return ""
+		}
+		return providers.ModelKey(candidate.Provider, candidate.Model)
 	}
+
+	candidateKey := providers.ModelKey(candidate.Provider, candidate.Model)
+	if strategyLookup[candidateKey] == "model" {
+		return candidateKey
+	}
+
+	return candidate.Provider
 }
 
 // resolveAgentWorkspace determines the workspace directory for an agent.

--- a/pkg/agent/instance_test.go
+++ b/pkg/agent/instance_test.go
@@ -172,11 +172,11 @@ func TestNewAgentInstance_ResolvePerModelCooldownKeys(t *testing.T) {
 		Agents: config.AgentsConfig{
 			Defaults: config.AgentDefaults{
 				Workspace:      tmpDir,
-				Model:          "router-a",
+				ModelName:      "router-a",
 				ModelFallbacks: []string{"router-b", "shared-provider"},
 			},
 		},
-		ModelList: []config.ModelConfig{
+		ModelList: []*config.ModelConfig{
 			{
 				ModelName:        "router-a",
 				Model:            "litellm/openai/gpt-4o-mini",
@@ -218,7 +218,7 @@ func TestNewAgentInstance_ResolveLightModelPerModelCooldownKeys(t *testing.T) {
 		Agents: config.AgentsConfig{
 			Defaults: config.AgentDefaults{
 				Workspace: tmpDir,
-				Model:     "primary-model",
+				ModelName: "primary-model",
 				Routing: &config.RoutingConfig{
 					Enabled:    true,
 					LightModel: "light-model",
@@ -226,7 +226,7 @@ func TestNewAgentInstance_ResolveLightModelPerModelCooldownKeys(t *testing.T) {
 				},
 			},
 		},
-		ModelList: []config.ModelConfig{
+		ModelList: []*config.ModelConfig{
 			{
 				ModelName: "primary-model",
 				Model:     "litellm/openai/gpt-4o-mini",
@@ -252,6 +252,41 @@ func TestNewAgentInstance_ResolveLightModelPerModelCooldownKeys(t *testing.T) {
 	}
 	if got := agent.LightCandidates[0].CooldownKey; got != "litellm/openai/gpt-4o" {
 		t.Fatalf("light candidate cooldown key = %q, want %q", got, "litellm/openai/gpt-4o")
+	}
+}
+
+func TestNewAgentInstance_ResolveMultiKeyCooldownKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:      tmpDir,
+				ModelName:      "glm-main",
+				ModelFallbacks: []string{"glm-replica"},
+			},
+		},
+		ModelList: []*config.ModelConfig{
+			{
+				ModelName: "glm-main",
+				Model:     "zhipu/glm-4.7",
+			},
+			{
+				ModelName: "glm-replica",
+				Model:     "zhipu/glm-4.7__key_1",
+			},
+		},
+	}
+
+	agent := NewAgentInstance(nil, &cfg.Agents.Defaults, cfg, &mockProvider{})
+	if len(agent.Candidates) != 2 {
+		t.Fatalf("len(Candidates) = %d, want 2", len(agent.Candidates))
+	}
+	if got := agent.Candidates[0].CooldownKey; got != "zhipu/glm-4.7" {
+		t.Fatalf("candidate[0] cooldown key = %q, want %q", got, "zhipu/glm-4.7")
+	}
+	if got := agent.Candidates[1].CooldownKey; got != "zhipu/glm-4.7__key_1" {
+		t.Fatalf("candidate[1] cooldown key = %q, want %q", got, "zhipu/glm-4.7__key_1")
 	}
 }
 

--- a/pkg/agent/instance_test.go
+++ b/pkg/agent/instance_test.go
@@ -211,6 +211,50 @@ func TestNewAgentInstance_ResolvePerModelCooldownKeys(t *testing.T) {
 	}
 }
 
+func TestNewAgentInstance_ResolveLightModelPerModelCooldownKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace: tmpDir,
+				Model:     "primary-model",
+				Routing: &config.RoutingConfig{
+					Enabled:    true,
+					LightModel: "light-model",
+					Threshold:  0.5,
+				},
+			},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "primary-model",
+				Model:     "litellm/openai/gpt-4o-mini",
+			},
+			{
+				ModelName:        "light-model",
+				Model:            " LiteLLM/OpenAI/GPT-4O ",
+				CooldownStrategy: "per_model",
+			},
+		},
+	}
+
+	agent := NewAgentInstance(nil, &cfg.Agents.Defaults, cfg, &mockProvider{})
+
+	if agent.Router == nil {
+		t.Fatal("expected Router to be initialized for light model routing")
+	}
+	if len(agent.LightCandidates) != 1 {
+		t.Fatalf("len(LightCandidates) = %d, want 1", len(agent.LightCandidates))
+	}
+	if got := agent.LightCandidates[0].Provider; got != "litellm" {
+		t.Fatalf("light candidate provider = %q, want %q", got, "litellm")
+	}
+	if got := agent.LightCandidates[0].CooldownKey; got != "litellm/openai/gpt-4o" {
+		t.Fatalf("light candidate cooldown key = %q, want %q", got, "litellm/openai/gpt-4o")
+	}
+}
+
 func TestNewAgentInstance_AllowsMediaTempDirForReadListAndExec(t *testing.T) {
 	workspace := t.TempDir()
 	mediaDir := media.TempDir()

--- a/pkg/agent/instance_test.go
+++ b/pkg/agent/instance_test.go
@@ -235,6 +235,8 @@ func TestNewAgentInstance_ResolveLightModelPerModelCooldownKeys(t *testing.T) {
 				ModelName:        "light-model",
 				Model:            " LiteLLM/OpenAI/GPT-4O ",
 				CooldownStrategy: "per_model",
+				APIBase:          "https://litellm.example.invalid/v1",
+				APIKeys:          config.SimpleSecureStrings("test-key"),
 			},
 		},
 	}

--- a/pkg/agent/instance_test.go
+++ b/pkg/agent/instance_test.go
@@ -165,6 +165,52 @@ func TestNewAgentInstance_ResolveCandidatesFromModelListAlias(t *testing.T) {
 	}
 }
 
+func TestNewAgentInstance_ResolvePerModelCooldownKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:      tmpDir,
+				Model:          "router-a",
+				ModelFallbacks: []string{"router-b", "shared-provider"},
+			},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName:        "router-a",
+				Model:            "litellm/openai/gpt-4o-mini",
+				CooldownStrategy: "per-model",
+			},
+			{
+				ModelName:        "router-b",
+				Model:            "litellm/openai/gpt-4o",
+				CooldownStrategy: "model",
+			},
+			{
+				ModelName: "shared-provider",
+				Model:     "litellm/openai/gpt-4.1",
+			},
+		},
+	}
+
+	agent := NewAgentInstance(nil, &cfg.Agents.Defaults, cfg, &mockProvider{})
+
+	if len(agent.Candidates) != 3 {
+		t.Fatalf("len(Candidates) = %d, want 3", len(agent.Candidates))
+	}
+
+	if got := agent.Candidates[0].CooldownKey; got != "litellm/openai/gpt-4o-mini" {
+		t.Fatalf("candidate[0] cooldown key = %q, want %q", got, "litellm/openai/gpt-4o-mini")
+	}
+	if got := agent.Candidates[1].CooldownKey; got != "litellm/openai/gpt-4o" {
+		t.Fatalf("candidate[1] cooldown key = %q, want %q", got, "litellm/openai/gpt-4o")
+	}
+	if got := agent.Candidates[2].CooldownKey; got != "litellm" {
+		t.Fatalf("candidate[2] cooldown key = %q, want %q", got, "litellm")
+	}
+}
+
 func TestNewAgentInstance_AllowsMediaTempDirForReadListAndExec(t *testing.T) {
 	workspace := t.TempDir()
 	mediaDir := media.TempDir()

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -2102,7 +2102,7 @@ turnLoop:
 			reasoningContent = response.ReasoningContent
 		}
 		go al.handleReasoning(
-			turnCtx,
+			context.WithoutCancel(turnCtx),
 			reasoningContent,
 			ts.channel,
 			al.targetReasoningChannelID(ts.channel),

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -3409,6 +3409,7 @@ func (al *AgentLoop) buildCommandsRuntime(agent *AgentInstance, opts *processOpt
 			if len(nextCandidates) == 0 {
 				return "", fmt.Errorf("model %q did not resolve to any provider candidates", value)
 			}
+			nextCandidates = applyCooldownKeys(cfg, nextCandidates)
 
 			oldModel := agent.Model
 			oldProvider := agent.Provider

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1556,6 +1556,92 @@ func TestProcessMessage_SwitchModelShowModelConsistency(t *testing.T) {
 	}
 }
 
+func TestProcessMessage_SwitchModelPreservesPerModelCooldownKeys(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "agent-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				Provider:          "openai",
+				ModelName:         "local",
+				ModelFallbacks:    []string{"shared-provider"},
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+			},
+		},
+		ModelList: []*config.ModelConfig{
+			{
+				ModelName: "local",
+				Model:     "openai/local-model",
+				APIBase:   "https://local.example.invalid/v1",
+			},
+			{
+				ModelName:        "router-a",
+				Model:            "litellm/openai/gpt-4o-mini",
+				APIBase:          "https://litellm.example.invalid/v1",
+				CooldownStrategy: "per-model",
+			},
+			{
+				ModelName: "shared-provider",
+				Model:     "litellm/openai/gpt-4.1",
+				APIBase:   "https://litellm.example.invalid/v1",
+			},
+		},
+	}
+	cfg.WithSecurity(&config.SecurityConfig{
+		ModelList: map[string]config.ModelSecurityEntry{
+			"local": {
+				APIKeys: []string{"test-key"},
+			},
+			"router-a": {
+				APIKeys: []string{"test-key"},
+			},
+			"shared-provider": {
+				APIKeys: []string{"test-key"},
+			},
+		},
+	})
+
+	msgBus := bus.NewMessageBus()
+	provider := &countingMockProvider{response: "LLM reply"}
+	al := NewAgentLoop(cfg, msgBus, provider)
+	helper := testHelper{al: al}
+
+	switchResp := helper.executeAndGetResponse(t, context.Background(), bus.InboundMessage{
+		Channel:  "telegram",
+		SenderID: "user1",
+		ChatID:   "chat1",
+		Content:  "/switch model to router-a",
+		Peer: bus.Peer{
+			Kind: "direct",
+			ID:   "user1",
+		},
+	})
+	if !strings.Contains(switchResp, "Switched model from local to router-a") {
+		t.Fatalf("unexpected /switch reply: %q", switchResp)
+	}
+
+	agent := al.GetRegistry().GetDefaultAgent()
+	if agent == nil {
+		t.Fatal("default agent is nil")
+	}
+	if len(agent.Candidates) != 2 {
+		t.Fatalf("len(Candidates) = %d, want 2", len(agent.Candidates))
+	}
+
+	if got := agent.Candidates[0].CooldownKey; got != "litellm/openai/gpt-4o-mini" {
+		t.Fatalf("candidate[0] cooldown key = %q, want %q", got, "litellm/openai/gpt-4o-mini")
+	}
+	if got := agent.Candidates[1].CooldownKey; got != "litellm" {
+		t.Fatalf("candidate[1] cooldown key = %q, want %q", got, "litellm")
+	}
+}
+
 func TestProcessMessage_SwitchModelRejectsUnknownAlias(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "agent-test-*")
 	if err != nil {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1579,33 +1579,23 @@ func TestProcessMessage_SwitchModelPreservesPerModelCooldownKeys(t *testing.T) {
 				ModelName: "local",
 				Model:     "openai/local-model",
 				APIBase:   "https://local.example.invalid/v1",
+				APIKeys:   config.SimpleSecureStrings("test-key"),
 			},
 			{
 				ModelName:        "router-a",
 				Model:            "litellm/openai/gpt-4o-mini",
 				APIBase:          "https://litellm.example.invalid/v1",
 				CooldownStrategy: "per-model",
+				APIKeys:          config.SimpleSecureStrings("test-key"),
 			},
 			{
 				ModelName: "shared-provider",
 				Model:     "litellm/openai/gpt-4.1",
 				APIBase:   "https://litellm.example.invalid/v1",
+				APIKeys:   config.SimpleSecureStrings("test-key"),
 			},
 		},
 	}
-	cfg.WithSecurity(&config.SecurityConfig{
-		ModelList: map[string]config.ModelSecurityEntry{
-			"local": {
-				APIKeys: []string{"test-key"},
-			},
-			"router-a": {
-				APIKeys: []string{"test-key"},
-			},
-			"shared-provider": {
-				APIKeys: []string{"test-key"},
-			},
-		},
-	})
 
 	msgBus := bus.NewMessageBus()
 	provider := &countingMockProvider{response: "LLM reply"}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -696,6 +696,7 @@ func (c *ModelConfig) APIKey() string {
 func (c *ModelConfig) IsVirtual() bool {
 	return c.isVirtual
 }
+}
 
 // Validate checks if the ModelConfig has all required fields.
 func (c *ModelConfig) Validate() error {
@@ -736,7 +737,6 @@ func (c *ModelConfig) SetAPIKey(value string) {
 		c.APIKeys = append(c.APIKeys, NewSecureString(value))
 	}
 }
-
 type GatewayConfig struct {
 	Host      string `json:"host"                env:"PICOCLAW_GATEWAY_HOST"`
 	Port      int    `json:"port"                env:"PICOCLAW_GATEWAY_PORT"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -671,7 +671,11 @@ type ModelConfig struct {
 	MaxTokensField string         `json:"max_tokens_field,omitempty"` // Field name for max tokens (e.g., "max_completion_tokens")
 	RequestTimeout int            `json:"request_timeout,omitempty"`
 	ThinkingLevel  string         `json:"thinking_level,omitempty"` // Extended thinking: off|low|medium|high|xhigh|adaptive
-	ExtraBody      map[string]any `json:"extra_body,omitempty"`     // Additional fields to inject into request body
+	// CooldownStrategy controls the scope of cooldown tracking for this model.
+	// - "provider" (default): cooldown is shared across all models in the provider
+	// - "model" or "per-model": cooldown is isolated to this specific model
+	CooldownStrategy string         `json:"cooldown_strategy,omitempty"`
+	ExtraBody        map[string]any `json:"extra_body,omitempty"` // Additional fields to inject into request body
 
 	APIKeys SecureStrings `json:"api_keys,omitzero" yaml:"api_keys,omitempty"` // API authentication keys (multiple keys for failover)
 
@@ -701,7 +705,28 @@ func (c *ModelConfig) Validate() error {
 	if c.Model == "" {
 		return fmt.Errorf("model is required")
 	}
+	if !isValidCooldownStrategy(c.CooldownStrategy) {
+		return fmt.Errorf("cooldown_strategy must be one of: provider, model, per-model (or per_model)")
+	}
 	return nil
+}
+
+// NormalizeCooldownStrategy canonicalizes cooldown strategy aliases.
+// It returns "provider" for the default/shared scope, "model" for per-model
+// scope, and "" for invalid values.
+func NormalizeCooldownStrategy(strategy string) string {
+	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(strategy)), "_", "-") {
+	case "", "provider":
+		return "provider"
+	case "model", "per-model":
+		return "model"
+	default:
+		return ""
+	}
+}
+
+func isValidCooldownStrategy(strategy string) bool {
+	return NormalizeCooldownStrategy(strategy) != ""
 }
 
 func (c *ModelConfig) SetAPIKey(value string) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -667,10 +667,10 @@ type ModelConfig struct {
 	Workspace   string `json:"workspace,omitempty"`    // Workspace path for CLI-based providers
 
 	// Optional optimizations
-	RPM            int            `json:"rpm,omitempty"`              // Requests per minute limit
-	MaxTokensField string         `json:"max_tokens_field,omitempty"` // Field name for max tokens (e.g., "max_completion_tokens")
-	RequestTimeout int            `json:"request_timeout,omitempty"`
-	ThinkingLevel  string         `json:"thinking_level,omitempty"` // Extended thinking: off|low|medium|high|xhigh|adaptive
+	RPM            int    `json:"rpm,omitempty"`              // Requests per minute limit
+	MaxTokensField string `json:"max_tokens_field,omitempty"` // Field name for max tokens (e.g., "max_completion_tokens")
+	RequestTimeout int    `json:"request_timeout,omitempty"`
+	ThinkingLevel  string `json:"thinking_level,omitempty"` // Extended thinking: off|low|medium|high|xhigh|adaptive
 	// CooldownStrategy controls the scope of cooldown tracking for this model.
 	// - "provider" (default): cooldown is shared across all models in the provider
 	// - "model" or "per-model": cooldown is isolated to this specific model
@@ -695,7 +695,6 @@ func (c *ModelConfig) APIKey() string {
 // IsVirtual returns true if this model was generated from multi-key expansion.
 func (c *ModelConfig) IsVirtual() bool {
 	return c.isVirtual
-}
 }
 
 // Validate checks if the ModelConfig has all required fields.
@@ -737,6 +736,7 @@ func (c *ModelConfig) SetAPIKey(value string) {
 		c.APIKeys = append(c.APIKeys, NewSecureString(value))
 	}
 }
+
 type GatewayConfig struct {
 	Host      string `json:"host"                env:"PICOCLAW_GATEWAY_HOST"`
 	Port      int    `json:"port"                env:"PICOCLAW_GATEWAY_PORT"`

--- a/pkg/config/model_config_test.go
+++ b/pkg/config/model_config_test.go
@@ -243,6 +243,29 @@ func TestModelConfig_Validate(t *testing.T) {
 	}
 }
 
+func TestNormalizeCooldownStrategy(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "", want: "provider"},
+		{input: "provider", want: "provider"},
+		{input: "model", want: "model"},
+		{input: "per-model", want: "model"},
+		{input: "per_model", want: "model"},
+		{input: " Per_Model ", want: "model"},
+		{input: "backend", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := NormalizeCooldownStrategy(tt.input); got != tt.want {
+				t.Fatalf("NormalizeCooldownStrategy(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConfig_ValidateModelList(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/config/model_config_test.go
+++ b/pkg/config/model_config_test.go
@@ -195,6 +195,15 @@ func TestModelConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid per-model cooldown strategy",
+			config: ModelConfig{
+				ModelName:        "router-model",
+				Model:            "litellm/openai/gpt-4o",
+				CooldownStrategy: "per-model",
+			},
+			wantErr: false,
+		},
+		{
 			name: "missing model_name",
 			config: ModelConfig{
 				Model: "openai/gpt-4o",
@@ -211,6 +220,15 @@ func TestModelConfig_Validate(t *testing.T) {
 		{
 			name:    "empty config",
 			config:  ModelConfig{},
+			wantErr: true,
+		},
+		{
+			name: "invalid cooldown strategy",
+			config: ModelConfig{
+				ModelName:        "test",
+				Model:            "openai/gpt-4o",
+				CooldownStrategy: "backend",
+			},
 			wantErr: true,
 		},
 	}

--- a/pkg/providers/fallback.go
+++ b/pkg/providers/fallback.go
@@ -46,7 +46,13 @@ func (c FallbackCandidate) cooldownKey() string {
 	if strings.TrimSpace(c.CooldownKey) != "" {
 		return c.CooldownKey
 	}
-	return ModelKey(c.Provider, c.Model)
+	if strings.TrimSpace(c.Provider) == "" {
+		if strings.TrimSpace(c.Model) == "" {
+			return ""
+		}
+		return ModelKey(c.Provider, c.Model)
+	}
+	return c.Provider
 }
 
 // ResolveCandidates parses model config into a deduplicated candidate list.
@@ -127,8 +133,7 @@ func (fc *FallbackChain) Execute(
 			return nil, context.Canceled
 		}
 
-		// Check cooldown (per provider/model, not just provider).
-		// This allows multi-key failover where different keys use different model names.
+		// Check cooldown using the resolved provider- or model-scoped key.
 		if !fc.cooldown.IsAvailable(cooldownKey) {
 			remaining := fc.cooldown.CooldownRemaining(cooldownKey)
 			result.Attempts = append(result.Attempts, FallbackAttempt{

--- a/pkg/providers/fallback.go
+++ b/pkg/providers/fallback.go
@@ -14,8 +14,9 @@ type FallbackChain struct {
 
 // FallbackCandidate represents one model/provider to try.
 type FallbackCandidate struct {
-	Provider string
-	Model    string
+	Provider    string
+	Model       string
+	CooldownKey string
 }
 
 // FallbackResult contains the successful response and metadata about all attempts.
@@ -39,6 +40,13 @@ type FallbackAttempt struct {
 // NewFallbackChain creates a new fallback chain with the given cooldown tracker.
 func NewFallbackChain(cooldown *CooldownTracker) *FallbackChain {
 	return &FallbackChain{cooldown: cooldown}
+}
+
+func (c FallbackCandidate) cooldownKey() string {
+	if strings.TrimSpace(c.CooldownKey) != "" {
+		return c.CooldownKey
+	}
+	return ModelKey(c.Provider, c.Model)
 }
 
 // ResolveCandidates parses model config into a deduplicated candidate list.
@@ -112,6 +120,8 @@ func (fc *FallbackChain) Execute(
 	}
 
 	for i, candidate := range candidates {
+		cooldownKey := candidate.cooldownKey()
+
 		// Check context before each attempt.
 		if ctx.Err() == context.Canceled {
 			return nil, context.Canceled
@@ -119,7 +129,6 @@ func (fc *FallbackChain) Execute(
 
 		// Check cooldown (per provider/model, not just provider).
 		// This allows multi-key failover where different keys use different model names.
-		cooldownKey := ModelKey(candidate.Provider, candidate.Model)
 		if !fc.cooldown.IsAvailable(cooldownKey) {
 			remaining := fc.cooldown.CooldownRemaining(cooldownKey)
 			result.Attempts = append(result.Attempts, FallbackAttempt{

--- a/pkg/providers/fallback.go
+++ b/pkg/providers/fallback.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -42,7 +43,7 @@ func NewFallbackChain(cooldown *CooldownTracker) *FallbackChain {
 	return &FallbackChain{cooldown: cooldown}
 }
 
-func (c FallbackCandidate) cooldownKey() string {
+func (c FallbackCandidate) cooldownKey(candidates []FallbackCandidate) string {
 	if strings.TrimSpace(c.CooldownKey) != "" {
 		return c.CooldownKey
 	}
@@ -52,7 +53,47 @@ func (c FallbackCandidate) cooldownKey() string {
 		}
 		return ModelKey(c.Provider, c.Model)
 	}
+	if belongsToMultiKeySet(c, candidates) {
+		return ModelKey(c.Provider, c.Model)
+	}
 	return c.Provider
+}
+
+func belongsToMultiKeySet(candidate FallbackCandidate, candidates []FallbackCandidate) bool {
+	provider := NormalizeProvider(candidate.Provider)
+	model := strings.ToLower(strings.TrimSpace(candidate.Model))
+	if provider == "" || model == "" {
+		return false
+	}
+
+	baseModel, isReplica := multiKeyBaseModel(model)
+	if isReplica {
+		return true
+	}
+
+	for _, other := range candidates {
+		if NormalizeProvider(other.Provider) != provider {
+			continue
+		}
+		otherBase, otherIsReplica := multiKeyBaseModel(other.Model)
+		if otherIsReplica && otherBase == baseModel {
+			return true
+		}
+	}
+
+	return false
+}
+
+func multiKeyBaseModel(model string) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	idx := strings.LastIndex(normalized, "__key_")
+	if idx <= 0 {
+		return normalized, false
+	}
+	if _, err := strconv.Atoi(normalized[idx+len("__key_"):]); err != nil {
+		return normalized, false
+	}
+	return normalized[:idx], true
 }
 
 // ResolveCandidates parses model config into a deduplicated candidate list.
@@ -126,7 +167,7 @@ func (fc *FallbackChain) Execute(
 	}
 
 	for i, candidate := range candidates {
-		cooldownKey := candidate.cooldownKey()
+		cooldownKey := candidate.cooldownKey(candidates)
 
 		// Check context before each attempt.
 		if ctx.Err() == context.Canceled {

--- a/pkg/providers/fallback_test.go
+++ b/pkg/providers/fallback_test.go
@@ -11,6 +11,14 @@ func makeCandidate(provider, model string) FallbackCandidate {
 	return FallbackCandidate{Provider: provider, Model: model}
 }
 
+func makePerModelCandidate(provider, model string) FallbackCandidate {
+	return FallbackCandidate{
+		Provider:    provider,
+		Model:       model,
+		CooldownKey: ModelKey(provider, model),
+	}
+}
+
 func successRun(content string) func(ctx context.Context, provider, model string) (*LLMResponse, error) {
 	return func(ctx context.Context, provider, model string) (*LLMResponse, error) {
 		return &LLMResponse{Content: content, FinishReason: "stop"}, nil
@@ -188,6 +196,57 @@ func TestFallback_CooldownSkip(t *testing.T) {
 	}
 	if skipped != 1 {
 		t.Errorf("skipped = %d, want 1", skipped)
+	}
+}
+
+func TestFallback_PerModelCooldownDoesNotSkipSiblingModel(t *testing.T) {
+	now := time.Now()
+	ct, _ := newTestTracker(now)
+	fc := NewFallbackChain(ct)
+
+	candidates := []FallbackCandidate{
+		makePerModelCandidate("litellm", "openai/gpt-4o-mini"),
+		makePerModelCandidate("litellm", "openai/gpt-4o"),
+	}
+
+	ct.MarkFailure(candidates[0].CooldownKey, FailoverRateLimit)
+
+	called := []string{}
+	run := func(ctx context.Context, provider, model string) (*LLMResponse, error) {
+		called = append(called, provider+"/"+model)
+		return &LLMResponse{Content: "ok", FinishReason: "stop"}, nil
+	}
+
+	result, err := fc.Execute(context.Background(), candidates, run)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Model != "openai/gpt-4o" {
+		t.Fatalf("result model = %q, want %q", result.Model, "openai/gpt-4o")
+	}
+	if len(called) != 1 || called[0] != "litellm/openai/gpt-4o" {
+		t.Fatalf("called = %v, want only second model", called)
+	}
+}
+
+func TestFallback_DefaultProviderCooldownSkipsSiblingModel(t *testing.T) {
+	now := time.Now()
+	ct, _ := newTestTracker(now)
+	fc := NewFallbackChain(ct)
+
+	candidates := []FallbackCandidate{
+		makeCandidate("litellm", "openai/gpt-4o-mini"),
+		makeCandidate("litellm", "openai/gpt-4o"),
+	}
+
+	ct.MarkFailure("litellm", FailoverRateLimit)
+
+	_, err := fc.Execute(context.Background(), candidates, func(ctx context.Context, provider, model string) (*LLMResponse, error) {
+		t.Fatal("run should not be called when provider cooldown is shared")
+		return nil, nil
+	})
+	if err == nil {
+		t.Fatal("expected error when all same-provider candidates are skipped")
 	}
 }
 

--- a/pkg/providers/fallback_test.go
+++ b/pkg/providers/fallback_test.go
@@ -165,8 +165,8 @@ func TestFallback_CooldownSkip(t *testing.T) {
 	ct, _ := newTestTracker(now)
 	fc := NewFallbackChain(ct)
 
-	// Put openai/gpt-4 in cooldown (using ModelKey now)
-	ct.MarkFailure(ModelKey("openai", "gpt-4"), FailoverRateLimit)
+	// Put openai in cooldown
+	ct.MarkFailure("openai", FailoverRateLimit)
 
 	candidates := []FallbackCandidate{
 		makeCandidate("openai", "gpt-4"),
@@ -258,9 +258,9 @@ func TestFallback_AllInCooldown(t *testing.T) {
 	ct := NewCooldownTracker()
 	fc := NewFallbackChain(ct)
 
-	// Put all models in cooldown (using ModelKey now)
-	ct.MarkFailure(ModelKey("openai", "gpt-4"), FailoverRateLimit)
-	ct.MarkFailure(ModelKey("anthropic", "claude"), FailoverBilling)
+	// Put all providers in cooldown
+	ct.MarkFailure("openai", FailoverRateLimit)
+	ct.MarkFailure("anthropic", FailoverBilling)
 
 	candidates := []FallbackCandidate{
 		makeCandidate("openai", "gpt-4"),
@@ -336,13 +336,12 @@ func TestFallback_SuccessResetsCooldown(t *testing.T) {
 	fc := NewFallbackChain(ct)
 
 	candidates := []FallbackCandidate{makeCandidate("openai", "gpt-4")}
-	modelKey := ModelKey("openai", "gpt-4")
 
 	attempt := 0
 	run := func(ctx context.Context, provider, model string) (*LLMResponse, error) {
 		attempt++
 		if attempt == 1 {
-			ct.MarkFailure(modelKey, FailoverRateLimit) // simulate failure tracked elsewhere
+			ct.MarkFailure("openai", FailoverRateLimit) // simulate failure tracked elsewhere
 		}
 		return &LLMResponse{Content: "ok", FinishReason: "stop"}, nil
 	}
@@ -351,7 +350,7 @@ func TestFallback_SuccessResetsCooldown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !ct.IsAvailable(modelKey) {
+	if !ct.IsAvailable("openai") {
 		t.Error("success should reset cooldown")
 	}
 }

--- a/pkg/providers/fallback_test.go
+++ b/pkg/providers/fallback_test.go
@@ -241,10 +241,14 @@ func TestFallback_DefaultProviderCooldownSkipsSiblingModel(t *testing.T) {
 
 	ct.MarkFailure("litellm", FailoverRateLimit)
 
-	_, err := fc.Execute(context.Background(), candidates, func(ctx context.Context, provider, model string) (*LLMResponse, error) {
-		t.Fatal("run should not be called when provider cooldown is shared")
-		return nil, nil
-	})
+	_, err := fc.Execute(
+		context.Background(),
+		candidates,
+		func(ctx context.Context, provider, model string) (*LLMResponse, error) {
+			t.Fatal("run should not be called when provider cooldown is shared")
+			return nil, nil
+		},
+	)
 	if err == nil {
 		t.Fatal("expected error when all same-provider candidates are skipped")
 	}


### PR DESCRIPTION
Fixes #1612

## Summary
- add `model_list[*].cooldown_strategy` to opt specific backends into per-model cooldown tracking
- keep provider-wide cooldowns as the default behavior
- attach resolved cooldown keys to fallback candidates during agent initialization
- add regression tests for config validation, candidate resolution, and sibling-model fallback behavior

## Validation
- `go test ./pkg/providers -run 'TestFallback_(CooldownSkip|PerModelCooldownDoesNotSkipSiblingModel|DefaultProviderCooldownSkipsSiblingModel)$'`\n- `go test ./pkg/agent -run 'TestNewAgentInstance_(ResolveCandidatesFromModelListAlias|ResolvePerModelCooldownKeys)$'`\n- `go test ./pkg/config -run 'Test(ModelConfig_Validate|Config_ValidateModelList)$'`\n- `go test ./pkg/providers`\n- `go test ./pkg/agent`\n- `go test ./pkg/config`\n\n## Notes\n- `go test ./...` still fails on upstream baseline in `cmd/picoclaw/internal/onboard` and `pkg/tools`, unrelated to this change.