### PR TITLE
fix(agent): suppress heartbeat tool feedback

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -85,6 +85,7 @@ type processOptions struct {
 	DefaultResponse         string              // Response when LLM returns empty
 	EnableSummary           bool                // Whether to trigger summarization
 	SendResponse            bool                // Whether to send response via bus
+	SuppressToolFeedback    bool                // Whether to suppress inline tool feedback messages
 	NoHistory               bool                // If true, don't load session history (for heartbeat)
 	SkipInitialSteeringPoll bool                // If true, skip the steering poll at loop start (used by Continue)
 }
@@ -1242,14 +1243,15 @@ func (al *AgentLoop) ProcessHeartbeat(
 		return "", fmt.Errorf("no default agent for heartbeat")
 	}
 	return al.runAgentLoop(ctx, agent, processOptions{
-		SessionKey:      "heartbeat",
-		Channel:         channel,
-		ChatID:          chatID,
-		UserMessage:     content,
-		DefaultResponse: defaultResponse,
-		EnableSummary:   false,
-		SendResponse:    false,
-		NoHistory:       true, // Don't load session history for heartbeat
+		SessionKey:           "heartbeat",
+		Channel:              channel,
+		ChatID:               chatID,
+		UserMessage:          content,
+		DefaultResponse:      defaultResponse,
+		EnableSummary:        false,
+		SendResponse:         false,
+		SuppressToolFeedback: true,
+		NoHistory:            true, // Don't load session history for heartbeat
 	})
 }
 
@@ -2305,7 +2307,9 @@ turnLoop:
 			)
 
 			// Send tool feedback to chat channel if enabled (from HEAD)
