### PR TITLE
fix(api): send auth header when probing local OpenAI-compatible models

### DIFF
--- a/web/backend/api/gateway_test.go
+++ b/web/backend/api/gateway_test.go
@@ -169,7 +169,7 @@ func TestGatewayStartReady_LocalModelWithoutAPIKey(t *testing.T) {
 	defer cleanup()
 	resetModelProbeHooks(t)
 
-	probeOpenAICompatibleModelFunc = func(apiBase, modelID string) bool {
+	probeOpenAICompatibleModelFunc = func(apiBase, modelID, apiKey string) bool {
 		return false
 	}
 
@@ -206,8 +206,8 @@ func TestGatewayStartReady_LocalModelWithRunningService(t *testing.T) {
 	defer cleanup()
 	resetModelProbeHooks(t)
 
-	probeOpenAICompatibleModelFunc = func(apiBase, modelID string) bool {
-		return apiBase == "http://127.0.0.1:8000/v1" && modelID == "custom-model"
+	probeOpenAICompatibleModelFunc = func(apiBase, modelID, apiKey string) bool {
+		return apiBase == "http://127.0.0.1:8000/v1" && modelID == "custom-model" && apiKey == ""
 	}
 
 	cfg, err := config.LoadConfig(configPath)
@@ -240,7 +240,7 @@ func TestGatewayStartReady_RemoteVLLMWithAPIKeyDoesNotProbe(t *testing.T) {
 	defer cleanup()
 	resetModelProbeHooks(t)
 
-	probeOpenAICompatibleModelFunc = func(apiBase, modelID string) bool {
+	probeOpenAICompatibleModelFunc = func(apiBase, modelID, apiKey string) bool {
 		t.Fatalf("unexpected OpenAI-compatible probe for %q (%q)", apiBase, modelID)
 		return false
 	}

--- a/web/backend/api/model_status.go
+++ b/web/backend/api/model_status.go
@@ -82,14 +82,14 @@ func probeLocalModelAvailability(m config.ModelConfig) bool {
 	case "ollama":
 		return probeOllamaModelFunc(apiBase, modelID)
 	case "vllm":
-		return probeOpenAICompatibleModelFunc(apiBase, modelID)
+		return probeOpenAICompatibleModelFunc(apiBase, modelID, m.APIKey)
 	case "github-copilot", "copilot":
 		return probeTCPServiceFunc(apiBase)
 	case "claude-cli", "claudecli", "codex-cli", "codexcli":
 		return true
 	default:
 		if hasLocalAPIBase(apiBase) {
-			return probeOpenAICompatibleModelFunc(apiBase, modelID)
+			return probeOpenAICompatibleModelFunc(apiBase, modelID, m.APIKey)
 		}
 		return false
 	}
@@ -209,7 +209,7 @@ func probeOllamaModel(apiBase, modelID string) bool {
 			Model string `json:"model"`
 		} `json:"models"`
 	}
-	if err := getJSON(root+"/api/tags", &resp); err != nil {
+	if err := getJSON(root+"/api/tags", &resp, ""); err != nil {
 		return false
 	}
 
@@ -221,7 +221,7 @@ func probeOllamaModel(apiBase, modelID string) bool {
 	return false
 }
 
-func probeOpenAICompatibleModel(apiBase, modelID string) bool {
+func probeOpenAICompatibleModel(apiBase, modelID, apiKey string) bool {
 	if strings.TrimSpace(apiBase) == "" {
 		return false
 	}
@@ -231,7 +231,7 @@ func probeOpenAICompatibleModel(apiBase, modelID string) bool {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if err := getJSON(strings.TrimRight(strings.TrimSpace(apiBase), "/")+"/models", &resp); err != nil {
+	if err := getJSON(strings.TrimRight(strings.TrimSpace(apiBase), "/")+"/models", &resp, apiKey); err != nil {
 		return false
 	}
 
@@ -243,10 +243,13 @@ func probeOpenAICompatibleModel(apiBase, modelID string) bool {
 	return false
 }
 
-func getJSON(rawURL string, out any) error {
+func getJSON(rawURL string, out any, apiKey string) error {
 	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
 	if err != nil {
 		return err
+	}
+	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 
 	client := &http.Client{Timeout: modelProbeTimeout}

--- a/web/backend/api/model_status_test.go
+++ b/web/backend/api/model_status_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sipeed/picoclaw/pkg/config"
+)
+
+func TestProbeLocalModelAvailability_OpenAICompatibleIncludesAPIKey(t *testing.T) {
+	const apiKey = "test-api-key"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/v1/models")
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+apiKey {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"custom-model"}]}`))
+	}))
+	defer srv.Close()
+
+	model := config.ModelConfig{
+		Model:   "openai/custom-model",
+		APIBase: srv.URL + "/v1",
+		APIKey:  apiKey,
+	}
+
+	if !probeLocalModelAvailability(model) {
+		t.Fatal("probeLocalModelAvailability() = false, want true when api_key is configured")
+	}
+}

--- a/web/backend/api/models_test.go
+++ b/web/backend/api/models_test.go
@@ -36,11 +36,11 @@ func TestHandleListModels_ConfiguredStatusUsesRuntimeProbesForLocalModels(t *tes
 	var ollamaProbes []string
 	var tcpProbes []string
 
-	probeOpenAICompatibleModelFunc = func(apiBase, modelID string) bool {
+	probeOpenAICompatibleModelFunc = func(apiBase, modelID, apiKey string) bool {
 		mu.Lock()
-		openAIProbes = append(openAIProbes, apiBase+"|"+modelID)
+		openAIProbes = append(openAIProbes, apiBase+"|"+modelID+"|"+apiKey)
 		mu.Unlock()
-		return apiBase == "http://127.0.0.1:8000/v1" && modelID == "custom-model"
+		return apiBase == "http://127.0.0.1:8000/v1" && modelID == "custom-model" && apiKey == ""
 	}
 	probeOllamaModelFunc = func(apiBase, modelID string) bool {
 		mu.Lock()
@@ -131,7 +131,7 @@ func TestHandleListModels_ConfiguredStatusUsesRuntimeProbesForLocalModels(t *tes
 	if !got["copilot-gpt-5.4"] {
 		t.Fatalf("copilot model configured = false, want true when local bridge probe succeeds")
 	}
-	if len(openAIProbes) != 1 || openAIProbes[0] != "http://127.0.0.1:8000/v1|custom-model" {
+	if len(openAIProbes) != 1 || openAIProbes[0] != "http://127.0.0.1:8000/v1|custom-model|" {
 		t.Fatalf("openAI probes = %#v, want only local vllm probe", openAIProbes)
 	}
 	if len(ollamaProbes) != 1 || ollamaProbes[0] != "http://localhost:11434/v1|llama3" {
@@ -205,7 +205,7 @@ func TestHandleListModels_ProbesLocalModelsConcurrently(t *testing.T) {
 	started := make(chan string, 2)
 	release := make(chan struct{})
 
-	probeOpenAICompatibleModelFunc = func(apiBase, modelID string) bool {
+	probeOpenAICompatibleModelFunc = func(apiBase, modelID, apiKey string) bool {
 		started <- apiBase + "|" + modelID
 		<-release
 		return true
@@ -265,9 +265,9 @@ func TestHandleListModels_NormalizesWildcardLocalAPIBaseForProbe(t *testing.T) {
 	resetModelProbeHooks(t)
 
 	var gotProbe string
-	probeOpenAICompatibleModelFunc = func(apiBase, modelID string) bool {
-		gotProbe = apiBase + "|" + modelID
-		return apiBase == "http://127.0.0.1:8000/v1" && modelID == "custom-model"
+	probeOpenAICompatibleModelFunc = func(apiBase, modelID, apiKey string) bool {
+		gotProbe = apiBase + "|" + modelID + "|" + apiKey
+		return apiBase == "http://127.0.0.1:8000/v1" && modelID == "custom-model" && apiKey == ""
 	}
 
 	cfg, err := config.LoadConfig(configPath)
@@ -307,7 +307,7 @@ func TestHandleListModels_NormalizesWildcardLocalAPIBaseForProbe(t *testing.T) {
 	if !resp.Models[0].Configured {
 		t.Fatal("wildcard-bound local model configured = false, want true after probe host normalization")
 	}
-	if gotProbe != "http://127.0.0.1:8000/v1|custom-model" {
-		t.Fatalf("probe api base = %q, want %q", gotProbe, "http://127.0.0.1:8000/v1|custom-model")
+	if gotProbe != "http://127.0.0.1:8000/v1|custom-model|" {
+		t.Fatalf("probe api base = %q, want %q", gotProbe, "http://127.0.0.1:8000/v1|custom-model|")
 	}
 }


### PR DESCRIPTION
## 📝 Description

Fixes the local OpenAI-compatible model availability probe so it sends the configured `api_key` when requesting `/v1/models`.

Problem summary:
- Local OpenAI-compatible gateways can require authentication even for the model-list endpoint.
- PicoClaw treated those models as unavailable because the runtime probe sent an unauthenticated request.

Root cause:
- `probeLocalModelAvailability` forwarded only `api_base` and `model_id` into `probeOpenAICompatibleModel`.
- The shared JSON fetch helper built the request without an `Authorization` header, so authenticated local endpoints returned 401/403 and the model probe failed.

What changed:
- Thread the configured `api_key` through the OpenAI-compatible runtime probe path.
- Attach `Authorization: Bearer <api_key>` when fetching `/models` for that probe.
- Add a regression test covering an authenticated local `/v1/models` endpoint.
- Update existing probe-hook tests to account for the new auth parameter.

Why this fix:
- It is the minimal change that addresses the reported failure without broadening probing behavior or introducing OAuth refresh logic into the model-status path.
- It keeps Ollama and non-authenticated probes unchanged.

Risk / compatibility:
- Low risk. The header is only added when a non-empty `api_key` is configured for the OpenAI-compatible probe.
- Existing behavior for unauthenticated endpoints is unchanged.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1864

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1864
- **Reasoning:** Local OpenAI-compatible providers are runtime-probed when their API base resolves to localhost. If `/v1/models` requires auth, the probe must reuse the configured bearer token or the model is incorrectly reported as unavailable.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows (local development environment)
- **Model/Provider:** N/A (backend unit tests only)
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Passed:
- `go test ./web/backend/api -run TestProbeLocalModelAvailability_OpenAICompatibleIncludesAPIKey -count=1`
- `go test ./web/backend/api -run TestHandleListModels_|TestGatewayStartReady_ -count=1`
- `go test ./web/backend/api -count=1`
- `go test ./web/backend -count=1`

Additional broader validation:
- `go test ./web/backend/... -count=1` still shows pre-existing Windows-specific failures in `web/backend/launcherconfig` (file mode expectations) and `web/backend/utils` (`sh` missing in PATH). These failures are unrelated to this change; the touched `web/backend/api` package passes in full.
- `go test ./...` on upstream `main` also had multiple pre-existing Windows-specific failures outside this change.
- `go generate ./...` on upstream `main` fails in this Windows environment because `cmd/picoclaw/internal/onboard/command.go` invokes `cp`, which is not available in PATH here.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.