### PR TITLE
fix: container run but app stopped on SIGINT or SIGTERM

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   picoclaw-gateway:
     image: docker.io/sipeed/picoclaw:latest
     container_name: picoclaw-gateway
-    restart: on-failure
+    restart: unless-stopped
     profiles:
       - gateway
     # Uncomment to access host network; leave commented unless needed.
@@ -40,7 +40,7 @@ services:
   picoclaw-launcher:
     image: docker.io/sipeed/picoclaw:launcher
     container_name: picoclaw-launcher
-    restart: on-failure
+    restart: unless-stopped
     profiles:
       - launcher
     environment:


### PR DESCRIPTION
## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

Closes #1825 

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** OCI virtual server
- **OS:** Oracle Linux Server 9.7
- **Model/Provider:** openrouter/nvidia/nemotron-3-nano-30b-a3b:free
- **Channels:** Telegram


## 📸 Evidence (Optional)

When I sent `SIGTERM` to a container using `podman kill -s SIGTERM <container_name_or_id>`, The app is restarted.

<img width="747" height="738" alt="image" src="https://github.com/user-attachments/assets/69b717e4-1171-4588-bb22-6ebef73315f7" />

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.