### PR TITLE
fix: deduplicate tool results and merge consecutive tool_result blocks for Anthropic API

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -660,8 +660,21 @@ func sanitizeHistoryForProvider(history []providers.Message) []providers.Message
 	// like DeepSeek that enforce: "An assistant message with 'tool_calls' must
 	// be followed by tool messages responding to each 'tool_call_id'."
 	final := make([]providers.Message, 0, len(sanitized))
+	seenToolCallID := make(map[string]bool)
 	for i := 0; i < len(sanitized); i++ {
 		msg := sanitized[i]
+
+		// Deduplicate tool results by ToolCallID
+		if msg.Role == "tool" && msg.ToolCallID != "" {
+			if seenToolCallID[msg.ToolCallID] {
+				logger.DebugCF("agent", "Dropping duplicate tool result", map[string]any{
+					"tool_call_id": msg.ToolCallID,
+				})
+				continue
+			}
+			seenToolCallID[msg.ToolCallID] = true
+		}
+
 		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
 			// Collect expected tool_call IDs
 			expected := make(map[string]bool, len(msg.ToolCalls))

--- a/pkg/agent/context_test.go
+++ b/pkg/agent/context_test.go
@@ -188,6 +188,31 @@ func TestSanitizeHistoryForProvider_PlainConversation(t *testing.T) {
 	assertRoles(t, result, "user", "assistant", "user", "assistant")
 }
 
+func TestSanitizeHistoryForProvider_DuplicateToolResults(t *testing.T) {
+	history := []providers.Message{
+		msg("user", "do something"),
+		assistantWithTools("A", "B"),
+		toolResult("A"),
+		toolResult("B"),
+		toolResult("A"), // duplicate
+		toolResult("B"), // duplicate
+		msg("assistant", "done"),
+	}
+
+	result := sanitizeHistoryForProvider(history)
+	if len(result) != 5 {
+		t.Fatalf("expected 5 messages, got %d: %+v", len(result), roles(result))
+	}
+	assertRoles(t, result, "user", "assistant", "tool", "tool", "assistant")
+	// Verify the kept tool results have the correct IDs
+	if result[2].ToolCallID != "A" {
+		t.Errorf("expected tool result A, got %q", result[2].ToolCallID)
+	}
+	if result[3].ToolCallID != "B" {
+		t.Errorf("expected tool result B, got %q", result[3].ToolCallID)
+	}
+}
+
 func roles(msgs []providers.Message) []string {
 	r := make([]string, len(msgs))
 	for i, m := range msgs {

--- a/pkg/providers/anthropic_messages/provider.go
+++ b/pkg/providers/anthropic_messages/provider.go
@@ -188,17 +188,23 @@ func buildRequestBody(
 
 		case "user":
 			if msg.ToolCallID != "" {
-				// Tool result message
-				content := []map[string]any{
-					{
-						"type":        "tool_result",
-						"tool_use_id": msg.ToolCallID,
-						"content":     msg.Content,
-					},
+				// Tool result message — merge into previous user message if it contains tool_results
+				toolResultBlock := map[string]any{
+					"type":        "tool_result",
+					"tool_use_id": msg.ToolCallID,
+					"content":     msg.Content,
+				}
+				if len(apiMessages) > 0 {
+					if prev, ok := apiMessages[len(apiMessages)-1].(map[string]any); ok && prev["role"] == "user" {
+						if content, ok := prev["content"].([]map[string]any); ok {
+							prev["content"] = append(content, toolResultBlock)
+							continue
+						}
+					}
 				}
 				apiMessages = append(apiMessages, map[string]any{
 					"role":    "user",
-					"content": content,
+					"content": []map[string]any{toolResultBlock},
 				})
 			} else {
 				// Regular user message
@@ -246,17 +252,23 @@ func buildRequestBody(
 			})
 
 		case "tool":
-			// Tool result (alternative format)
-			content := []map[string]any{
-				{
-					"type":        "tool_result",
-					"tool_use_id": msg.ToolCallID,
-					"content":     msg.Content,
-				},
+			// Tool result (alternative format) — merge into previous user message if it contains tool_results
+			toolResultBlock := map[string]any{
+				"type":        "tool_result",
+				"tool_use_id": msg.ToolCallID,
+				"content":     msg.Content,
+			}
+			if len(apiMessages) > 0 {
+				if prev, ok := apiMessages[len(apiMessages)-1].(map[string]any); ok && prev["role"] == "user" {
+					if content, ok := prev["content"].([]map[string]any); ok {
+						prev["content"] = append(content, toolResultBlock)
+						continue
+					}
+				}
 			}
 			apiMessages = append(apiMessages, map[string]any{
 				"role":    "user",
-				"content": content,
+				"content": []map[string]any{toolResultBlock},
 			})
 		}
 	}

--- a/pkg/providers/anthropic_messages/provider_test.go
+++ b/pkg/providers/anthropic_messages/provider_test.go
@@ -562,6 +562,96 @@ func TestBuildRequestBodyEdgeCases(t *testing.T) {
 	}
 }
 
+func TestBuildRequestBody_ConsecutiveToolResultsMerged(t *testing.T) {
+	// Consecutive tool results (role "tool") should be merged into a single "user" message
+	messages := []Message{
+		{Role: "user", Content: "Use tools"},
+		{Role: "assistant", Content: "", ToolCalls: []ToolCall{
+			{ID: "t1", Name: "tool_a", Arguments: map[string]any{"x": 1}},
+			{ID: "t2", Name: "tool_b", Arguments: map[string]any{"y": 2}},
+		}},
+		{Role: "tool", ToolCallID: "t1", Content: "result1"},
+		{Role: "tool", ToolCallID: "t2", Content: "result2"},
+	}
+
+	got, err := buildRequestBody(messages, nil, "test-model", map[string]any{"max_tokens": 8192})
+	if err != nil {
+		t.Fatalf("buildRequestBody() error: %v", err)
+	}
+
+	apiMessages, ok := got["messages"].([]any)
+	if !ok {
+		t.Fatalf("messages is not []any")
+	}
+
+	// Expect: user, assistant, user (merged tool results)
+	if len(apiMessages) != 3 {
+		for i, m := range apiMessages {
+			t.Logf("message[%d]: %+v", i, m)
+		}
+		t.Fatalf("expected 3 API messages, got %d", len(apiMessages))
+	}
+
+	// The third message should be a user message with 2 tool_result blocks
+	toolResultMsg, ok := apiMessages[2].(map[string]any)
+	if !ok {
+		t.Fatalf("tool result message is not map[string]any")
+	}
+	if toolResultMsg["role"] != "user" {
+		t.Errorf("expected role 'user', got %v", toolResultMsg["role"])
+	}
+	content, ok := toolResultMsg["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("content is not []map[string]any: %T", toolResultMsg["content"])
+	}
+	if len(content) != 2 {
+		t.Fatalf("expected 2 tool_result blocks, got %d", len(content))
+	}
+	if content[0]["tool_use_id"] != "t1" {
+		t.Errorf("first tool_result tool_use_id = %v, want t1", content[0]["tool_use_id"])
+	}
+	if content[1]["tool_use_id"] != "t2" {
+		t.Errorf("second tool_result tool_use_id = %v, want t2", content[1]["tool_use_id"])
+	}
+}
+
+func TestBuildRequestBody_UserToolResultsMerged(t *testing.T) {
+	// Consecutive tool results using role "user" with ToolCallID should also be merged
+	messages := []Message{
+		{Role: "user", Content: "Use tools"},
+		{Role: "assistant", Content: "", ToolCalls: []ToolCall{
+			{ID: "t1", Name: "tool_a", Arguments: map[string]any{"x": 1}},
+			{ID: "t2", Name: "tool_b", Arguments: map[string]any{"y": 2}},
+		}},
+		{Role: "user", ToolCallID: "t1", Content: "result1"},
+		{Role: "user", ToolCallID: "t2", Content: "result2"},
+	}
+
+	got, err := buildRequestBody(messages, nil, "test-model", map[string]any{"max_tokens": 8192})
+	if err != nil {
+		t.Fatalf("buildRequestBody() error: %v", err)
+	}
+
+	apiMessages, ok := got["messages"].([]any)
+	if !ok {
+		t.Fatalf("messages is not []any")
+	}
+
+	// Expect: user, assistant, user (merged tool results)
+	if len(apiMessages) != 3 {
+		t.Fatalf("expected 3 API messages, got %d", len(apiMessages))
+	}
+
+	toolResultMsg := apiMessages[2].(map[string]any)
+	content, ok := toolResultMsg["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("content is not []map[string]any: %T", toolResultMsg["content"])
+	}
+	if len(content) != 2 {
+		t.Fatalf("expected 2 tool_result blocks, got %d", len(content))
+	}
+}
+
 // TestParseResponseBodyEdgeCases tests edge cases for parseResponseBody.
 func TestParseResponseBodyEdgeCases(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Fixes #1792

## 📝 Description

修复使用 Anthropic 提供商时，LLM 调用返回 400 错误：`each tool_use must have a single result. Found multiple tool_result blocks with id` 的问题。

根因有两个：

1. 历史消息清理函数 `sanitizeHistoryForProvider` 未对重复的 `ToolCallID` 进行去重，导致相同 ID 的 tool result 被多次发送。
2. Anthropic Messages 适配器在 `buildRequestBody` 中将每个 tool result 作为独立的 `user` 消息发送，而 Anthropic API 要求连续的 tool result 必须合并到同一个 `user` 消息的 `content` 数组中。

本 PR 的修改：

- 在 `sanitizeHistoryForProvider`（`pkg/agent/context.go`）的第二遍扫描中增加 `seenToolCallID` map，遇到相同 `ToolCallID` 的 tool 消息时仅保留第一个，跳过后续重复项。
- 在 Anthropic 的 `buildRequestBody`（`pkg/providers/anthropic_messages/provider.go`）中，将连续的 tool result（无论是 `role: "user"` + `ToolCallID` 还是 `role: "tool"` 格式）合并到前一个 `user` 消息的 `content` 数组中，而非创建新的独立消息。
- 新增对应的单元测试覆盖去重和合并逻辑。

## 🗣️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation

- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- 如有相关 issue 请在此链接，例如 Fixes #123 -->

## 📚 Technical Context (Skip for Docs)

- **Reference URL:** https://docs.anthropic.com/en/api/messages
- **Reasoning:** Anthropic Messages API 要求每个 `tool_use` 对应唯一一个 `tool_result`，且同一轮对话中的多个 tool result 必须放在同一个 `user` 消息的 `content` 数组内。违反这两个约束时 API 会返回 400 错误。

## 🧪 Test Environment

- **Hardware:** Mac (Apple Silicon)
- **OS:** macOS
- **Model/Provider:** Anthropic Claude
- **Channels:** N/A（单元测试验证）


## 📸 Evidence (Optional)

<details>
<summary>Click to view Logs/Screenshots</summary>

修复前错误日志：

```
400 Bad Request: each tool_use must have a single result. Found multiple tool_result blocks with id
```

修复后单元测试通过：

```bash
go test ./pkg/agent/ -run TestSanitizeHistoryForProvider_DuplicateToolResults -v
go test ./pkg/providers/anthropic_messages/ -run TestBuildRequestBody_ConsecutiveToolResultsMerged -v
go test ./pkg/providers/anthropic_messages/ -run TestBuildRequestBody_UserToolResultsMerged -v
```

</details>

## ☑️ Checklist

- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
