### PR TITLE
fix(weixin): probe sync dir writability before choosing home

### DIFF
--- a/pkg/channels/weixin/state.go
+++ b/pkg/channels/weixin/state.go
@@ -41,7 +41,24 @@ type contextTokensFile struct {
 }
 
 func picoclawHomeDir() string {
-	return config.GetHome()
+	if home := os.Getenv(config.EnvHome); home != "" {
+		return home
+	}
+
+	if userHome, err := os.UserHomeDir(); err == nil && userHome != "" {
+		home := filepath.Join(userHome, ".picoclaw")
+		syncDir := filepath.Join(home, "channels", "weixin", "sync")
+		mkErr := os.MkdirAll(syncDir, 0o700)
+		if mkErr == nil {
+			return home
+		}
+		logger.WarnCF("weixin", "Default picoclaw home is not writable; using temp directory for sync cursor", map[string]any{
+			"path":  home,
+			"error": mkErr.Error(),
+		})
+	}
+
+	return filepath.Join(os.TempDir(), "picoclaw")
 }
 
 func genWeixinAccountKey(cfg config.WeixinConfig) string {

--- a/pkg/channels/weixin/state.go
+++ b/pkg/channels/weixin/state.go
@@ -75,10 +75,14 @@ func picoclawHomeDir() string {
 		if probeErr := probeSyncDirWritable(home); probeErr == nil {
 			return home
 		} else {
-			logger.WarnCF("weixin", "Default picoclaw home is not writable; using temp directory for sync cursor", map[string]any{
-				"path":  home,
-				"error": probeErr.Error(),
-			})
+			logger.WarnCF(
+				"weixin",
+				"Default picoclaw home is not writable; using temp directory for sync cursor",
+				map[string]any{
+					"path":  home,
+					"error": probeErr.Error(),
+				},
+			)
 		}
 	}
 

--- a/pkg/channels/weixin/state.go
+++ b/pkg/channels/weixin/state.go
@@ -40,6 +40,31 @@ type contextTokensFile struct {
 	Tokens map[string]string `json:"tokens"`
 }
 
+func syncDirForHome(home string) string {
+	return filepath.Join(home, "channels", "weixin", "sync")
+}
+
+func probeSyncDirWritable(home string) error {
+	syncDir := syncDirForHome(home)
+	if err := os.MkdirAll(syncDir, 0o700); err != nil {
+		return err
+	}
+
+	probeFile, err := os.CreateTemp(syncDir, ".write-probe-*")
+	if err != nil {
+		return err
+	}
+	probePath := probeFile.Name()
+	if err := probeFile.Close(); err != nil {
+		_ = os.Remove(probePath)
+		return err
+	}
+	if err := os.Remove(probePath); err != nil {
+		return err
+	}
+	return nil
+}
+
 func picoclawHomeDir() string {
 	if home := os.Getenv(config.EnvHome); home != "" {
 		return home
@@ -47,15 +72,14 @@ func picoclawHomeDir() string {
 
 	if userHome, err := os.UserHomeDir(); err == nil && userHome != "" {
 		home := filepath.Join(userHome, ".picoclaw")
-		syncDir := filepath.Join(home, "channels", "weixin", "sync")
-		mkErr := os.MkdirAll(syncDir, 0o700)
-		if mkErr == nil {
+		if probeErr := probeSyncDirWritable(home); probeErr == nil {
 			return home
+		} else {
+			logger.WarnCF("weixin", "Default picoclaw home is not writable; using temp directory for sync cursor", map[string]any{
+				"path":  home,
+				"error": probeErr.Error(),
+			})
 		}
-		logger.WarnCF("weixin", "Default picoclaw home is not writable; using temp directory for sync cursor", map[string]any{
-			"path":  home,
-			"error": mkErr.Error(),
-		})
 	}
 
 	return filepath.Join(os.TempDir(), "picoclaw")

--- a/pkg/channels/weixin/weixin_test.go
+++ b/pkg/channels/weixin/weixin_test.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -266,6 +268,29 @@ func TestBuildWeixinSyncBufPathUsesPicoclawHome(t *testing.T) {
 	got := buildWeixinSyncBufPath(wxCfg)
 	if filepath.Dir(got) != filepath.Join(home, "channels", "weixin", "sync") {
 		t.Fatalf("sync path dir = %q", filepath.Dir(got))
+	}
+}
+
+func TestBuildWeixinSyncBufPathFallsBackWhenHomeIsUnusable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME handling differs on windows")
+	}
+
+	t.Setenv(config.EnvHome, "")
+	unusableHome := filepath.Join(t.TempDir(), "home-file")
+	if err := os.WriteFile(unusableHome, []byte("not-a-dir"), 0o600); err != nil {
+		t.Fatalf("WriteFile(unusableHome) error = %v", err)
+	}
+	t.Setenv("HOME", unusableHome)
+
+	wxCfg := config.WeixinConfig{
+		BaseURL: "https://ilinkai.weixin.qq.com/",
+	}
+	wxCfg.SetToken("token-123")
+	got := buildWeixinSyncBufPath(wxCfg)
+	wantDir := filepath.Join(os.TempDir(), "picoclaw", "channels", "weixin", "sync")
+	if filepath.Dir(got) != wantDir {
+		t.Fatalf("sync path dir = %q, want %q", filepath.Dir(got), wantDir)
 	}
 }
 

--- a/pkg/channels/weixin/weixin_test.go
+++ b/pkg/channels/weixin/weixin_test.go
@@ -294,6 +294,44 @@ func TestBuildWeixinSyncBufPathFallsBackWhenHomeIsUnusable(t *testing.T) {
 	}
 }
 
+func TestBuildWeixinSyncBufPathFallsBackWhenSyncDirUnwritable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission mode behavior differs on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root can usually bypass directory write permissions")
+	}
+
+	t.Setenv(config.EnvHome, "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	syncDir := filepath.Join(home, ".picoclaw", "channels", "weixin", "sync")
+	if err := os.MkdirAll(syncDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(syncDir) error = %v", err)
+	}
+	if err := os.Chmod(syncDir, 0o500); err != nil {
+		t.Fatalf("Chmod(syncDir, 0500) error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(syncDir, 0o700) })
+
+	if probeFile, err := os.CreateTemp(syncDir, ".probe-*"); err == nil {
+		_ = probeFile.Close()
+		_ = os.Remove(probeFile.Name())
+		t.Skip("environment does not enforce non-writable directory permissions")
+	}
+
+	wxCfg := config.WeixinConfig{
+		BaseURL: "https://ilinkai.weixin.qq.com/",
+	}
+	wxCfg.SetToken("token-123")
+	got := buildWeixinSyncBufPath(wxCfg)
+	wantDir := filepath.Join(os.TempDir(), "picoclaw", "channels", "weixin", "sync")
+	if filepath.Dir(got) != wantDir {
+		t.Fatalf("sync path dir = %q, want %q", filepath.Dir(got), wantDir)
+	}
+}
+
 func TestSessionPauseGuard(t *testing.T) {
 	ch := &WeixinChannel{
 		typingCache: make(map[string]typingTicketCacheEntry),


### PR DESCRIPTION
## Summary
- probe the default Weixin sync cursor directory with a real temp-file write before using `~/.picoclaw`
- fall back to a temp-backed picoclaw home when the default home cannot persist sync state
- add regressions for unusable `HOME` and existing non-writable sync directories

## Testing
- go test ./pkg/channels/weixin

Fixes #1917