### PR TITLE
fix(build): disable Matrix gateway import on freebsd/arm

### DIFF
--- a/pkg/gateway/channel_matrix.go
+++ b/pkg/gateway/channel_matrix.go
@@ -1,4 +1,4 @@
-//go:build !mipsle && !netbsd
+//go:build !mipsle && !netbsd && !(freebsd && arm)
 
 package gateway
 
@@ -12,6 +12,9 @@ import (
 	// - netbsd/*: modernc.org/sqlite v1.46.1 fails to compile due to broken
 	//   generated mutex code on NetBSD (for example sqlite_netbsd_amd64.go calls
 	//   mu.enter/mu.leave, but the generated mutex type does not define them).
+	// - freebsd/arm: modernc.org/libc v1.67.6 fails to compile due to broken
+	//   generated 32-bit FreeBSD code (size_t/uint64 and int32/int64 mismatches
+	//   in libc_freebsd.go).
 	//
 	// This means Matrix is currently unavailable on those targets. The proper
 	// long-term fix is to split Matrix basic support from its E2EE/sqlite-backed


### PR DESCRIPTION
## 📝 Description

This change excludes the Matrix gateway registration import on `freebsd/arm`.

The Matrix stack already has target-specific build limitations, and `modernc.org/libc` currently fails to compile generated 32-bit FreeBSD code in the dependency chain used by Matrix. Extending the existing build guard keeps the gateway package from importing Matrix on an unsupported target and avoids this build break.

This PR does not claim full Matrix support on `freebsd/arm`; it only scopes the gateway import the same way unsupported targets are already handled for `mipsle` and `netbsd`.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A (local build failure observed on `freebsd/arm` in the Matrix dependency chain)
- **Reasoning:** `pkg/gateway/channel_matrix.go` already excludes unsupported targets. Adding `!(freebsd && arm)` matches the current intent by preventing the gateway package from importing Matrix where its dependency chain is known not to compile.

## 🧪 Test Environment
- **Hardware:** Mac15,6
- **OS:** macOS 26.3.1
- **Model/Provider:** N/A (build-only validation)
- **Channels:** N/A


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- `make check` passed locally.
- `GOOS=freebsd GOARCH=arm go test ./...` still fails in `pkg/channels/matrix` because `mautrix/crypto/libolm` has no matching Go files for that target. This change is intentionally limited to avoiding the gateway import path on `freebsd/arm`.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
