### PR TITLE
fix(providers): add Azure AI Foundry host recognition to enable prompt caching and native search

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -417,7 +417,9 @@ func isNativeSearchHost(apiBase string) bool {
 		return false
 	}
 	host := u.Hostname()
-	return host == "api.openai.com" || strings.HasSuffix(host, ".openai.azure.com")
+	return host == "api.openai.com" ||
+		strings.HasSuffix(host, ".openai.azure.com") ||
+		strings.HasSuffix(host, ".services.ai.azure.com")
 }
 
 // supportsPromptCacheKey reports whether the given API base is known to
@@ -430,5 +432,7 @@ func supportsPromptCacheKey(apiBase string) bool {
 		return false
 	}
 	host := u.Hostname()
-	return host == "api.openai.com" || strings.HasSuffix(host, ".openai.azure.com")
+	return host == "api.openai.com" ||
+		strings.HasSuffix(host, ".openai.azure.com") ||
+		strings.HasSuffix(host, ".services.ai.azure.com")
 }

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -831,6 +831,8 @@ func TestSupportsPromptCacheKey(t *testing.T) {
 		{"https://api.groq.com/openai/v1", false},
 		{"http://localhost:11434/v1", false},
 		{"https://openrouter.ai/api/v1", false},
+		{"https://myfoundry.eastus.services.ai.azure.com/v1", true},
+		{"https://myfoundry.services.ai.azure.com", true},
 		// Edge cases: proxy URLs with openai.com in path should NOT match
 		{"https://my-proxy.com/api.openai.com/v1", false},
 		{"https://proxy.example.com/openai.azure.com/v1", false},
@@ -900,6 +902,7 @@ func TestIsNativeSearchHost(t *testing.T) {
 		{"https://api.deepseek.com/v1", false},
 		{"https://api.groq.com/openai/v1", false},
 		{"http://localhost:11434/v1", false},
+		{"https://myfoundry.eastus.services.ai.azure.com/v1", true},
 		{"", false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## 📝 Description

**Summary:**
- **Azure AI Foundry Support**: Added recognition for `*.services.ai.azure.com` endpoints to enable Prompt Caching and Native Search features for Azure AI Foundry users.

**Changes:**
- `pkg/providers/openai_compat/provider.go`: Updated the host guards to recognize the Azure Foundry URL family.
- `pkg/providers/openai_compat/provider_test.go`: Added regression tests for Foundry host identification.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [X] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue
N/A

## 📚 Technical Context (Skip for Docs)
- **Problem**: Previously, only `.openai.azure.com` was recognized, meaning Foundry users (`.services.ai.azure.com`) missed out on prompt caching and native search features.
- **Solution**: Updated the predicates to include the newer Azure domain.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows 11
- **Model/Provider:** N/A (used testing units)
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Test Results</summary>

**Test Results:**
- `TestSupportsPromptCacheKey` (Foundry case): **PASS**
- `TestIsNativeSearchHost` (Foundry case): **PASS**

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
