### PR TITLE
config: add baidu_search example to config.example.json

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -286,6 +286,12 @@
         "search_engine": "search_std",
         "max_results": 5
       },
+      "baidu_search": {
+        "enabled": false,
+        "api_key": "",
+        "base_url": "https://qianfan.baidubce.com/v2/ai_search/web_search",
+        "max_results": 10
+      },
       "fetch_limit_bytes": 10485760,
       "private_host_whitelist": []
     },


### PR DESCRIPTION
## Summary

Add the `baidu_search` configuration block to `config.example.json`, placed after `glm_search`.

The `BaiduSearchConfig` struct and provider implementation were added in a previous PR but the example config was not updated at the time.

## Changes

- Add `baidu_search` block with default values matching `BaiduSearchConfig` defaults:
  - `enabled: false`
  - `api_key: ""`
  - `base_url: "https://qianfan.baidubce.com/v2/ai_search/web_search"`
  - `max_results: 10`