### PR TITLE
fix: apply security credentials before config validation in web handlers

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1942,6 +1942,11 @@ func (c *Config) ValidateModelList() error {
 
 func (c *Config) SecurityCopyFrom(cfg *Config) {
 	c.security = cfg.security
+	if c.security != nil {
+		if err := applySecurityConfig(c, c.security); err != nil {
+			logger.Errorf("failed to apply security config in SecurityCopyFrom: %v", err)
+		}
+	}
 }
 
 func MergeAPIKeys(apiKey string, apiKeys []string) []string {

--- a/web/backend/api/config.go
+++ b/web/backend/api/config.go
@@ -54,6 +54,15 @@ func (h *Handler) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 		cfg.Tools.Exec.AllowRemote = config.DefaultConfig().Tools.Exec.AllowRemote
 	}
 
+	// Load existing config and copy security credentials before validation,
+	// so that security-managed fields (e.g. pico token) are available.
+	oldCfg, err := config.LoadConfig(h.configPath)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to load config: %v", err), http.StatusInternalServerError)
+		return
+	}
+	cfg.SecurityCopyFrom(oldCfg)
+
 	if errs := validateConfig(&cfg); len(errs) > 0 {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
@@ -64,13 +73,7 @@ func (h *Handler) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger.Infof("new config: %+v", cfg)
-	oldCfg, err := config.LoadConfig(h.configPath)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to load config: %v", err), http.StatusInternalServerError)
-		return
-	}
-	cfg.SecurityCopyFrom(oldCfg)
+	logger.Infof("configuration updated successfully")
 
 	if err := config.SaveConfig(h.configPath, &cfg); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to save config: %v", err), http.StatusInternalServerError)
@@ -149,6 +152,10 @@ func (h *Handler) handlePatchConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Copy security credentials before validation so security-managed
+	// fields (e.g. pico token) are available for validation checks.
+	newCfg.SecurityCopyFrom(cfg)
+
 	if errs := validateConfig(&newCfg); len(errs) > 0 {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
@@ -158,8 +165,6 @@ func (h *Handler) handlePatchConfig(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-
-	newCfg.SecurityCopyFrom(cfg)
 
 	if err := config.SaveConfig(h.configPath, &newCfg); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to save config: %v", err), http.StatusInternalServerError)

--- a/web/backend/api/config_test.go
+++ b/web/backend/api/config_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sipeed/picoclaw/pkg/config"
@@ -138,6 +140,120 @@ func TestHandlePatchConfig_AllowsInvalidExecRegexPatternsWhenExecDisabled(t *tes
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+// setupPicoEnabledEnv creates a test environment with Pico channel enabled and
+// its token stored only in .security.yml (not in the JSON payload).
+func setupPicoEnabledEnv(t *testing.T) (string, func()) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	oldPicoHome := os.Getenv("PICOCLAW_HOME")
+
+	if err := os.Setenv("HOME", tmp); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	if err := os.Setenv("PICOCLAW_HOME", filepath.Join(tmp, ".picoclaw")); err != nil {
+		t.Fatalf("set PICOCLAW_HOME: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.ModelList = []*config.ModelConfig{{
+		ModelName: "custom-default",
+		Model:     "openai/gpt-4o",
+	}}
+	cfg.Agents.Defaults.ModelName = "custom-default"
+	cfg.Channels.Pico.Enabled = true
+	cfg.WithSecurity(&config.SecurityConfig{
+		ModelList: map[string]config.ModelSecurityEntry{
+			"custom-default": {APIKeys: []string{"sk-default"}},
+		},
+		Channels: config.ChannelsSecurity{
+			Pico: &config.PicoSecurity{Token: "test-pico-token"},
+		},
+	})
+
+	configPath := filepath.Join(tmp, "config.json")
+	if err := config.SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig error: %v", err)
+	}
+
+	cleanup := func() {
+		_ = os.Setenv("HOME", oldHome)
+		if oldPicoHome == "" {
+			_ = os.Unsetenv("PICOCLAW_HOME")
+		} else {
+			_ = os.Setenv("PICOCLAW_HOME", oldPicoHome)
+		}
+	}
+	return configPath, cleanup
+}
+
+func TestHandleUpdateConfig_SucceedsWhenPicoTokenInSecurityOnly(t *testing.T) {
+	configPath, cleanup := setupPicoEnabledEnv(t)
+	defer cleanup()
+
+	h := NewHandler(configPath)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	// PUT request with pico enabled but no token in JSON — token is in .security.yml
+	req := httptest.NewRequest(http.MethodPut, "/api/config", bytes.NewBufferString(`{
+		"version": 1,
+		"agents": {
+			"defaults": {
+				"workspace": "~/.picoclaw/workspace",
+				"model_name": "custom-default"
+			}
+		},
+		"channels": {
+			"pico": {
+				"enabled": true,
+				"ping_interval": 30,
+				"read_timeout": 60,
+				"write_timeout": 10,
+				"max_connections": 100
+			}
+		},
+		"model_list": [
+			{
+				"model_name": "custom-default",
+				"model": "openai/gpt-4o",
+				"api_keys": ["sk-default"]
+			}
+		]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT /api/config status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestHandlePatchConfig_SucceedsWhenPicoTokenInSecurityOnly(t *testing.T) {
+	configPath, cleanup := setupPicoEnabledEnv(t)
+	defer cleanup()
+
+	h := NewHandler(configPath)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	// PATCH request changing an unrelated field — pico token still in .security.yml
+	req := httptest.NewRequest(http.MethodPatch, "/api/config", bytes.NewBufferString(`{
+		"gateway": {
+			"log_level": "info"
+		}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH /api/config status = %d, want %d, body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

Web launcher config save (PUT and PATCH `/api/config`) fails with `"channels.pico.token is required when pico channel is enabled"` even when the token is correctly stored in `.security.yml`.

**Root cause:** `validateConfig()` checks security-managed private fields (e.g. `Pico.Token()`, `Telegram.Token()`, `Discord.Token()`), but these fields are only populated by `applySecurityConfig()`. The handlers called `SecurityCopyFrom()` *after* validation, and `SecurityCopyFrom` itself only copied the raw `security` struct pointer without applying it to the private fields.

**Fix (two parts):**

1. **`web/backend/api/config.go`** — Move `SecurityCopyFrom()` before `validateConfig()` in both `handleUpdateConfig` (PUT) and `handlePatchConfig` (PATCH), so security-managed tokens are available during validation.

2. **`pkg/config/config.go`** — Make `SecurityCopyFrom()` call `applySecurityConfig()` after copying the security struct, so private credential fields (token, appSecret, etc.) are actually populated on the target config — matching the behavior of `WithSecurity()`.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Affects all users who enable the Pico channel (or Telegram/Discord) and store tokens in `.security.yml` — the web UI cannot save any config changes.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** `SecurityCopyFrom` was inconsistent with `WithSecurity` — the latter calls `applySecurityConfig` to populate private fields, but `SecurityCopyFrom` did not. The validation order in both PUT and PATCH handlers compounded the issue.

## 🧪 Test Environment
- **Hardware:** PC (Windows 11, Docker Desktop WSL2)
- **OS:** Debian 12 (container)
- **Model/Provider:** GitHub Copilot (gpt-5.4, claude-sonnet-4.6)
- **Channels:** Pico (WebSocket)

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.