-			if al.cfg.Agents.Defaults.IsToolFeedbackEnabled() && ts.channel != "" {
+			if al.cfg.Agents.Defaults.IsToolFeedbackEnabled() &&
+				ts.channel != "" &&
+				!ts.opts.SuppressToolFeedback {
 				feedbackPreview := utils.Truncate(
 					string(argsJSON),
 					al.cfg.Agents.Defaults.GetToolFeedbackMaxArgsLength(),

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1018,6 +1018,40 @@ func (m *artifactThenSendProvider) GetDefaultModel() string {
 	return "artifact-then-send-model"
 }
 
+type toolFeedbackProvider struct {
+	filePath string
+	calls    int
+}
+
+func (m *toolFeedbackProvider) Chat(
+	ctx context.Context,
+	messages []providers.Message,
+	tools []providers.ToolDefinition,
+	model string,
+	opts map[string]any,
+) (*providers.LLMResponse, error) {
+	m.calls++
+	if m.calls == 1 {
+		return &providers.LLMResponse{
+			ToolCalls: []providers.ToolCall{{
+				ID:        "call_heartbeat_read_file",
+				Type:      "function",
+				Name:      "read_file",
+				Arguments: map[string]any{"path": m.filePath},
+			}},
+		}, nil
+	}
+
+	return &providers.LLMResponse{
+		Content:   "HEARTBEAT_OK",
+		ToolCalls: []providers.ToolCall{},
+	}, nil
+}
+
+func (m *toolFeedbackProvider) GetDefaultModel() string {
+	return "heartbeat-tool-feedback-model"
+}
+
 type toolLimitOnlyProvider struct{}
 
 func (m *toolLimitOnlyProvider) Chat(
@@ -2310,6 +2344,112 @@ func TestProcessMessage_PublishesReasoningContentToReasoningChannel(t *testing.T
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected reasoning content to be published to reasoning channel")
+	}
+}
+
+func TestProcessHeartbeat_DoesNotPublishToolFeedback(t *testing.T) {
+	tmpDir := t.TempDir()
+	heartbeatFile := filepath.Join(tmpDir, "heartbeat-task.txt")
+	if err := os.WriteFile(heartbeatFile, []byte("heartbeat task"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				ModelName:         "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+				ToolFeedback: config.ToolFeedbackConfig{
+					Enabled:       true,
+					MaxArgsLength: 300,
+				},
+			},
+		},
+		Tools: config.ToolsConfig{
+			ReadFile: config.ReadFileToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	msgBus := bus.NewMessageBus()
+	provider := &toolFeedbackProvider{filePath: heartbeatFile}
+	al := NewAgentLoop(cfg, msgBus, provider)
+
+	response, err := al.ProcessHeartbeat(context.Background(), "check heartbeat tasks", "telegram", "chat-1")
+	if err != nil {
+		t.Fatalf("ProcessHeartbeat() error = %v", err)
+	}
+	if response != "HEARTBEAT_OK" {
+		t.Fatalf("ProcessHeartbeat() response = %q, want %q", response, "HEARTBEAT_OK")
+	}
+
+	select {
+	case outbound := <-msgBus.OutboundChan():
+		t.Fatalf("expected no outbound tool feedback during heartbeat, got %+v", outbound)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestProcessMessage_PublishesToolFeedbackWhenEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	heartbeatFile := filepath.Join(tmpDir, "tool-feedback.txt")
+	if err := os.WriteFile(heartbeatFile, []byte("tool feedback task"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				ModelName:         "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+				ToolFeedback: config.ToolFeedbackConfig{
+					Enabled:       true,
+					MaxArgsLength: 300,
+				},
+			},
+		},
+		Tools: config.ToolsConfig{
+			ReadFile: config.ReadFileToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	msgBus := bus.NewMessageBus()
+	provider := &toolFeedbackProvider{filePath: heartbeatFile}
+	al := NewAgentLoop(cfg, msgBus, provider)
+
+	response, err := al.processMessage(context.Background(), bus.InboundMessage{
+		Channel:  "telegram",
+		SenderID: "user-1",
+		ChatID:   "chat-1",
+		Content:  "check tool feedback",
+	})
+	if err != nil {
+		t.Fatalf("processMessage() error = %v", err)
+	}
+	if response != "HEARTBEAT_OK" {
+		t.Fatalf("processMessage() response = %q, want %q", response, "HEARTBEAT_OK")
+	}
+
+	select {
+	case outbound := <-msgBus.OutboundChan():
+		if outbound.Channel != "telegram" {
+			t.Fatalf("tool feedback channel = %q, want %q", outbound.Channel, "telegram")
+		}
+		if outbound.ChatID != "chat-1" {
+			t.Fatalf("tool feedback chatID = %q, want %q", outbound.ChatID, "chat-1")
+		}
+		if !strings.Contains(outbound.Content, "`read_file`") {
+			t.Fatalf("tool feedback content = %q, want read_file preview", outbound.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected outbound tool feedback for regular messages")
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

Fixes the heartbeat tool-feedback leak behind `#1824`: when PicoClaw restarts and the heartbeat runs from `HEARTBEAT.md`, the agent can publish inline tool feedback messages back to the last user channel.

Problem summary:
- Heartbeat turns run against the last active channel/chat so they have user context.
- `ProcessHeartbeat()` disables the final user response, but tool-call previews were still published during the turn.
- On restart, users can receive `🔧 read_file`, `🔧 exec`, and similar heartbeat-internal feedback even though no direct reply should be sent.

Root cause:
- `runTurn()` publishes inline tool feedback whenever tool feedback is enabled and a channel is present.
- Heartbeat turns pass the real channel/chat into the loop, so they matched the same branch as normal chat turns.
- There was no heartbeat-specific suppression for these intermediate messages.

What changed:
- Add a focused `SuppressToolFeedback` option to `processOptions`.
- Enable that option for `ProcessHeartbeat()` so heartbeat turns keep their execution context without leaking inline tool feedback.
- Add a regression test that reproduces the heartbeat tool-call path and verifies no outbound feedback is published.
- Add a protection test that confirms regular user messages still publish tool feedback when the setting is enabled.

Why this fix:
- It is the smallest change that directly addresses `#1824`.
- It preserves the existing heartbeat flow, last-channel context, and normal chat tool-feedback behavior.
- It avoids broader changes to heartbeat routing or outbound delivery semantics.

Risk / compatibility:
- Low risk. The only behavioral change is that heartbeat turns no longer emit inline tool-call previews to the user channel.
- Regular chat turns continue to publish tool feedback unchanged.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #1824

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/1824
- **Reasoning:** The heartbeat service already treats final heartbeat results as silent in the normal `HEARTBEAT_OK` case. The user-visible leak came from the generic inline tool-feedback path in `runTurn()`, so the least risky fix is to suppress that path specifically for heartbeat turns.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows (local development environment)
- **Model/Provider:** N/A (unit tests with mock providers)
- **Channels:** Telegram (simulated unit tests), heartbeat service

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Passed:
- `go test ./pkg/agent -run TestProcessHeartbeat_DoesNotPublishToolFeedback -count=1`
- `go test ./pkg/agent -run "TestProcessHeartbeat_DoesNotPublishToolFeedback|TestProcessMessage_PublishesToolFeedbackWhenEnabled|TestProcessMessage_PublishesReasoningContentToReasoningChannel" -count=1`
- `go test ./pkg/heartbeat -count=1`

Baseline reproduction:
- The new heartbeat regression test fails on clean `upstream/main` before this fix because a `🔧 read_file` feedback message is published to the outbound bus during heartbeat execution.

Additional notes:
- `go test ./pkg/agent -count=1` still fails due to pre-existing `TestGlobalSkillFileContentChange`; I confirmed that same failure on clean `upstream/main`, so it is unrelated to this PR.
- `codex review --base origin/main` could not run in this environment because the local Codex config rejected `approvals_reviewer = never`.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
