### PR TITLE
docs(configuration): add security config reference at document start

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,8 @@
 
 Config file: `~/.picoclaw/config.json`
 
+> **Security Configuration:** For storing API keys, tokens, and other sensitive data, see the [Security Configuration Guide](security_configuration.md).
+
 ### Environment Variables
 
 You can override default paths using environment variables. This is useful for portable installations, containerized deployments, or running picoclaw as a system service. These variables are independent and control different paths.


### PR DESCRIPTION
## Summary

Add a prominent reference to security_configuration.md at the beginning of the configuration guide. This helps new users quickly find information about storing API keys in .security.yml.

## Changes

- Added link to Security Configuration Guide in the introductory section of configuration.md
- Reference is placed near the beginning so users see it when configuring their setup

## Related Issue

Fixes #1986

## Evidence

- The reference is now prominently placed at the document start
- Link points to the existing security_configuration.md file