### PR TITLE
fix(chat): avoid full secret exposure for 7-char secrets

### DIFF
--- a/web/frontend/src/components/secret-placeholder.ts
+++ b/web/frontend/src/components/secret-placeholder.ts
@@ -4,13 +4,20 @@ export function maskedSecretPlaceholder(value: unknown, fallback = ""): string {
     return fallback
   }
 
-  if (secret.length < 7) {
+  // ensure at least 40% of the characters are masked for secrets of length 4 or more
+  if (secret.length <= 6) {
     const first = secret[0]
     const last = secret[secret.length - 1]
     return `${first}***${last}`
   }
 
-  const prefix = secret.slice(0, Math.min(3, secret.length))
-  const suffix = secret.slice(-Math.min(4, secret.length))
-  return `${prefix}***${suffix}`
+  if (secret.length <= 12) {
+    const firstTwo = secret.slice(0, 2)
+    const lastTwo = secret.slice(-2)
+    return `${firstTwo}****${lastTwo}`
+  }
+
+  const prefix = secret.slice(0, 3)
+  const suffix = secret.slice(-4)
+  return `${prefix}*****${suffix}`
 }


### PR DESCRIPTION
## 📝 Description

- ensure at least 40% of the characters are masked for secrets of length 4 or more
- secrets with length <= 6 now show first and last char with mask
- secrets with length <= 12 now show first two and last two chars
- longer secrets show 3 prefix and 4 suffix

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<img width="879" height="1296" alt="屏幕截图 2026-03-24 110650" src="https://github.com/user-attachments/assets/92c9aeb6-a799-41c4-b805-874d9035b894" />

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.