### PR TITLE
fix(providers): add thinking and reasoning fallback for OpenAI-compatible providers (Ollama)

### DIFF
--- a/pkg/providers/common/common.go
+++ b/pkg/providers/common/common.go
@@ -73,6 +73,8 @@ type openaiMessage struct {
 	Role             string     `json:"role"`
 	Content          string     `json:"content"`
 	ReasoningContent string     `json:"reasoning_content,omitempty"`
+	Reasoning        string     `json:"reasoning,omitempty"`
+	Thinking         string     `json:"thinking,omitempty"`
 	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string     `json:"tool_call_id,omitempty"`
 }
@@ -89,6 +91,8 @@ func SerializeMessages(messages []Message) []any {
 				Role:             m.Role,
 				Content:          m.Content,
 				ReasoningContent: m.ReasoningContent,
+				Reasoning:        m.Reasoning,
+				Thinking:         m.Thinking,
 				ToolCalls:        m.ToolCalls,
 				ToolCallID:       m.ToolCallID,
 			})
@@ -127,6 +131,12 @@ func SerializeMessages(messages []Message) []any {
 		if m.ReasoningContent != "" {
 			msg["reasoning_content"] = m.ReasoningContent
 		}
+		if m.Reasoning != "" {
+			msg["reasoning"] = m.Reasoning
+		}
+		if m.Thinking != "" {
+			msg["thinking"] = m.Thinking
+		}
 		out = append(out, msg)
 	}
 	return out
