### PR TITLE
feat(docker): Add python3 to runtime image for skill script support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN make build
 # ============================================================
 FROM alpine:3.23
 
-RUN apk add --no-cache ca-certificates tzdata curl
+RUN apk add --no-cache ca-certificates tzdata curl python3
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \


### PR DESCRIPTION
## Description

Adds `python3` to the Alpine runtime image in `docker/Dockerfile` to support skills that depend on Python scripts.

## Type of Change

- [x] ✨ Feature (non-breaking change which adds functionality)

## 🤖 AI Code Generation

**Level:** 👨‍💻 Mostly Human-written

## Related Issue

Closes #1870

## Technical Context

Some skills may include Python scripts for data processing, API integration, or specialized tasks. Without Python3 in the container, these skills fail at runtime. Adding Python3 to the base image enables skill extensibility in Docker deployments.

## Test Environment

- **Hardware:** x86_64 Linux
- **OS:** Ubuntu 22.04
- **Docker:** 24.0.7

## Evidence

Builds successfully and includes Python3:
```bash
$ docker build -t picoclaw-test -f docker/Dockerfile .
$ docker run --rm picoclaw-test python3 --version
Python 3.12.3
```

## Checklist

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] I have tested the changes in a Docker environment
- [x] My changes generate no new warnings