### PR TITLE
fix(web): ensure at least 40% of the characters are hidden for api key

### DIFF
--- a/web/backend/api/models.go
+++ b/web/backend/api/models.go
@@ -311,7 +311,7 @@ func (h *Handler) handleSetDefaultModel(w http.ResponseWriter, r *http.Request) 
 // Keys 9-12 chars show prefix + last 2 chars: "sk-****cd".
 // Shorter keys are fully masked as "****".
 // Empty keys return empty string.
-// Ensure at least 40% of the key is masked.
+// Ensure at least 40% of the key will not be displayed.
 func maskAPIKey(key string) string {
 	if key == "" {
 		return ""

--- a/web/backend/api/models_test.go
+++ b/web/backend/api/models_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -364,6 +365,24 @@ func TestMaskAPIKey(t *testing.T) {
 			got := maskAPIKey(tc.key)
 			if got != tc.want {
 				t.Fatalf("maskAPIKey(%q) = %q, want %q", tc.key, got, tc.want)
+			}
+
+			if tc.key != "" {
+				displayed := strings.Replace(tc.want, "****", "", 1)
+				if len(tc.key) <= 8 {
+					if displayed != "" {
+						t.Fatalf("maskAPIKey(%q) displayed part = %q, want empty", tc.key, displayed)
+					}
+				} else {
+					if len(displayed)*10 > len(tc.key)*6 {
+						t.Fatalf(
+							"maskAPIKey(%q) displayed length = %d, want at most 60%% of %d",
+							tc.key,
+							len(displayed),
+							len(tc.key),
+						)
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## 📝 Description
### Masking behavior
- Empty key returns empty string.
- Keys with length <= 8 are fully masked as `****`.
- Keys with length 9-12 show first 3 + `****` + last 2.
- Keys with length > 12 show first 3 + `****` + last 4.
- The mask token is always fixed to `****`.

### Test improvements
- Refined `TestMaskAPIKey` with boundary and common cases.
- Added a uniform character-count check for each non-empty case:
  - remove the first `****` from expected output
  - for keys <= 8, remaining displayed part must be empty
  - otherwise, remaining displayed length must be <= 60% of original key length

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 📚 Technical Context (Skip for Docs)
[#1942](https://github.com/sipeed/picoclaw/pull/1942)

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.