@@ -142,6 +152,7 @@ func ParseResponse(body io.Reader) (*LLMResponse, error) {
 				Content          string            `json:"content"`
 				ReasoningContent string            `json:"reasoning_content"`
 				Reasoning        string            `json:"reasoning"`
+				Thinking         string            `json:"thinking"`
 				ReasoningDetails []ReasoningDetail `json:"reasoning_details"`
 				ToolCalls        []struct {
 					ID       string `json:"id"`
@@ -208,10 +219,22 @@ func ParseResponse(body io.Reader) (*LLMResponse, error) {
 		toolCalls = append(toolCalls, toolCall)
 	}
 
+	content := choice.Message.Content
+	if content == "" {
+		if choice.Message.Thinking != "" {
+			content = choice.Message.Thinking
+		} else if choice.Message.Reasoning != "" {
+			content = choice.Message.Reasoning
+		} else if choice.Message.ReasoningContent != "" {
+			content = choice.Message.ReasoningContent
+		}
+	}
+
 	return &LLMResponse{
-		Content:          choice.Message.Content,
+		Content:          content,
 		ReasoningContent: choice.Message.ReasoningContent,
 		Reasoning:        choice.Message.Reasoning,
+		Thinking:         choice.Message.Thinking,
 		ReasoningDetails: choice.Message.ReasoningDetails,
 		ToolCalls:        toolCalls,
 		FinishReason:     choice.FinishReason,

--- a/pkg/providers/common/common_test.go
+++ b/pkg/providers/common/common_test.go
@@ -556,3 +556,65 @@ func TestParseResponse_WithThoughtSignature(t *testing.T) {
 			out.ToolCalls[0].ExtraContent.Google.ThoughtSignature, "sig123")
 	}
 }
+
+func TestSerializeMessages_WithReasoningFallbackFields(t *testing.T) {
+	messages := []Message{
+		{
+			Role:             "assistant",
+			Content:          "final answer",
+			ReasoningContent: "deepseek thinking",
+			Reasoning:        "ollama reasoning",
+			Thinking:         "ollama thinking",
+		},
+	}
+	result := SerializeMessages(messages)
+
+	data, _ := json.Marshal(result)
+	var msgs []map[string]any
+	json.Unmarshal(data, &msgs)
+
+	if msgs[0]["reasoning_content"] != "deepseek thinking" {
+		t.Errorf("reasoning_content mismatch, got %v", msgs[0]["reasoning_content"])
+	}
+	if msgs[0]["reasoning"] != "ollama reasoning" {
+		t.Errorf("reasoning mismatch, got %v", msgs[0]["reasoning"])
+	}
+	if msgs[0]["thinking"] != "ollama thinking" {
+		t.Errorf("thinking mismatch, got %v", msgs[0]["thinking"])
+	}
+}
+
+func TestParseResponse_WithOllamaThinkingFallback(t *testing.T) {
+	// Test thinking fallback
+	body := `{"choices":[{"message":{"content":"","thinking":"I am thinking..."},"finish_reason":"stop"}]}`
+	out, err := ParseResponse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("ParseResponse() error = %v", err)
+	}
+	if out.Content != "I am thinking..." {
+		t.Errorf("Content fallback to thinking failed, got %q", out.Content)
+	}
+	if out.Thinking != "I am thinking..." {
+		t.Errorf("Thinking field not preserved, got %q", out.Thinking)
+	}
+
+	// Test reasoning fallback
+	body = `{"choices":[{"message":{"content":"","reasoning":"Ollama reasoning text"},"finish_reason":"stop"}]}`
+	out, err = ParseResponse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("ParseResponse() error = %v", err)
+	}
+	if out.Content != "Ollama reasoning text" {
+		t.Errorf("Content fallback to reasoning failed, got %q", out.Content)
+	}
+
+	// Test priority: content > thinking > reasoning
+	body = `{"choices":[{"message":{"content":"real content","thinking":"hidden thinking"},"finish_reason":"stop"}]}`
+	out, err = ParseResponse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("ParseResponse() error = %v", err)
+	}
+	if out.Content != "real content" {
+		t.Errorf("Content should have priority, got %q", out.Content)
+	}
+}

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -241,6 +241,9 @@ func parseStreamResponse(
 	onChunk func(accumulated string),
 ) (*LLMResponse, error) {
 	var textContent strings.Builder
+	var reasoningContent strings.Builder
+	var reasoning strings.Builder
+	var thinking strings.Builder
 	var finishReason string
 	var usage *UsageInfo
 
@@ -273,8 +276,11 @@ func parseStreamResponse(
 		var chunk struct {
 			Choices []struct {
 				Delta struct {
-					Content   string `json:"content"`
-					ToolCalls []struct {
+					Content          string `json:"content"`
+					ReasoningContent string `json:"reasoning_content"`
+					Reasoning        string `json:"reasoning"`
+					Thinking         string `json:"thinking"`
+					ToolCalls        []struct {
 						Index    int    `json:"index"`
 						ID       string `json:"id"`
 						Function *struct {
@@ -301,13 +307,24 @@ func parseStreamResponse(
 		}
 
 		choice := chunk.Choices[0]
+		delta := choice.Delta
 
-		// Accumulate text content
-		if choice.Delta.Content != "" {
-			textContent.WriteString(choice.Delta.Content)
-			if onChunk != nil {
-				onChunk(textContent.String())
-			}
+		// Accumulate text content with fallback to reasoning/thinking
+		if delta.Content != "" {
+			textContent.WriteString(delta.Content)
+		} else if delta.Thinking != "" {
+			thinking.WriteString(delta.Thinking)
+			textContent.WriteString(delta.Thinking) // Surface reasoning to user
+		} else if delta.Reasoning != "" {
+			reasoning.WriteString(delta.Reasoning)
+			textContent.WriteString(delta.Reasoning) // Surface reasoning to user
+		} else if delta.ReasoningContent != "" {
+			reasoningContent.WriteString(delta.ReasoningContent)
+			textContent.WriteString(delta.ReasoningContent) // Surface reasoning to user
+		}
+
+		if onChunk != nil {
+			onChunk(textContent.String())
 		}
 
 		// Accumulate tool call deltas
@@ -366,10 +383,13 @@ func parseStreamResponse(
 	}
 
 	return &LLMResponse{
-		Content:      textContent.String(),
-		ToolCalls:    toolCalls,
-		FinishReason: finishReason,
-		Usage:        usage,
+		Content:          textContent.String(),
+		ReasoningContent: reasoningContent.String(),
+		Reasoning:        reasoning.String(),
+		Thinking:         thinking.String(),
+		ToolCalls:        toolCalls,
+		FinishReason:     finishReason,
+		Usage:            usage,
 	}, nil
 }
 

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -1089,3 +1089,77 @@ func TestSerializeMessages_StripsSystemParts(t *testing.T) {
 		t.Fatal("system_parts should not appear in serialized output")
 	}
 }
+
+func TestParseStreamResponse_ThinkingFallback(t *testing.T) {
+	// Mock SSE stream with thinking/reasoning chunks
+	stream := `data: {"choices":[{"delta":{"thinking":"Let me "},"index":0}]}
+data: {"choices":[{"delta":{"thinking":"think... "},"index":0}]}
+data: {"choices":[{"delta":{"content":"The answer is "},"index":0}]}
+data: {"choices":[{"delta":{"content":"42"},"index":0}]}
+data: [DONE]
+`
+
+	var accumulated string
+	onChunk := func(acc string) {
+		accumulated = acc
+	}
+
+	resp, err := parseStreamResponse(t.Context(), strings.NewReader(stream), onChunk)
+	if err != nil {
+		t.Fatalf("parseStreamResponse() error = %v", err)
+	}
+
+	// Verify Thinking field is populated
+	if resp.Thinking != "Let me think... " {
+		t.Errorf("resp.Thinking = %q, want %q", resp.Thinking, "Let me think... ")
+	}
+
+	// Verify Content contains BOTH thinking (as fallback/prefix) and content
+	expectedContent := "Let me think... The answer is 42"
+	if resp.Content != expectedContent {
+		t.Errorf("resp.Content = %q, want %q", resp.Content, expectedContent)
+	}
+
+	// Verify onChunk received the intermediate states
+	if accumulated != expectedContent {
+		t.Errorf("last onChunk = %q, want %q", accumulated, expectedContent)
+	}
+}
+
+func TestParseStreamResponse_ReasoningFallback(t *testing.T) {
+	// Mock SSE stream with reasoning (Ollama style)
+	stream := `data: {"choices":[{"delta":{"reasoning":"I will calculate "},"index":0}]}
+data: {"choices":[{"delta":{"reasoning":"the sum."},"index":0}]}
+data: [DONE]
+`
+
+	resp, err := parseStreamResponse(t.Context(), strings.NewReader(stream), nil)
+	if err != nil {
+		t.Fatalf("parseStreamResponse() error = %v", err)
+	}
+
+	if resp.Content != "I will calculate the sum." {
+		t.Errorf("resp.Content = %q, want %q", resp.Content, "I will calculate the sum.")
+	}
+}
+
+func TestParseStreamResponse_MixedContent(t *testing.T) {
+	// Verify that if both thinking and content are present, they are both captured correctly.
+	// Some models might start with thinking and then send content.
+	stream := `data: {"choices":[{"delta":{"thinking":"Wait, "},"index":0}]}
+data: {"choices":[{"delta":{"content":"Hello"},"index":0}]}
+data: [DONE]
+`
+
+	resp, err := parseStreamResponse(t.Context(), strings.NewReader(stream), nil)
+	if err != nil {
+		t.Fatalf("parseStreamResponse() error = %v", err)
+	}
+
+	if resp.Thinking != "Wait, " {
+		t.Errorf("Thinking = %q", resp.Thinking)
+	}
+	if resp.Content != "Wait, Hello" {
+		t.Errorf("Content = %q", resp.Content)
+	}
+}

--- a/pkg/providers/protocoltypes/types.go
+++ b/pkg/providers/protocoltypes/types.go
@@ -27,10 +27,11 @@ type FunctionCall struct {
 type LLMResponse struct {
 	Content          string            `json:"content"`
 	ReasoningContent string            `json:"reasoning_content,omitempty"`
+	Reasoning        string            `json:"reasoning,omitempty"`
+	Thinking         string            `json:"thinking,omitempty"`
 	ToolCalls        []ToolCall        `json:"tool_calls,omitempty"`
 	FinishReason     string            `json:"finish_reason"`
 	Usage            *UsageInfo        `json:"usage,omitempty"`
-	Reasoning        string            `json:"reasoning"`
 	ReasoningDetails []ReasoningDetail `json:"reasoning_details"`
 }
 
@@ -67,6 +68,8 @@ type Message struct {
 	Content          string         `json:"content"`
 	Media            []string       `json:"media,omitempty"`
 	ReasoningContent string         `json:"reasoning_content,omitempty"`
+	Reasoning        string         `json:"reasoning,omitempty"`
+	Thinking         string         `json:"thinking,omitempty"`
 	SystemParts      []ContentBlock `json:"system_parts,omitempty"` // structured system blocks for cache-aware adapters
 	ToolCalls        []ToolCall     `json:"tool_calls,omitempty"`
 	ToolCallID       string         `json:"tool_call_id,omitempty"`


### PR DESCRIPTION
## 📝 Description

**Summary:**
- **Ollama Thinking Fallback**: Added support for `thinking` and `reasoning` fields in OpenAI-compatible providers. This ensures output from reasoning models like DeepSeek-R1 (running on Ollama) is no longer lost if `content` is empty.
- **Improved Field Handling**: Verified preservation of reasoning fields across multi-turn sessions.

**Changes:**
- `pkg/providers/protocoltypes/types.go`: Added `Thinking` and `Reasoning` fields.
- `pkg/providers/common/common.go`: Implemented thinking/reasoning fallback parsing and history serialization.
- `pkg/providers/openai_compat/provider.go`: Modified streaming decoder to handle thinking deltas.
- `pkg/providers/common/common_test.go` & `pkg/providers/openai_compat/provider_test.go`: Added unit tests for streaming and non-streaming responses.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue
N/A

## 📚 Technical Context (Skip for Docs)
- **Problem Overview:**
  OpenAI's standard API uses `content`. Models like DeepSeek-R1 (Ollama implementation) surface their reasoning process in a separate `thinking` field. If the library only looks for `content`, it sees an empty string while the model is thinking, leading to missing responses.
  
- **Solution Implementation:**
  We added support for the `thinking` field in both the streaming decoder and the common endpoint parser. We accumulation thinking deltas and either prepend them to the final text or provide them as a fallback, ensuring the bot remains responsive.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows
- **Providers:** Ollama (DeepSeek-R1), DeepSeek API (reasoning_content)

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Test Results</summary>

**Test Results:**
- `TestParseStreamResponse_ThinkingFallback`: **PASS** (Verified real-time streaming accumulation).
- `TestParseResponse_WithOllamaThinkingFallback`: **PASS** (Verified non-streaming fallback).
- `TestSerializeMessages_WithReasoningFallbackFields`: **PASS** (Verified history preservation).

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
