### PR TITLE
fix(identity): support negative integers in isNumeric for Telegram group IDs

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -94,13 +94,18 @@ func MatchAllowed(sender bus.SenderInfo, allowed string) bool {
 	return false
 }
 
-// isNumeric returns true if s consists entirely of digits.
+// isNumeric returns true if s consists entirely of digits, allowing for an optional leading minus sign
+// (required for Telegram group/channel IDs like -1001234567890).
 func isNumeric(s string) bool {
 	if s == "" {
 		return false
 	}
-	for _, r := range s {
-		if r < '0' || r > '9' {
+	start := 0
+	if s[0] == '-' && len(s) > 1 {
+		start = 1
+	}
+	for i := start; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
 			return false
 		}
 	}

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -97,6 +97,15 @@ func TestMatchAllowed(t *testing.T) {
 			allowed: "654321",
 			want:    false,
 		},
+		{
+			name: "negative numeric ID matches PlatformID",
+			sender: bus.SenderInfo{
+				Platform:   "telegram",
+				PlatformID: "-1001234567890",
+			},
+			allowed: "-1001234567890",
+			want:    true,
+		},
 		// Username matching
 		{
 			name:    "@username matches Username",
@@ -238,6 +247,9 @@ func TestIsNumeric(t *testing.T) {
 		{"abc", false},
 		{"12a34", false},
 		{"telegram", false},
+		{"-1001234567890", true},
+		{"-", false},
+		{"-12a34", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 📝 Description

**Summary:**
This PR fixes a bug in the identity system where **Telegram group and channel IDs** (which are negative integers, e.g., `-1001234567890`) were being incorrectly identified as non-numeric. This could lead to them being misidentified as platform names instead of raw IDs in the `allow_from` whitelist.

**Key Fixes:**
- **Negative Integer Support**: Updated `isNumeric()` in `pkg/identity` to support an optional leading minus sign.
- **Improved Whitelist Reliability**: Fixes the edge case where compound allow-list entries (e.g., `"-1001234567890:mygroup"`) would fail to match because the first part wasn't recognized as a numeric identifier.
- **Regression Tests**: Added unit tests in `identity_test.go` covering negative IDs, the bare minus sign edge case, and matching logic for Telegram group senders.

**Changes:**
- `pkg/identity/identity.go`: Updated `isNumeric` to handle the `'-'` prefix.
- `pkg/identity/identity_test.go`: Added test cases for `isNumeric` and `MatchAllowed` with negative integers.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue
N/A

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows
- **Channels:**  Telegram

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Test Results</summary>

</details>

## ☑️ Checklist
- [X] My code/docs follow the style of this project.
- [X] I have performed a self-review of my own changes.
- [X] I have updated the documentation accordingly.
