### PR TITLE
generate works now for all platforms

### DIFF
--- a/cmd/copyembed/main.go
+++ b/cmd/copyembed/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "Usage: copyembed <src> <dst>")
+		os.Exit(1)
+	}
+	src := os.Args[1]
+	dst := os.Args[2]
+
+	if err := copyDir(src, dst); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Copied %s -> %s\n", src, dst)
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(dst, rel)
+
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+
+		return os.WriteFile(target, data, info.Mode())
+	})
+}

--- a/cmd/picoclaw/internal/onboard/command.go
+++ b/cmd/picoclaw/internal/onboard/command.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate cp -r ../../../../workspace .
+//go:generate go run github.com/sipeed/picoclaw/cmd/copyembed ../../../../workspace workspace
 //go:embed workspace
 var embeddedFiles embed.FS
 


### PR DESCRIPTION
## 📝 Description

The go:generatecommand was not platform independent
So this fixes it.
One of my machines is a windows machine and don't know the cp command ;-)

## 🗣️ Type of Change
- [X ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ X] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 📸 Evidence (Optional)
<details>
<summary>
go run -trimpath cmd/picoclaw/main.go onboard 
cmd\picoclaw\internal\onboard\command.go:10:12: pattern workspace: no matching files found
</summary>
</details>

## ☑️ Checklist
- [X ] My code/docs follow the style of this project.
- [ X] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.