### PR TITLE
fix(chat): preserve blank lines and add input hint

### DIFF
--- a/web/frontend/src/components/chat/user-message.tsx
+++ b/web/frontend/src/components/chat/user-message.tsx
@@ -5,7 +5,7 @@ interface UserMessageProps {
 export function UserMessage({ content }: UserMessageProps) {
   return (
     <div className="flex w-full flex-col items-end gap-1.5">
-      <div className="max-w-[70%] rounded-2xl rounded-tr-sm bg-violet-500 px-5 py-3 text-[15px] leading-relaxed text-white shadow-sm">
+      <div className="max-w-[70%] rounded-2xl rounded-tr-sm bg-violet-500 px-5 py-3 text-[15px] leading-relaxed text-white shadow-sm whitespace-pre-wrap">
         {content}
       </div>
     </div>

--- a/web/frontend/src/i18n/locales/en.json
+++ b/web/frontend/src/i18n/locales/en.json
@@ -17,7 +17,7 @@
   "chat": {
     "welcome": "How can I help you today?",
     "welcomeDesc": "Ask me about weather, settings, or any other tasks. I'm here to assist you.",
-    "placeholder": "Start a new message...",
+    "placeholder": "Start a new message...\nPress Enter to send, Shift + Enter for a new line",
     "newChat": "New Chat",
     "notConnected": "Gateway is not running. Start it to chat.",
     "thinking": {

--- a/web/frontend/src/i18n/locales/zh.json
+++ b/web/frontend/src/i18n/locales/zh.json
@@ -17,7 +17,7 @@
   "chat": {
     "welcome": "今天我能为您做些什么？",
     "welcomeDesc": "您可以询问我天气、设置或其他任何任务，我随时为您效劳。",
-    "placeholder": "输入新消息...",
+    "placeholder": "输入新消息...\n按 Enter 发送，Shift + Enter 换行",
     "newChat": "新建对话",
     "notConnected": "服务未运行，请先启动以进行对话。",
     "thinking": {


### PR DESCRIPTION
## 📝 Description
- Add Tailwind `whitespace-pre-wrap` to the user message bubble of web chat so spaces and blank lines can be rendered correctly.
- Update chat input placeholders in en.json and zh.json to show Enter vs Shift+Enter.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue
Fixes #1881 

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** -
- **Reasoning:** -

## 🧪 Test Environment
- **Hardware:** Local x64 server
- **OS:** Ubuntu Server 24
- **Model/Provider:** Local (gpt-oss-20b)
- **Channels:** Web (picoclaw-launcher)

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<img width="1843" height="1372" alt="image" src="https://github.com/user-attachments/assets/b8640358-8b99-448f-9665-20801013af66" />

<img width="1840" height="1386" alt="image" src="https://github.com/user-attachments/assets/fabf7146-e1e5-4e44-81a8-dd0638764aec" />

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.