### PR TITLE
chore(deps): bump Go toolchain to 1.25.8 for stdlib security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sipeed/picoclaw
 
-go 1.25.7
+go 1.25.8
 
 require (
 	fyne.io/systray v1.12.0


### PR DESCRIPTION
## 📝 Description

Bump the Go toolchain version in `go.mod` from `1.25.7` to `1.25.8` so PicoClaw builds and tests against the latest Go 1.25 patch release that includes standard library security fixes.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://go.dev/doc/devel/release
- **Reasoning:** Go 1.25.8 was released on March 5, 2026 and includes security fixes in `html/template`, `net/url`, and `os`, plus bug fixes in the `go` command, the compiler, and `os`. Updating the toolchain version keeps PicoClaw aligned with the latest supported Go 1.25 patch release without changing application behavior.

## 🧪 Test Environment
- **Hardware:** Apple Silicon Mac
- **OS:** macOS 26.3.1 (arm64)
- **Model/Provider:** N/A (dependency/toolchain bump only)
- **Channels:** N/A (dependency/toolchain bump only)


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

`make check` passed locally.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
