### PR TITLE
fix(agent): include SystemParts in token estimation and add reasoning guards

### DIFF
--- a/pkg/agent/context_budget.go
+++ b/pkg/agent/context_budget.go
@@ -91,11 +91,12 @@ func findSafeBoundary(history []providers.Message, targetIndex int) int {
 // metadata, and Media items. Uses a heuristic of 2.5 characters per token.
 func estimateMessageTokens(msg providers.Message) int {
 	chars := utf8.RuneCountInString(msg.Content)
+	chars += utf8.RuneCountInString(msg.ReasoningContent)
 
-	// ReasoningContent (extended thinking / chain-of-thought) can be
-	// substantial and is stored in session history via AddFullMessage.
-	if msg.ReasoningContent != "" {
-		chars += utf8.RuneCountInString(msg.ReasoningContent)
+	// SystemParts are structured system blocks that can be substantial
+	// when using instruction-heavy agents or KV-cache-aware adapters.
+	for _, part := range msg.SystemParts {
+		chars += utf8.RuneCountInString(part.Text)
 	}
 
 	for _, tc := range msg.ToolCalls {

--- a/pkg/agent/context_budget.go
+++ b/pkg/agent/context_budget.go
@@ -90,14 +90,28 @@ func findSafeBoundary(history []providers.Message, targetIndex int) int {
 // including Content, ReasoningContent, ToolCalls arguments, ToolCallID
 // metadata, and Media items. Uses a heuristic of 2.5 characters per token.
 func estimateMessageTokens(msg providers.Message) int {
-	chars := utf8.RuneCountInString(msg.Content)
-	chars += utf8.RuneCountInString(msg.ReasoningContent)
+	contentChars := utf8.RuneCountInString(msg.Content)
 
-	// SystemParts are structured system blocks that can be substantial
-	// when using instruction-heavy agents or KV-cache-aware adapters.
-	for _, part := range msg.SystemParts {
-		chars += utf8.RuneCountInString(part.Text)
+	// SystemParts are structured system blocks used for cache-aware adapters.
+	// They carry the same content as Content, but in multiple blocks.
+	// We estimate them as an alternative representation, not additive.
+	systemPartsChars := 0
+	if len(msg.SystemParts) > 0 {
+		for _, part := range msg.SystemParts {
+			systemPartsChars += utf8.RuneCountInString(part.Text)
+		}
+		// Per-part overhead for JSON structure (type, text, cache_control).
+		const perPartOverhead = 20
+		systemPartsChars += len(msg.SystemParts) * perPartOverhead
 	}
+
+	// Use the larger of the two representations to stay conservative.
+	chars := contentChars
+	if systemPartsChars > chars {
+		chars = systemPartsChars
+	}
+
+	chars += utf8.RuneCountInString(msg.ReasoningContent)
 
 	for _, tc := range msg.ToolCalls {
 		chars += len(tc.ID) + len(tc.Type)

--- a/pkg/agent/context_budget_test.go
+++ b/pkg/agent/context_budget_test.go
@@ -529,6 +529,26 @@ func TestEstimateMessageTokens_MediaItems(t *testing.T) {
 	}
 }
 
+func TestEstimateMessageTokens_SystemParts(t *testing.T) {
+	plain := providers.Message{Role: "system", Content: "instructions"}
+	withParts := providers.Message{
+		Role:    "system",
+		Content: "instructions",
+		SystemParts: []providers.ContentBlock{
+			{Type: "text", Text: "some more system context"},
+			{Type: "text", Text: "even more cached blocks"},
+		},
+	}
+
+	plainTokens := estimateMessageTokens(plain)
+	partsTokens := estimateMessageTokens(withParts)
+
+	if partsTokens <= plainTokens {
+		t.Errorf("system message with SystemParts (%d) should exceed plain message (%d)",
+			partsTokens, plainTokens)
+	}
+}
+
 // --- estimateToolDefsTokens tests ---
 
 func TestEstimateToolDefsTokens(t *testing.T) {


### PR DESCRIPTION
## 📝 Description

This PR fixes a deficiency in the token estimation logic for context pruning. Currently, the agent ignores `SystemParts` (structured system blocks used for cache-aware adapters and large instructions), leading to underestimated token counts and potential context window overflows (400 errors). It also streamlines the reasoning content path for better robustness.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [X] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue
N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** In `estimateMessageTokens`, `msg.SystemParts` was being ignored. Large instructions or RAG indices kept in system messages would stay hidden from the budget checker, causing overflows on the next provider call.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows 11
- **Model/Provider:** Anthropic Sonnet 3.7
- **Channels:** CLI / Any


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```
=== RUN   TestEstimateMessageTokens_SystemParts
--- PASS: TestEstimateMessageTokens_SystemParts (0.00s)
PASS
ok      github.com/sipeed/picoclaw/pkg/agent    0.340s
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [X] I have updated the documentation accordingly..