### PR TITLE
feat(security): add tirith pre-exec command scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,24 @@ PicoClaw can search the web to provide up-to-date information. Configure in `too
 | [SearXNG](https://github.com/searxng/searxng) | Not needed | Self-hosted | Free metasearch engine |
 | [GLM Search](https://open.bigmodel.cn/) | Required | Varies | Zhipu web search |
 
+### 🛡️ Tirith Security Scanning
+
+Shell commands are pre-screened by [Tirith](https://github.com/sheeki03/tirith) before execution. Tirith detects homograph/punycode URLs, pipe-to-shell patterns, terminal injection, typosquatted packages, and insecure transport. Auto-installed on first use with SHA-256 checksum verification. Also integrated in [Hermes Agent](https://github.com/NousResearch/hermes-agent/pull/1256).
+
+Configure via `config.json`:
+```json
+{
+  "tools": {
+    "exec": {
+      "tirith_enabled": true,
+      "tirith_bin": "tirith",
+      "tirith_timeout": 5,
+      "tirith_fail_open": true
+    }
+  }
+}
+```
+
 ### ⚙️ Other Tools
 
 PicoClaw includes built-in tools for file operations, code execution, scheduling, and more. See [Tools Configuration](docs/tools_configuration.md) for details.

--- a/README.md
+++ b/README.md
@@ -452,24 +452,6 @@ PicoClaw can search the web to provide up-to-date information. Configure in `too
 | [SearXNG](https://github.com/searxng/searxng) | Not needed | Self-hosted | Free metasearch engine |
 | [GLM Search](https://open.bigmodel.cn/) | Required | Varies | Zhipu web search |
 
-### 🛡️ Tirith Security Scanning
-
-Shell commands are pre-screened by [Tirith](https://github.com/sheeki03/tirith) before execution. Tirith detects homograph/punycode URLs, pipe-to-shell patterns, terminal injection, typosquatted packages, and insecure transport. Auto-installed on first use with SHA-256 checksum verification. Also integrated in [Hermes Agent](https://github.com/NousResearch/hermes-agent/pull/1256).
-
-Configure via `config.json`:
-```json
-{
-  "tools": {
-    "exec": {
-      "tirith_enabled": true,
-      "tirith_bin": "tirith",
-      "tirith_timeout": 5,
-      "tirith_fail_open": true
-    }
-  }
-}
-```
-
 ### ⚙️ Other Tools
 
 PicoClaw includes built-in tools for file operations, code execution, scheduling, and more. See [Tools Configuration](docs/tools_configuration.md) for details.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1172,13 +1172,21 @@ type CronToolsConfig struct {
 	AllowCommand       bool `                                 env:"PICOCLAW_TOOLS_CRON_ALLOW_COMMAND"        json:"allow_command"`
 }
 
+type TirithConfig struct {
+	Enabled  bool   `env:"PICOCLAW_TOOLS_EXEC_TIRITH_ENABLED"   json:"tirith_enabled"`
+	BinPath  string `env:"PICOCLAW_TOOLS_EXEC_TIRITH_BIN"       json:"tirith_bin"`
+	Timeout  int    `env:"PICOCLAW_TOOLS_EXEC_TIRITH_TIMEOUT"   json:"tirith_timeout"`
+	FailOpen bool   `env:"PICOCLAW_TOOLS_EXEC_TIRITH_FAIL_OPEN" json:"tirith_fail_open"`
+}
+
 type ExecConfig struct {
 	ToolConfig          `         envPrefix:"PICOCLAW_TOOLS_EXEC_"`
-	EnableDenyPatterns  bool     `                                 env:"PICOCLAW_TOOLS_EXEC_ENABLE_DENY_PATTERNS"  json:"enable_deny_patterns"`
-	AllowRemote         bool     `                                 env:"PICOCLAW_TOOLS_EXEC_ALLOW_REMOTE"          json:"allow_remote"`
-	CustomDenyPatterns  []string `                                 env:"PICOCLAW_TOOLS_EXEC_CUSTOM_DENY_PATTERNS"  json:"custom_deny_patterns"`
-	CustomAllowPatterns []string `                                 env:"PICOCLAW_TOOLS_EXEC_CUSTOM_ALLOW_PATTERNS" json:"custom_allow_patterns"`
-	TimeoutSeconds      int      `                                 env:"PICOCLAW_TOOLS_EXEC_TIMEOUT_SECONDS"       json:"timeout_seconds"` // 0 means use default (60s)
+	EnableDenyPatterns  bool          `                                 env:"PICOCLAW_TOOLS_EXEC_ENABLE_DENY_PATTERNS"  json:"enable_deny_patterns"`
+	AllowRemote         bool          `                                 env:"PICOCLAW_TOOLS_EXEC_ALLOW_REMOTE"          json:"allow_remote"`
+	CustomDenyPatterns  []string      `                                 env:"PICOCLAW_TOOLS_EXEC_CUSTOM_DENY_PATTERNS"  json:"custom_deny_patterns"`
+	CustomAllowPatterns []string      `                                 env:"PICOCLAW_TOOLS_EXEC_CUSTOM_ALLOW_PATTERNS" json:"custom_allow_patterns"`
+	TimeoutSeconds      int           `                                 env:"PICOCLAW_TOOLS_EXEC_TIMEOUT_SECONDS"       json:"timeout_seconds"` // 0 means use default (60s)
+	Tirith              TirithConfig  `                                 envPrefix:"PICOCLAW_TOOLS_EXEC_TIRITH_"         json:"tirith"`
 }
 
 type SkillsToolsConfig struct {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -440,6 +440,12 @@ func DefaultConfig() *Config {
 				EnableDenyPatterns: true,
 				AllowRemote:        true,
 				TimeoutSeconds:     60,
+				Tirith: TirithConfig{
+					Enabled:  true,
+					BinPath:  "tirith",
+					Timeout:  5,
+					FailOpen: true,
+				},
 			},
 			Skills: SkillsToolsConfig{
 				ToolConfig: ToolConfig{

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -26,6 +26,7 @@ type ExecTool struct {
 	allowedPathPatterns []*regexp.Regexp
 	restrictToWorkspace bool
 	allowRemote         bool
+	tirithConfig        TirithConfig
 }
 
 var (
@@ -150,6 +151,22 @@ func NewExecToolWithConfig(
 		timeout = time.Duration(config.Tools.Exec.TimeoutSeconds) * time.Second
 	}
 
+	tirithCfg := TirithConfig{
+		Enabled:  true,
+		BinPath:  "tirith",
+		Timeout:  5,
+		FailOpen: true,
+	}
+	if config != nil {
+		tc := config.Tools.Exec.Tirith
+		tirithCfg = TirithConfig{
+			Enabled:  tc.Enabled,
+			BinPath:  tc.BinPath,
+			Timeout:  tc.Timeout,
+			FailOpen: tc.FailOpen,
+		}
+	}
+
 	return &ExecTool{
 		workingDir:          workingDir,
 		timeout:             timeout,
@@ -159,6 +176,7 @@ func NewExecToolWithConfig(
 		allowedPathPatterns: allowedPathPatterns,
 		restrictToWorkspace: restrict,
 		allowRemote:         allowRemote,
+		tirithConfig:        tirithCfg,
 	}, nil
 }
 
@@ -228,6 +246,11 @@ func (t *ExecTool) Execute(ctx context.Context, args map[string]any) *ToolResult
 
 	if guardError := t.guardCommand(command, cwd); guardError != "" {
 		return ErrorResult(guardError)
+	}
+
+	// Tirith content-level security gate (after cheap regex guards)
+	if tirithError := tirithGuard(command, t.tirithConfig); tirithError != "" {
+		return ErrorResult(tirithError)
 	}
 
 	// Re-resolve symlinks immediately before execution to shrink the TOCTOU window

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -681,5 +682,91 @@ func TestShellTool_URLBypassPrevented(t *testing.T) {
 		if !result.IsError || !strings.Contains(result.ForLLM, "path outside working dir") {
 			t.Errorf("bypass attempt should be blocked: %q\n  got: %s", cmd, result.ForLLM)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tirith guard tests
+// ---------------------------------------------------------------------------
+
+func TestTirithGuard_Disabled(t *testing.T) {
+	cfg := TirithConfig{Enabled: false}
+	result := tirithGuard("echo hello", cfg)
+	if result != "" {
+		t.Errorf("disabled tirith should allow all commands, got: %s", result)
+	}
+}
+
+func TestTirithGuard_MissingBinary_FailOpen(t *testing.T) {
+	cfg := TirithConfig{
+		Enabled:  true,
+		BinPath:  "/nonexistent/tirith-test-binary",
+		Timeout:  1,
+		FailOpen: true,
+	}
+	tirithMu.Lock()
+	tirithResolvedPath = ""
+	tirithInstallFailed = false
+	tirithMu.Unlock()
+
+	result := tirithGuard("echo hello", cfg)
+	if result != "" {
+		t.Errorf("missing tirith with fail-open should allow, got: %s", result)
+	}
+}
+
+func TestTirithGuard_MissingBinary_FailClosed(t *testing.T) {
+	cfg := TirithConfig{
+		Enabled:  true,
+		BinPath:  "/nonexistent/tirith-test-binary",
+		Timeout:  1,
+		FailOpen: false,
+	}
+	tirithMu.Lock()
+	tirithResolvedPath = ""
+	tirithInstallFailed = false
+	tirithMu.Unlock()
+
+	result := tirithGuard("echo hello", cfg)
+	if result == "" {
+		t.Error("missing tirith with fail-closed should block")
+	}
+	if !strings.Contains(result, "fail-closed") {
+		t.Errorf("expected fail-closed message, got: %s", result)
+	}
+}
+
+func TestTirithSummarize_ValidJSON(t *testing.T) {
+	input := []byte(`{"findings":[{"severity":"HIGH","title":"Pipe to shell"}]}`)
+	result := tirithSummarize(input)
+	if !strings.Contains(result, "Pipe to shell") || !strings.Contains(result, "HIGH") {
+		t.Errorf("expected finding summary, got: %s", result)
+	}
+}
+
+func TestTirithSummarize_InvalidJSON(t *testing.T) {
+	result := tirithSummarize([]byte("not json"))
+	if !strings.Contains(result, "details unavailable") {
+		t.Errorf("expected details unavailable, got: %s", result)
+	}
+}
+
+func TestTirithSummarize_EmptyFindings(t *testing.T) {
+	result := tirithSummarize([]byte(`{"findings":[]}`))
+	if result != "security issue detected" {
+		t.Errorf("expected generic message, got: %s", result)
+	}
+}
+
+func TestTirithDetectTarget(t *testing.T) {
+	target, ext := tirithDetectTarget()
+	if target == "" {
+		t.Skip("unsupported platform for this test")
+	}
+	if runtime.GOOS == "windows" && ext != ".zip" {
+		t.Errorf("windows should use .zip, got: %s", ext)
+	}
+	if runtime.GOOS != "windows" && ext != ".tar.gz" {
+		t.Errorf("unix should use .tar.gz, got: %s", ext)
 	}
 }

--- a/pkg/tools/tirith.go
+++ b/pkg/tools/tirith.go
@@ -3,6 +3,9 @@ package tools
 import (
 	"bytes"
 	"context"
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -371,43 +374,71 @@ func tirithExtract(tmpDir, archivePath, ext, binName string) string {
 }
 
 func tirithExtractTarGz(tmpDir, archivePath, binName string) string {
-	cmd := exec.Command("tar", "xzf", archivePath, "-C", tmpDir)
-	if err := cmd.Run(); err != nil {
+	f, err := os.Open(archivePath)
+	if err != nil {
 		return ""
 	}
-	// Find the binary
-	candidates := []string{
-		filepath.Join(tmpDir, binName),
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return ""
 	}
-	for _, c := range candidates {
-		if isExecutable(c) {
-			return c
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			break
+		}
+		name := filepath.Base(hdr.Name)
+		if name == binName && hdr.Typeflag == tar.TypeReg {
+			dest := filepath.Join(tmpDir, binName)
+			out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY, 0o755)
+			if err != nil {
+				return ""
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return ""
+			}
+			out.Close()
+			return dest
 		}
 	}
-	// Walk for it
-	var found string
-	_ = filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
-		if err == nil && info.Name() == binName && !info.IsDir() {
-			found = path
-			return filepath.SkipAll
-		}
-		return nil
-	})
-	return found
+	return ""
 }
 
 func tirithExtractZip(tmpDir, archivePath, binName string) string {
-	cmd := exec.Command("unzip", "-o", archivePath, "-d", tmpDir)
-	if err := cmd.Run(); err != nil {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
 		return ""
 	}
-	var found string
-	_ = filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
-		if err == nil && info.Name() == binName && !info.IsDir() {
-			found = path
-			return filepath.SkipAll
+	defer r.Close()
+
+	for _, f := range r.File {
+		name := filepath.Base(f.Name)
+		if name == binName && !f.FileInfo().IsDir() {
+			rc, err := f.Open()
+			if err != nil {
+				return ""
+			}
+			dest := filepath.Join(tmpDir, binName)
+			out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY, 0o755)
+			if err != nil {
+				rc.Close()
+				return ""
+			}
+			if _, err := io.Copy(out, rc); err != nil {
+				out.Close()
+				rc.Close()
+				return ""
+			}
+			out.Close()
+			rc.Close()
+			return dest
 		}
-		return nil
-	})
-	return found
+	}
+	return ""
 }

--- a/pkg/tools/tirith.go
+++ b/pkg/tools/tirith.go
@@ -1,0 +1,413 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+// TirithConfig holds Tirith security scanner settings (tools-internal).
+// Mapped from config.TirithConfig at ExecTool construction time.
+type TirithConfig struct {
+	Enabled  bool
+	BinPath  string
+	Timeout  int
+	FailOpen bool
+}
+
+const (
+	tirithRepo          = "sheeki03/tirith"
+	tirithMarkerTTL     = 24 * time.Hour
+	tirithInstallTimeout = 30 * time.Second
+)
+
+var (
+	tirithResolvedPath string
+	tirithInstallFailed bool
+	tirithMu           sync.Mutex
+)
+
+// tirithGuard scans a command with tirith for content-level threats.
+// Call AFTER guardCommand() — cheap regex guards reject known-bad first.
+// Returns empty string if allowed, error message if blocked.
+func tirithGuard(command string, cfg TirithConfig) string {
+	if !cfg.Enabled {
+		return ""
+	}
+
+	binPath := resolveTirithPath(cfg.BinPath)
+
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 5
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	shellFlag := "posix"
+	if runtime.GOOS == "windows" {
+		shellFlag = "powershell"
+	}
+
+	cmd := exec.CommandContext(ctx, binPath, "check", "--json", "--non-interactive",
+		"--shell", shellFlag, "--", command)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			switch exitErr.ExitCode() {
+			case 1: // block
+				return fmt.Sprintf("Command blocked by Tirith security scan: %s", tirithSummarize(stdout.Bytes()))
+			case 2: // warn — log and allow
+				log.Printf("[tirith] warning: %s", tirithSummarize(stdout.Bytes()))
+				return ""
+			}
+		}
+		// Spawn failure / timeout
+		if cfg.FailOpen {
+			log.Printf("[tirith] unavailable (fail-open): %v", err)
+			return ""
+		}
+		return fmt.Sprintf("Tirith security scan failed (fail-closed): %v", err)
+	}
+	// Exit code 0 — allow
+	return ""
+}
+
+func tirithSummarize(jsonOutput []byte) string {
+	if len(jsonOutput) == 0 {
+		return "security issue detected"
+	}
+	var data struct {
+		Findings []struct {
+			Severity string `json:"severity"`
+			Title    string `json:"title"`
+		} `json:"findings"`
+	}
+	if err := json.Unmarshal(jsonOutput, &data); err != nil {
+		return "security issue detected (details unavailable)"
+	}
+	parts := make([]string, 0, len(data.Findings))
+	for _, f := range data.Findings {
+		if f.Title != "" {
+			parts = append(parts, fmt.Sprintf("[%s] %s", f.Severity, f.Title))
+		}
+	}
+	if len(parts) == 0 {
+		return "security issue detected"
+	}
+	return strings.Join(parts, "; ")
+}
+
+// resolveTirithPath resolves the tirith binary, auto-installing if needed.
+func resolveTirithPath(configured string) string {
+	tirithMu.Lock()
+	defer tirithMu.Unlock()
+
+	if tirithResolvedPath != "" {
+		return tirithResolvedPath
+	}
+	if tirithInstallFailed {
+		return configured
+	}
+
+	explicit := configured != "tirith" && configured != ""
+
+	if explicit {
+		if isExecutable(configured) {
+			tirithResolvedPath = configured
+			return configured
+		}
+		if p, err := exec.LookPath(configured); err == nil {
+			tirithResolvedPath = p
+			return p
+		}
+		tirithInstallFailed = true
+		return configured
+	}
+
+	// Default: PATH → ~/.picoclaw/bin → auto-install
+	if p, err := exec.LookPath("tirith"); err == nil {
+		tirithResolvedPath = p
+		return p
+	}
+
+	binName := "tirith"
+	if runtime.GOOS == "windows" {
+		binName = "tirith.exe"
+	}
+	localBin := filepath.Join(tirithBinDir(), binName)
+	if isExecutable(localBin) {
+		tirithResolvedPath = localBin
+		return localBin
+	}
+
+	// Check failure marker
+	if tirithIsFailedOnDisk() {
+		tirithInstallFailed = true
+		return configured
+	}
+
+	installed := tirithInstall()
+	if installed != "" {
+		tirithResolvedPath = installed
+		return installed
+	}
+
+	tirithInstallFailed = true
+	tirithMarkFailed()
+	return configured
+}
+
+func tirithBinDir() string {
+	home, _ := os.UserHomeDir()
+	d := filepath.Join(home, ".picoclaw", "bin")
+	_ = os.MkdirAll(d, 0o755)
+	return d
+}
+
+func tirithMarkerPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".picoclaw", ".tirith-install-failed")
+}
+
+func tirithIsFailedOnDisk() bool {
+	info, err := os.Stat(tirithMarkerPath())
+	if err != nil {
+		return false
+	}
+	return time.Since(info.ModTime()) < tirithMarkerTTL
+}
+
+func tirithMarkFailed() {
+	p := tirithMarkerPath()
+	_ = os.MkdirAll(filepath.Dir(p), 0o755)
+	_ = os.WriteFile(p, []byte("failed"), 0o644)
+}
+
+func isExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return !info.IsDir()
+	}
+	return !info.IsDir() && info.Mode()&0o111 != 0
+}
+
+func tirithInstall() string {
+	target, ext := tirithDetectTarget()
+	if target == "" {
+		log.Printf("[tirith] auto-install: unsupported platform %s/%s", runtime.GOOS, runtime.GOARCH)
+		return ""
+	}
+
+	archiveName := fmt.Sprintf("tirith-%s%s", target, ext)
+	baseURL := fmt.Sprintf("https://github.com/%s/releases/latest/download", tirithRepo)
+
+	tmpDir, err := os.MkdirTemp("", "tirith-install-")
+	if err != nil {
+		return ""
+	}
+	defer os.RemoveAll(tmpDir)
+
+	archivePath := filepath.Join(tmpDir, archiveName)
+	checksumsPath := filepath.Join(tmpDir, "checksums.txt")
+
+	log.Printf("[tirith] downloading latest release for %s...", target)
+
+	if err := tirithDownload(baseURL+"/"+archiveName, archivePath); err != nil {
+		log.Printf("[tirith] download failed: %v", err)
+		return ""
+	}
+	if err := tirithDownload(baseURL+"/checksums.txt", checksumsPath); err != nil {
+		log.Printf("[tirith] checksums download failed: %v", err)
+		return ""
+	}
+
+	if !tirithVerifyChecksum(archivePath, checksumsPath, archiveName) {
+		log.Printf("[tirith] checksum verification failed")
+		return ""
+	}
+
+	binName := "tirith"
+	if runtime.GOOS == "windows" {
+		binName = "tirith.exe"
+	}
+
+	extractedPath := tirithExtract(tmpDir, archivePath, ext, binName)
+	if extractedPath == "" {
+		return ""
+	}
+
+	dest := filepath.Join(tirithBinDir(), binName)
+	if err := os.Rename(extractedPath, dest); err != nil {
+		// Cross-device rename fallback
+		src, err2 := os.ReadFile(extractedPath)
+		if err2 != nil {
+			return ""
+		}
+		if err2 := os.WriteFile(dest, src, 0o755); err2 != nil {
+			return ""
+		}
+	}
+	_ = os.Chmod(dest, 0o755)
+
+	log.Printf("[tirith] installed to %s (SHA-256 verified)", dest)
+	return dest
+}
+
+func tirithDetectTarget() (string, string) {
+	var plat string
+	switch runtime.GOOS {
+	case "darwin":
+		plat = "apple-darwin"
+	case "linux":
+		plat = "unknown-linux-gnu"
+	case "windows":
+		plat = "pc-windows-msvc"
+	default:
+		return "", ""
+	}
+
+	var arch string
+	switch runtime.GOARCH {
+	case "amd64":
+		arch = "x86_64"
+	case "arm64":
+		arch = "aarch64"
+	default:
+		return "", ""
+	}
+
+	ext := ".tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = ".zip"
+	}
+	return arch + "-" + plat, ext
+}
+
+func tirithDownload(url, dest string) error {
+	client := &http.Client{Timeout: tirithInstallTimeout}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+func tirithVerifyChecksum(archivePath, checksumsPath, archiveName string) bool {
+	data, err := os.ReadFile(checksumsPath)
+	if err != nil {
+		return false
+	}
+	var expected string
+	for _, line := range strings.Split(string(data), "\n") {
+		parts := strings.SplitN(strings.TrimSpace(line), "  ", 2)
+		if len(parts) == 2 && parts[1] == archiveName {
+			expected = parts[0]
+			break
+		}
+	}
+	if expected == "" {
+		return false
+	}
+
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return false
+	}
+	return hex.EncodeToString(h.Sum(nil)) == expected
+}
+
+func tirithExtract(tmpDir, archivePath, ext, binName string) string {
+	if ext == ".zip" {
+		return tirithExtractZip(tmpDir, archivePath, binName)
+	}
+	return tirithExtractTarGz(tmpDir, archivePath, binName)
+}
+
+func tirithExtractTarGz(tmpDir, archivePath, binName string) string {
+	cmd := exec.Command("tar", "xzf", archivePath, "-C", tmpDir)
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	// Find the binary
+	candidates := []string{
+		filepath.Join(tmpDir, binName),
+	}
+	for _, c := range candidates {
+		if isExecutable(c) {
+			return c
+		}
+	}
+	// Walk for it
+	var found string
+	_ = filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
+		if err == nil && info.Name() == binName && !info.IsDir() {
+			found = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+func tirithExtractZip(tmpDir, archivePath, binName string) string {
+	cmd := exec.Command("unzip", "-o", archivePath, "-d", tmpDir)
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	var found string
+	_ = filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
+		if err == nil && info.Name() == binName && !info.IsDir() {
+			found = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
+}

--- a/pkg/tools/tirith.go
+++ b/pkg/tools/tirith.go
@@ -1,3 +1,12 @@
+// Tirith pre-exec security scanning.
+//
+// Tirith (https://github.com/sheeki03/tirith) is a terminal security tool
+// that scans commands for content-level threats: homograph/punycode URLs,
+// pipe-to-interpreter patterns, terminal injection (ANSI escapes, bidi
+// Unicode, zero-width chars), typosquatted packages, and insecure transport.
+//
+// Exit code is the verdict source of truth: 0=allow, 1=block, 2=warn.
+// Auto-installed from GitHub releases with SHA-256 checksum verification.
 package tools
 
 import (


### PR DESCRIPTION
## Description

Add pre-exec security scanning to PicoClaw's shell tool using [Tirith](https://github.com/sheeki03/tirith), a terminal security tool that detects content-level threats that the existing regex deny list cannot catch: homograph/punycode URLs, pipe-to-shell patterns with sudo/env variants, terminal injection (ANSI escapes, bidi Unicode, zero-width chars), typosquatted packages, and insecure transport.

Tirith has already been integrated into [Hermes Agent](https://github.com/NousResearch/hermes-agent/pull/1256) where it gates all terminal command execution. This PR brings the same protection to PicoClaw.

PicoClaw runs on resource-constrained devices where container isolation is not practical. The existing `guardCommand()` catches known destructive patterns, but content-level threats pass through undetected. Tirith fills this gap with sub-millisecond scanning and auto-installs from GitHub releases with SHA-256 checksum verification.

**Changes:**
- `pkg/tools/tirith.go` — scanner with proper `*exec.ExitError` handling, cross-platform auto-install (Go stdlib `archive/tar` + `archive/zip`), synchronized first-use installation
- `pkg/tools/shell.go` — `tirithGuard()` called after `guardCommand()` (cheap guards first)
- `pkg/config/config.go` + `defaults.go` — TirithConfig fields with defaults
- `pkg/tools/shell_test.go` — 7 tirith-specific tests (disabled, fail-open, fail-closed, JSON summarize, platform detect)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## AI Code Generation
- [ ] Mostly AI-generated (AI draft, Human verified/modified)

## Related Issue

Closes #1931

## Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sheeki03/tirith
- **Reasoning:** Content-level security scanning complements the existing regex deny list. Fail-open by default so PicoClaw works identically when tirith is not installed.

## Test Environment
- **Hardware:** macOS (Apple Silicon)
- **OS:** macOS 15
- **Model/Provider:** N/A (security tooling, not LLM-dependent)
- **Channels:** N/A

## Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.