### PR TITLE
fix(cron): publish agent response to user after scheduled job runs

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -666,7 +666,34 @@ func (al *AgentLoop) ProcessDirectWithChannel(
 		SessionKey: sessionKey,
 	}
 
-	return al.processMessage(ctx, msg)
+	response, err := al.processMessage(ctx, msg)
+	if err != nil {
+		return response, err
+	}
+
+	// Publish response if non-empty and the message tool hasn't already sent it.
+	// This mirrors the publish logic in Run() for direct/cron invocations that
+	// bypass the main message loop.
+	if response != "" {
+		alreadySent := false
+		defaultAgent := al.GetRegistry().GetDefaultAgent()
+		if defaultAgent != nil {
+			if tool, ok := defaultAgent.Tools.Get("message"); ok {
+				if mt, ok := tool.(*tools.MessageTool); ok {
+					alreadySent = mt.HasSentInRound()
+				}
+			}
+		}
+		if !alreadySent {
+			al.bus.PublishOutbound(ctx, bus.OutboundMessage{
+				Channel: msg.Channel,
+				ChatID:  msg.ChatID,
+				Content: response,
+			})
+		}
+	}
+
+	return response, nil
 }
 
 // ProcessHeartbeat processes a heartbeat request without session history.


### PR DESCRIPTION
# fix(cron): publish agent response to user after scheduled job runs

## 📝 Description

Cron jobs execute successfully (LLM inference runs) but the bot never delivers the response to the user. From the user's perspective, nothing happens at the scheduled time.

`ProcessDirectWithChannel` called `processMessage` and discarded the returned response, relying on a wrong assumption that `AgentLoop.Run()` would publish it. `Run()` only publishes for messages that go through the inbound bus loop; cron jobs call `ProcessDirectWithChannel` directly, bypassing it entirely.

Added the same `HasSentInRound()` guard + `PublishOutbound` call that `Run()` uses, so the response reaches the user's channel (e.g. Telegram) after a cron job triggers LLM inference.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** `pkg/agent/loop.go` — `ProcessDirectWithChannel` and `Run()`
- **Reasoning:** `Run()` publishes the response after `processMessage` returns, but cron jobs call `ProcessDirectWithChannel` directly, which returned the response to `CronTool.ExecuteJob` where it was discarded with `_ = response`. The fix moves the publish logic into `ProcessDirectWithChannel` so it works regardless of the call path. The `HasSentInRound()` guard prevents double-delivery if the agent already sent via the `message` tool during the loop.

## 🧪 Test Environment
- **Hardware:** Raspberry Pi Zero W
- **OS:** Raspberry Pi OS (Linux)
- **Model/Provider:** Ollama — glm-4.7-flash
- **Channels:** Telegram


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
