### PR TITLE
fix(agent): requeue non-steering messages back to inbound instead of outbound

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1361,11 +1361,7 @@ func (al *AgentLoop) requeueInboundMessage(msg bus.InboundMessage) error {
 	}
 	pubCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	return al.bus.PublishOutbound(pubCtx, bus.OutboundMessage{
-		Channel: msg.Channel,
-		ChatID:  msg.ChatID,
-		Content: msg.Content,
-	})
+	return al.bus.PublishInbound(pubCtx, msg)
 }
 
 func (al *AgentLoop) processSystemMessage(


### PR DESCRIPTION
## 📝 Description

Fix incorrect requeue behavior in drainBusToSteering.

Previously, non-steering inbound messages were republished as outbound messages,
which could misroute user input and cause messages from other scopes to be echoed
back to clients. This change ensures such messages are requeued through the inbound
path, preserving correct message routing semantics.

---

## 🗣️ Type of Change

* [x] 🐞 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature (non-breaking change which adds functionality)
* [ ] 📖 Documentation update
* [ ] ⚡ Code refactoring (no functional changes, no api changes)

---

## 🤖 AI Code Generation

* [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
* [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
* [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

---

## 🔗 Related Issue

N/A

---

## 📚 Technical Context (Skip for Docs)

* **Reference URL:** N/A
* **Reasoning:**
  drainBusToSteering consumes messages from the inbound bus and is expected to
  requeue unrelated messages without altering their semantics. The previous
  implementation incorrectly published them as outbound messages, which could
  lead to message misrouting and unintended echoing of messages from other scopes
  back to clients.

---

## 🧪 Test Environment

* **Hardware:** PC
* **OS:** macOS / Linux
* **Model/Provider:** N/A
* **Channels:** N/A

---

## ☑️ Checklist

* [x] My code/docs follow the style of this project.
* [x] I have performed a self-review of my own changes.
* [ ] I have updated the documentation accordingly.
