### PR TITLE
fix(spawn): use target agent model

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -244,6 +244,13 @@ func registerSharedTools(
 			// spawn_status which are added below — preventing recursive
 			// subagent spawning.
 			subagentManager.SetTools(agent.Tools.Clone())
+			subagentManager.SetAgentModelResolver(func(targetAgentID string) (string, bool) {
+				targetAgent, ok := registry.GetAgent(targetAgentID)
+				if !ok || targetAgent == nil || targetAgent.Model == "" {
+					return "", false
+				}
+				return targetAgent.Model, true
+			})
 			if spawnEnabled {
 				spawnTool := tools.NewSpawnTool(subagentManager)
 				currentAgentID := agentID

--- a/pkg/tools/spawn_test.go
+++ b/pkg/tools/spawn_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSpawnTool_Execute_EmptyTask(t *testing.T) {
@@ -75,5 +76,41 @@ func TestSpawnTool_Execute_NilManager(t *testing.T) {
 	}
 	if !strings.Contains(result.ForLLM, "Subagent manager not configured") {
 		t.Errorf("Error message should mention manager not configured, got: %s", result.ForLLM)
+	}
+}
+
+func TestSpawnTool_ExecuteAsync_UsesTargetAgentModel(t *testing.T) {
+	provider := &MockLLMProvider{}
+	manager := NewSubagentManager(provider, "caller-model", "/tmp/test")
+	manager.SetAgentModelResolver(func(agentID string) (string, bool) {
+		if agentID == "analyst" {
+			return "premium-model", true
+		}
+		return "", false
+	})
+	tool := NewSpawnTool(manager)
+
+	done := make(chan *ToolResult, 1)
+	result := tool.ExecuteAsync(context.Background(), map[string]any{
+		"task":     "Investigate the issue",
+		"agent_id": "analyst",
+	}, func(_ context.Context, result *ToolResult) {
+		done <- result
+	})
+	if result == nil || result.IsError {
+		t.Fatalf("expected async spawn success, got: %+v", result)
+	}
+
+	select {
+	case callbackResult := <-done:
+		if callbackResult == nil || callbackResult.IsError {
+			t.Fatalf("expected successful callback result, got: %+v", callbackResult)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for async spawn callback")
+	}
+
+	if provider.lastModel != "premium-model" {
+		t.Fatalf("model = %q, want %q", provider.lastModel, "premium-model")
 	}
 }

--- a/pkg/tools/subagent.go
+++ b/pkg/tools/subagent.go
@@ -26,6 +26,7 @@ type SubagentManager struct {
 	mu             sync.RWMutex
 	provider       providers.LLMProvider
 	defaultModel   string
+	resolveModel   func(agentID string) (string, bool)
 	workspace      string
 	tools          *ToolRegistry
 	maxIterations  int
@@ -59,6 +60,13 @@ func (sm *SubagentManager) SetLLMOptions(maxTokens int, temperature float64) {
 	sm.hasMaxTokens = true
 	sm.temperature = temperature
 	sm.hasTemperature = true
+}
+
+// SetAgentModelResolver resolves the effective model for a target agent ID.
+func (sm *SubagentManager) SetAgentModelResolver(resolve func(agentID string) (string, bool)) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.resolveModel = resolve
 }
 
 // SetTools sets the tool registry for subagent execution.
@@ -144,7 +152,15 @@ After completing the task, provide a clear summary of what was done.`
 	temperature := sm.temperature
 	hasMaxTokens := sm.hasMaxTokens
 	hasTemperature := sm.hasTemperature
+	resolveModel := sm.resolveModel
 	sm.mu.RUnlock()
+
+	model := sm.defaultModel
+	if task.AgentID != "" && resolveModel != nil {
+		if resolvedModel, ok := resolveModel(task.AgentID); ok && resolvedModel != "" {
+			model = resolvedModel
+		}
+	}
 
 	var llmOptions map[string]any
 	if hasMaxTokens || hasTemperature {
@@ -159,7 +175,7 @@ After completing the task, provide a clear summary of what was done.`
 
 	loopResult, err := RunToolLoop(ctx, ToolLoopConfig{
 		Provider:      sm.provider,
-		Model:         sm.defaultModel,
+		Model:         model,
 		Tools:         tools,
 		MaxIterations: maxIter,
 		LLMOptions:    llmOptions,

--- a/pkg/tools/subagent_tool_test.go
+++ b/pkg/tools/subagent_tool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sipeed/picoclaw/pkg/providers"
 )
@@ -11,6 +12,7 @@ import (
 // MockLLMProvider is a test implementation of LLMProvider
 type MockLLMProvider struct {
 	lastOptions map[string]any
+	lastModel   string
 }
 
 func (m *MockLLMProvider) Chat(
@@ -21,6 +23,7 @@ func (m *MockLLMProvider) Chat(
 	options map[string]any,
 ) (*providers.LLMResponse, error) {
 	m.lastOptions = options
+	m.lastModel = model
 	// Find the last user message to generate a response
 	for i := len(messages) - 1; i >= 0; i-- {
 		if messages[i].Role == "user" {
@@ -66,6 +69,46 @@ func TestSubagentManager_SetLLMOptions_AppliesToRunToolLoop(t *testing.T) {
 	}
 	if provider.lastOptions["temperature"] != 0.6 {
 		t.Fatalf("temperature = %v, want %v", provider.lastOptions["temperature"], 0.6)
+	}
+}
+
+func TestSubagentManager_RunTask_UsesResolvedTargetAgentModel(t *testing.T) {
+	provider := &MockLLMProvider{}
+	manager := NewSubagentManager(provider, "caller-model", "/tmp/test")
+	manager.SetAgentModelResolver(func(agentID string) (string, bool) {
+		if agentID == "analyst" {
+			return "premium-model", true
+		}
+		return "", false
+	})
+
+	done := make(chan *ToolResult, 1)
+	_, err := manager.Spawn(
+		context.Background(),
+		"Investigate the issue",
+		"analysis",
+		"analyst",
+		"cli",
+		"direct",
+		func(_ context.Context, result *ToolResult) {
+			done <- result
+		},
+	)
+	if err != nil {
+		t.Fatalf("Spawn() error: %v", err)
+	}
+
+	select {
+	case result := <-done:
+		if result == nil || result.IsError {
+			t.Fatalf("expected successful async result, got: %+v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for subagent completion")
+	}
+
+	if provider.lastModel != "premium-model" {
+		t.Fatalf("model = %q, want %q", provider.lastModel, "premium-model")
 	}
 }
 


### PR DESCRIPTION
## Description

When `spawn` receives an `agent_id`, the spawned subagent should run with that target agent's configured model. The previous path always reused the caller agent's default model because `SubagentManager` had no way to resolve the target agent before entering the tool loop.

This change adds a target-agent model resolver hook to `SubagentManager` and wires it from the agent registry so async `spawn` requests use the target agent model when one is configured, while still falling back to the caller/default model if the target cannot be resolved.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## AI Code Generation
- [ ] Fully AI-generated
- [x] Mostly AI-generated
- [ ] Mostly Human-written

## Related Issue
Fixes #1322

## Technical Context
- add `SetAgentModelResolver` to `SubagentManager`
- resolve `agent_id -> target model` from the agent registry when registering spawn tools
- add regression coverage for manager-level and `spawn` async execution paths

## Test Environment
- Hardware: PC
- OS: Linux
- Model/Provider: mock provider
- Channels: N/A

## Evidence
- `go test ./pkg/tools -run 'Test(SubagentManager_SetLLMOptions_AppliesToRunToolLoop|SubagentManager_RunTask_UsesResolvedTargetAgentModel|SpawnTool_ExecuteAsync_UsesTargetAgentModel|SpawnTool_Execute_ValidTask|SpawnTool_Execute_EmptyTask|SpawnTool_Execute_NilManager)$'`
- `go test ./pkg/agent -run 'TestHandleCommand'`

## Checklist
- [x] I reviewed the change.
- [x] I added regression tests.
