### PR TITLE
docs: clarify gateway.log_level configuration default (fatal)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,22 @@ PICOCLAW_HOME=/opt/picoclaw picoclaw agent
 PICOCLAW_HOME=/srv/picoclaw PICOCLAW_CONFIG=/srv/picoclaw/main.json picoclaw gateway
 ```
 
+### Gateway Log Level
+
+`gateway.log_level` controls Gateway log verbosity and is configurable in `config.json`.
+
+```json
+{
+  "gateway": {
+    "log_level": "fatal"
+  }
+}
+```
+
+When omitted, the default is `fatal`. Supported values: `debug`, `info`, `warn`, `error`, `fatal`.
+
+You can also override this with the environment variable `PICOCLAW_LOG_LEVEL`.
+
 ### Workspace Layout
 
 PicoClaw stores data in your configured workspace (default: `~/.picoclaw/workspace`):


### PR DESCRIPTION
## Summary
This is a docs-only follow-up after confusion around gateway logging in #2006.

It documents the existing `gateway.log_level` configuration behavior more clearly:
- `gateway.log_level` is configurable in `config.json`
- default is `fatal` when omitted
- supported values are `debug`, `info`, `warn`, `error`, `fatal`
- env override is `PICOCLAW_LOG_LEVEL`

## Scope
- Docs only
- No runtime code changes
- No config default changes

## Files
- `docs/configuration.md`

Refs #2013