### PR TITLE
fix(config): persist disabled placeholder settings

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -356,7 +356,7 @@ type TypingConfig struct {
 
 // PlaceholderConfig controls placeholder message behavior (Phase 10).
 type PlaceholderConfig struct {
-	Enabled bool   `json:"enabled,omitempty"`
+	Enabled bool   `json:"enabled"`
 	Text    string `json:"text,omitempty"`
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -380,6 +380,37 @@ func TestSaveConfig_IncludesEmptyLegacyModelField(t *testing.T) {
 	}
 }
 
+func TestSaveConfig_PreservesDisabledTelegramPlaceholder(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config.json")
+
+	cfg := DefaultConfig()
+	cfg.Channels.Telegram.Placeholder.Enabled = false
+
+	if err := SaveConfig(path, cfg); err != nil {
+		t.Fatalf("SaveConfig failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if !strings.Contains(string(data), `"placeholder": {`) {
+		t.Fatalf("saved config should include telegram placeholder config, got: %s", string(data))
+	}
+	if !strings.Contains(string(data), `"enabled": false`) {
+		t.Fatalf("saved config should persist placeholder.enabled=false, got: %s", string(data))
+	}
+
+	loaded, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if loaded.Channels.Telegram.Placeholder.Enabled {
+		t.Fatal("telegram placeholder should remain disabled after SaveConfig/LoadConfig round-trip")
+	}
+}
+
 // TestConfig_Complete verifies all config fields are set
 func TestConfig_Complete(t *testing.T) {
 	cfg := DefaultConfig()


### PR DESCRIPTION
## 📝 Description

Fixes the channel config persistence bug behind `#1774`: disabling the placeholder message in channel settings did not survive a save/reload cycle.

Problem summary:
- The launcher UI can send `placeholder.enabled = false` for channels such as Telegram.
- After saving, reloading the config restores the effective value back to `true`, so the setting appears to have no effect.

Root cause:
- `LoadConfig()` starts from `DefaultConfig()`, where Telegram placeholder messages are enabled by default.
- `PlaceholderConfig.Enabled` used `json:,omitempty`, so saving `false` omitted the field from `config.json`.
- On the next load, the field was absent and the default `true` value from `DefaultConfig()` reappeared.

What changed:
- Remove `omitempty` from `PlaceholderConfig.Enabled` so explicit `false` is serialized.
- Add a regression test that saves a config with `telegram.placeholder.enabled = false`, verifies `enabled: false` is written to disk, and confirms the value remains disabled after `LoadConfig()`.

Why this fix:
- It is the smallest change that directly addresses the persistence bug reported in `#1774`.
- It avoids broader changes to config merge semantics, which would carry more risk and widen the PR scope.

Risk / compatibility:
- Low risk. The only behavioral change is that placeholder configs now persist an explicit `enabled` boolean instead of relying on omission.
- This improves round-trip stability for placeholder settings without changing channel runtime logic.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1774

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1774
- **Reasoning:** This is a config round-trip bug, not a frontend-only bug. The UI correctly submits `placeholder.enabled=false`, but the config layer dropped that explicit false because of `omitempty` and then defaulted it back to true on reload.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows (local development environment)
- **Model/Provider:** N/A (config/unit tests only)
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Passed:
- `go test ./pkg/config -run TestSaveConfig_PreservesDisabledTelegramPlaceholder -count=1`
- `go test ./pkg/config -count=1`
- `go test ./web/backend/api -count=1`

Additional notes:
- I also reproduced the bug before the fix with a minimal save/load script: `telegram.placeholder.enabled=false` was omitted from the saved JSON, and `LoadConfig()` restored it to `true` from `DefaultConfig()`.
- `codex review --base origin/main` could not run in this environment because the local Codex config rejected `approvals_reviewer = never`.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.