### PR TITLE
fix: detecting the external port that is being used, returning correct websocket

### DIFF
--- a/web/backend/api/gateway_host.go
+++ b/web/backend/api/gateway_host.go
@@ -190,12 +190,20 @@ func joinClientVisibleHostPort(r *http.Request, host string, serverListenPort in
 func (h *Handler) picoWebUIAddr(r *http.Request) string {
 	wsPort := h.serverPort
 	if wsPort == 0 {
-		wsPort = 18800 // default web server port
+		wsPort = 18800
 	}
 	if fwdHost := forwardedHostFirst(r); fwdHost != "" {
 		return joinClientVisibleHostPort(r, fwdHost, wsPort)
 	}
 	host := requestHostName(r)
+	// Use clientVisiblePort only when an explicit port is present in headers
+	// or Host header — do not infer from TLS/scheme, as serverPort takes priority.
+	if p := forwardedPortFirst(r); p != "" {
+		return net.JoinHostPort(host, p)
+	}
+	if _, port, err := net.SplitHostPort(r.Host); err == nil && port != "" {
+		return net.JoinHostPort(host, port)
+	}
 	return net.JoinHostPort(host, strconv.Itoa(wsPort))
 }
 


### PR DESCRIPTION

## 📝 Description

This PR fixes the root cause of the WebUI chat input being disabled (stop sign cursor) when using custom ports.

### Problem
When running the launcher with a custom port (e.g. Docker GUI mapping 46569 -> 18800, Tailscale, etc.), the frontend loads, but the chat box remains disabled.

Because the `/api/pico/token` endpoint was **hardcoding** the WebSocket URL to port `18800`.

## 🗣️ Type of Change
- [X] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [X] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

Fixes #1737

## 🧪 Test Environment
- **Hardware:** Asus Zephyrus G14
- **OS:** Ubuntu 24.04.4

## ☑️ Checklist
- [ ] My code/docs follow the style of this project.
- [X] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.