### PR TITLE
fix(cron): update test to use OutboundChan instead of removed SubscribeOutbound

### DIFF
--- a/pkg/tools/cron_test.go
+++ b/pkg/tools/cron_test.go
@@ -226,9 +226,12 @@ func TestCronTool_ExecuteJobPublishesErrorWhenExecDisabled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	msg, ok := tool.msgBus.SubscribeOutbound(ctx)
-	if !ok {
-		t.Fatal("expected outbound message")
+	var msg bus.OutboundMessage
+	select {
+	case msg = <-tool.msgBus.OutboundChan():
+		// got message
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for outbound message")
 	}
 	if !strings.Contains(msg.Content, "command execution is disabled") {
 		t.Fatalf("expected exec disabled message, got: %s", msg.Content)


### PR DESCRIPTION
The SubscribeOutbound method was removed in commit 9c31b0c (`fix: Fixed the bug where the bus was closed...`) but pkg/tools/cron_test.go was not updated to use the new OutboundChan() API.

This PR updates the test to use the new API:
- `SubscribeOutbound(ctx)` → `OutboundChan()` + select

Test: All tests in pkg/tools pass.