### PR TITLE
fix(provider): normalize dotted Anthropic model IDs for API-key paths

### DIFF
--- a/pkg/providers/anthropic_messages/provider.go
+++ b/pkg/providers/anthropic_messages/provider.go
@@ -162,7 +162,7 @@ func buildRequestBody(
 	}
 
 	result := map[string]any{
-		"model":      model,
+		"model":      strings.ReplaceAll(model, ".", "-"),
 		"max_tokens": int64(maxTokens),
 		"messages":   []any{},
 	}

--- a/pkg/providers/anthropic_messages/provider_test.go
+++ b/pkg/providers/anthropic_messages/provider_test.go
@@ -118,6 +118,26 @@ func TestBuildRequestBody(t *testing.T) {
 			},
 		},
 		{
+			name: "normalizes dotted anthropic model ID",
+			messages: []Message{
+				{Role: "user", Content: "Hello"},
+			},
+			model: "claude-sonnet-4.6",
+			options: map[string]any{
+				"max_tokens": 8192,
+			},
+			want: map[string]any{
+				"model":      "claude-sonnet-4-6",
+				"max_tokens": int64(8192),
+				"messages": []any{
+					map[string]any{
+						"role":    "user",
+						"content": "Hello",
+					},
+				},
+			},
+		},
+		{
 			name: "missing max_tokens returns error",
 			messages: []Message{
 				{Role: "user", Content: "Test"},

--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -218,6 +218,7 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 		if cfg.APIKey() == "" {
 			return nil, "", fmt.Errorf("api_key is required for anthropic protocol (model: %s)", cfg.Model)
 		}
+		modelID = strings.ReplaceAll(modelID, ".", "-")
 		return NewHTTPProviderWithMaxTokensFieldAndRequestTimeout(
 			cfg.APIKey(),
 			apiBase,

--- a/pkg/providers/factory_provider_test.go
+++ b/pkg/providers/factory_provider_test.go
@@ -282,7 +282,7 @@ func TestGetDefaultAPIBase_Mimo(t *testing.T) {
 	}
 }
 
-func TestCreateProviderFromConfig_Anthropic(t *testing.T) {
+func TestCreateProviderFromConfig_AnthropicAPIKeyNormalizesDottedModelID(t *testing.T) {
 	cfg := &config.ModelConfig{
 		ModelName: "test-anthropic",
 		Model:     "anthropic/claude-sonnet-4.6",
@@ -296,8 +296,8 @@ func TestCreateProviderFromConfig_Anthropic(t *testing.T) {
 	if provider == nil {
 		t.Fatal("CreateProviderFromConfig() returned nil provider")
 	}
-	if modelID != "claude-sonnet-4.6" {
-		t.Errorf("modelID = %q, want %q", modelID, "claude-sonnet-4.6")
+	if modelID != "claude-sonnet-4-6" {
+		t.Errorf("modelID = %q, want %q", modelID, "claude-sonnet-4-6")
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

Normalize dotted Anthropic model IDs like `claude-sonnet-4.6` to the API-accepted dashed form `claude-sonnet-4-6` in the two API-key paths that were still forwarding the dotted value.

This fixes the API-key `anthropic` provider path and the native `anthropic-messages` request builder, and adds regression tests for both.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1624

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1624
- **Reasoning:** `pkg/providers/anthropic/provider.go` already normalizes dotted Anthropic model IDs for the SDK/OAuth path, but the API-key `anthropic` branch in `CreateProviderFromConfig` and the native `anthropic-messages` request body were still sending dotted IDs. Anthropic rejects those with a 404 and suggests the dashed model ID.

## 🧪 Test Environment
- **Hardware:** x86_64 PC
- **OS:** NewStartOS V4.4.2-ZTE
- **Model/Provider:** N/A (unit tests only)
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```text
$ go test ./pkg/providers/...
ok   github.com/sipeed/picoclaw/pkg/providers
ok   github.com/sipeed/picoclaw/pkg/providers/anthropic
ok   github.com/sipeed/picoclaw/pkg/providers/anthropic_messages
ok   github.com/sipeed/picoclaw/pkg/providers/azure
ok   github.com/sipeed/picoclaw/pkg/providers/common
ok   github.com/sipeed/picoclaw/pkg/providers/openai_compat
```

```text
$ go test ./pkg/providers/anthropic_messages
ok   github.com/sipeed/picoclaw/pkg/providers/anthropic_messages
```

`go test ./...` still fails in unrelated existing/environment-dependent areas (`cmd/picoclaw`, `cmd/picoclaw/internal`, `cmd/picoclaw/internal/model`, `pkg/agent`, `pkg/auth`, `pkg/migrate/internal`, `pkg/tools`) and was not changed in this PR.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
