### PR TITLE
feat(tool): anti cloudflare challenge in web_fetch

### DIFF
--- a/pkg/tools/web.go
+++ b/pkg/tools/web.go
@@ -926,12 +926,16 @@ func (t *WebFetchTool) Execute(ctx context.Context, args map[string]any) *ToolRe
 			return nil, nil, fmt.Errorf("request failed: %w", doErr)
 		}
 		resp.Body = http.MaxBytesReader(nil, resp.Body, t.fetchLimitBytes)
-		defer resp.Body.Close()
+
 		b, readErr := io.ReadAll(resp.Body)
 		return resp, b, readErr
 	}
 
 	resp, body, err := doFetch(userAgent)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
@@ -943,11 +947,16 @@ func (t *WebFetchTool) Execute(ctx context.Context, args map[string]any) *ToolRe
 	// Cloudflare (and similar WAFs) signal bot challenges with 403 + cf-mitigated: challenge.
 	// Retry once with an honest User-Agent that identifies picoclaw, which some
 	// operators explicitly allow-list for AI assistants.
-	if resp.StatusCode == http.StatusForbidden && resp.Header.Get("cf-mitigated") == "challenge" {
+	if resp.StatusCode == http.StatusForbidden && resp.Header.Get("Cf-Mitigated") == "challenge" {
 		logger.DebugCF("tool", "Cloudflare challenge detected, retrying with honest User-Agent",
 			map[string]any{"url": urlStr})
 		honestUA := fmt.Sprintf(userAgentHonest, config.Version)
-		if resp2, body2, err2 := doFetch(honestUA); err2 == nil {
+		resp2, body2, err2 := doFetch(honestUA)
+		if resp2 != nil && resp2.Body != nil {
+			defer resp2.Body.Close()
+		}
+
+		if err2 == nil {
 			resp, body = resp2, body2
 		} else {
 			var maxBytesErr *http.MaxBytesError

--- a/pkg/tools/web_test.go
+++ b/pkg/tools/web_test.go
@@ -1084,7 +1084,7 @@ func TestWebFetchTool_CloudflareChallenge_RetryWithHonestUA(t *testing.T) {
 
 		if requestCount == 1 {
 			// First request: simulate Cloudflare challenge
-			w.Header().Set("cf-mitigated", "challenge")
+			w.Header().Set("Cf-Mitigated", "challenge")
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusForbidden)
 			w.Write([]byte("<html><body>Cloudflare challenge</body></html>"))
@@ -1158,7 +1158,7 @@ func TestWebFetchTool_CloudflareChallenge_RetryFailsToo(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Always return CF challenge regardless of UA
-		w.Header().Set("cf-mitigated", "challenge")
+		w.Header().Set("Cf-Mitigated", "challenge")
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusForbidden)
 		w.Write([]byte("<html><body>still blocked</body></html>"))


### PR DESCRIPTION
## 📝 Description

This PR improves the resilience of the web scraping tool against Web Application Firewalls (WAFs) like Cloudflare. 

Key changes:
- Added a fallback mechanism: if the initial request gets blocked by a bot challenge (HTTP 403 with `cf-mitigated: challenge` header), the tool will automatically retry the request using an "honest" AI bot User-Agent (`picoclaw/... AI assistant bot`). This helps access websites that explicitly allow-list identified AI agents.
- Added an explicit `\n[Content truncated due to size limit]` suffix when the scraped text exceeds the maximum character limit, providing better context to the LLM.
- Extracted the HTTP fetching logic into a reusable `doFetch` helper function.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** Standard browser User-Agents used by bots are often caught by Cloudflare's anti-bot protections. By detecting the specific `cf-mitigated: challenge` header and retrying with an honest, recognizable AI bot User-Agent, we increase the success rate of web fetches for sites that allow legitimate AI assistants. The truncation message was also added to prevent the LLM from hallucinating or assuming it read the end of a page when it was actually cut off.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Linux / macOS - **Model/Provider:** OpenAI GPT-4o - **Channels:** Terminal / Local


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.