### PR TITLE
feat(tool): overwrite flag in write_file

### DIFF
--- a/pkg/tools/filesystem.go
+++ b/pkg/tools/filesystem.go
@@ -536,7 +536,7 @@ func (t *WriteFileTool) Execute(ctx context.Context, args map[string]any) *ToolR
 
 	if !overwrite {
 		if _, err := t.fs.Open(path); err == nil {
-			return ErrorResult(fmt.Sprintf("file already exists: %s (set overwrite=true to replace it)", path))
+			return ErrorResult(fmt.Sprintf("file: %s already exists. Set overwrite=true to replace.", path))
 		}
 	}
 

--- a/pkg/tools/filesystem_test.go
+++ b/pkg/tools/filesystem_test.go
@@ -203,7 +203,7 @@ func TestFilesystemTool_WriteFile_OverwriteDefaultBlocked(t *testing.T) {
 	})
 
 	assert.True(t, result.IsError, "expected error when overwriting without overwrite=true")
-	assert.Contains(t, result.ForLLM, "file already exists")
+	assert.Contains(t, result.ForLLM, "already exists")
 	assert.Contains(t, result.ForLLM, "overwrite=true")
 
 	// Original content must be untouched
@@ -267,7 +267,7 @@ func TestFilesystemTool_WriteFile_OverwriteFalseExplicitBlocked(t *testing.T) {
 	})
 
 	assert.True(t, result.IsError, "expected error when overwrite=false")
-	assert.Contains(t, result.ForLLM, "file already exists")
+	assert.Contains(t, result.ForLLM, "already exists")
 
 	data, err := os.ReadFile(testFile)
 	assert.NoError(t, err)
@@ -289,7 +289,7 @@ func TestFilesystemTool_WriteFile_OverwriteSandboxed(t *testing.T) {
 		"content": "new content",
 	})
 	assert.True(t, result.IsError, "expected error in sandbox mode without overwrite=true")
-	assert.Contains(t, result.ForLLM, "file already exists")
+	assert.Contains(t, result.ForLLM, "already exists")
 
 	// With overwrite=true → allowed
 	result = tool.Execute(context.Background(), map[string]any{


### PR DESCRIPTION
## 📝 Description

Added a boolean `overwrite` parameter to the `write_file` tool. This change introduces a safety check to prevent accidental file overwriting: if a file already exists, the tool will return an error unless `overwrite=true` is explicitly passed in the arguments. The tool's description has also been updated to properly instruct the language model about this new behavior.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** Allowing silent file overwrites by default can lead to accidental data loss or undesired behavior by the LLM. Requiring an explicit flag (`overwrite: true`) adds a safety guardrail to filesystem operations.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** macOS / Linux - **Model/Provider:** OpenAI GPT-4o - **Channels:** Terminal / Local


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.