### PR TITLE
fix: gemini api keys through openai-compatible endpoint

### DIFF
--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -113,7 +113,7 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 			cfg.RequestTimeout,
 		), modelID, nil
 
-	case "litellm", "openrouter", "groq", "zhipu", "gemini", "nvidia",
+	case "litellm", "openrouter", "groq", "zhipu", "gemini", "google", "nvidia",
 		"ollama", "moonshot", "shengsuanyun", "deepseek", "cerebras",
 		"vivgrid", "volcengine", "vllm", "qwen", "qwen-intl", "qwen-international", "dashscope-intl",
 		"qwen-us", "dashscope-us", "mistral", "avian", "minimax", "longcat", "modelscope", "novita",
@@ -241,8 +241,8 @@ func getDefaultAPIBase(protocol string) string {
 		return "https://api.groq.com/openai/v1"
 	case "zhipu":
 		return "https://open.bigmodel.cn/api/paas/v4"
-	case "gemini":
-		return "https://generativelanguage.googleapis.com/v1beta"
+	case "gemini", "google":
+		return "https://generativelanguage.googleapis.com/v1beta/openai"
 	case "nvidia":
 		return "https://integrate.api.nvidia.com/v1"
 	case "ollama":

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -190,7 +190,7 @@ func normalizeModel(model, apiBase string) string {
 
 	prefix := strings.ToLower(before)
 	switch prefix {
-	case "litellm", "moonshot", "nvidia", "groq", "ollama", "deepseek", "google",
+	case "litellm", "moonshot", "nvidia", "groq", "ollama", "deepseek", "google", "gemini",
 		"openrouter", "zhipu", "mistral", "vivgrid", "minimax", "novita":
 		return after
 	default:


### PR DESCRIPTION
This PR fixes an issue where Gemini API keys were failing when using the OpenAI-compatible endpoint.

Changes:
1. Updated `getDefaultAPIBase` for `gemini` and `google` protocols to include the `/openai` suffix, which is required by Google AI Studio for OpenAI compatibility.
2. Added `google` as a supported protocol in `CreateProviderFromConfig`.
3. Added `gemini` and `google` to the `normalizeModel` list in the OpenAI-compatible provider to ensure protocol prefixes are stripped before sending the model name to Google.

These changes ensure that `picoclaw` can correctly route and format requests for Gemini models using its OpenAI-compatible bridge.