### PR TITLE
fix(agent): route reasoning_content to reasoning channel

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -2060,9 +2060,13 @@ turnLoop:
 			}
 		}
 
+		reasoningContent := response.Reasoning
+		if reasoningContent == "" {
+			reasoningContent = response.ReasoningContent
+		}
 		go al.handleReasoning(
 			turnCtx,
-			response.Reasoning,
+			reasoningContent,
 			ts.channel,
 			al.targetReasoningChannelID(ts.channel),
 		)

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -397,6 +397,29 @@ func (m *simpleMockProvider) GetDefaultModel() string {
 	return "mock-model"
 }
 
+type reasoningContentProvider struct {
+	response         string
+	reasoningContent string
+}
+
+func (m *reasoningContentProvider) Chat(
+	ctx context.Context,
+	messages []providers.Message,
+	tools []providers.ToolDefinition,
+	model string,
+	opts map[string]any,
+) (*providers.LLMResponse, error) {
+	return &providers.LLMResponse{
+		Content:          m.response,
+		ReasoningContent: m.reasoningContent,
+		ToolCalls:        []providers.ToolCall{},
+	}, nil
+}
+
+func (m *reasoningContentProvider) GetDefaultModel() string {
+	return "reasoning-content-model"
+}
+
 type countingMockProvider struct {
 	response string
 	calls    int
@@ -1507,6 +1530,62 @@ func TestHandleReasoning(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestProcessMessage_PublishesReasoningContentToReasoningChannel(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				Model:             "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+			},
+		},
+	}
+
+	msgBus := bus.NewMessageBus()
+	provider := &reasoningContentProvider{
+		response:         "final answer",
+		reasoningContent: "thinking trace",
+	}
+	al := NewAgentLoop(cfg, msgBus, provider)
+
+	chManager, err := channels.NewManager(&config.Config{}, msgBus, nil)
+	if err != nil {
+		t.Fatalf("Failed to create channel manager: %v", err)
+	}
+	chManager.RegisterChannel("telegram", &fakeChannel{id: "reason-chat"})
+	al.SetChannelManager(chManager)
+
+	response, err := al.processMessage(context.Background(), bus.InboundMessage{
+		Channel:  "telegram",
+		SenderID: "user1",
+		ChatID:   "chat1",
+		Content:  "hello",
+	})
+	if err != nil {
+		t.Fatalf("processMessage() error = %v", err)
+	}
+	if response != "final answer" {
+		t.Fatalf("processMessage() response = %q, want %q", response, "final answer")
+	}
+
+	select {
+	case outbound := <-msgBus.OutboundChan():
+		if outbound.Channel != "telegram" {
+			t.Fatalf("reasoning channel = %q, want %q", outbound.Channel, "telegram")
+		}
+		if outbound.ChatID != "reason-chat" {
+			t.Fatalf("reasoning chatID = %q, want %q", outbound.ChatID, "reason-chat")
+		}
+		if outbound.Content != "thinking trace" {
+			t.Fatalf("reasoning content = %q, want %q", outbound.Content, "thinking trace")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected reasoning content to be published to reasoning channel")
+	}
 }
 
 func TestResolveMediaRefs_ResolvesToBase64(t *testing.T) {


### PR DESCRIPTION
## 📝 Description

Fixes the reasoning channel regression behind `#1746`: OpenAI-compatible providers can return reasoning in `reasoning_content`, but PicoClaw did not forward that content to the configured reasoning channel.

Problem summary:
- `reasoning_channel_id` is expected to receive model reasoning for channels such as Telegram.
- OpenAI-compatible providers can populate `reasoning_content` while leaving `reasoning` empty.
- PicoClaw detected that reasoning existed, but the reasoning channel received nothing.

Root cause:
- `pkg/agent/loop.go` passed only `response.Reasoning` into `handleReasoning()`.
- For OpenAI-compatible providers, the preserved reasoning often lives in `response.ReasoningContent`, so the publish path saw an empty string and returned early.

What changed:
- Keep the existing `response.Reasoning` path unchanged when it is populated.
- Fall back to `response.ReasoningContent` before calling `handleReasoning()`.
- Add a regression test that reproduces the OpenAI-compatible case and verifies the reasoning message is delivered to the configured channel.

Why this fix:
- It is the smallest change that directly addresses the reported failure without broadening provider normalization behavior.
- It preserves the current priority of `response.Reasoning` and only uses `response.ReasoningContent` when needed.

Risk / compatibility:
- Low risk. This only affects the reasoning-channel publish path, and only when `response.Reasoning` is empty.
- Providers that already populate `response.Reasoning` keep their existing behavior.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1746

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1746
- **Reasoning:** The agent event path already treats `ReasoningContent` as evidence that reasoning exists, but the channel delivery path only forwarded `response.Reasoning`. That mismatch makes OpenAI-compatible reasoning invisible to `reasoning_channel_id`.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows (local development environment)
- **Model/Provider:** N/A (agent/unit tests only)
- **Channels:** Telegram (simulated via channel manager test double)

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Passed:
- `go test ./pkg/agent -run TestProcessMessage_PublishesReasoningContentToReasoningChannel -count=1`
- `go test ./pkg/agent -run TestHandleReasoning -count=1`
- `go test ./pkg/providers/openai_compat -count=1`

Additional broader validation:
- `go test ./pkg/agent -count=1` still fails in `TestGlobalSkillFileContentChange`.
- I reproduced that same failure on a clean `upstream/main` worktree at commit `3500080`, so it is pre-existing and not introduced by this PR.
- `codex review --base origin/main` could not run in this environment because the local Codex config rejected `approvals_reviewer = never`.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.