### PR TITLE
fix(config): disable tool feedback by default

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -487,6 +487,33 @@ func TestDefaultConfig_WebPreferNativeEnabled(t *testing.T) {
 	}
 }
 
+func TestDefaultConfig_ToolFeedbackDisabled(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Agents.Defaults.ToolFeedback.Enabled {
+		t.Fatal("DefaultConfig().Agents.Defaults.ToolFeedback.Enabled should be false")
+	}
+}
+
+func TestLoadConfig_ToolFeedbackDefaultsFalseWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(
+		configPath,
+		[]byte(`{"version":1,"agents":{"defaults":{"workspace":"./workspace"}}}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error: %v", err)
+	}
+	if cfg.Agents.Defaults.ToolFeedback.Enabled {
+		t.Fatal("agents.defaults.tool_feedback.enabled should remain false when unset in config file")
+	}
+}
+
 func TestLoadConfig_WebPreferNativeDefaultsTrueWhenUnset(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -39,7 +39,7 @@ func DefaultConfig() *Config {
 				SummarizeTokenPercent:     75,
 				SteeringMode:              "one-at-a-time",
 				ToolFeedback: ToolFeedbackConfig{
-					Enabled:       true,
+					Enabled:       false,
 					MaxArgsLength: 300,
 				},
 				SplitOnMarker: false,

--- a/web/frontend/src/components/config/form-model.ts
+++ b/web/frontend/src/components/config/form-model.ts
@@ -67,7 +67,7 @@ export const EMPTY_FORM: CoreConfigForm = {
   workspace: "",
   restrictToWorkspace: true,
   splitOnMarker: false,
-  toolFeedbackEnabled: true,
+  toolFeedbackEnabled: false,
   toolFeedbackMaxArgsLength: "300",
   execEnabled: true,
   allowRemote: true,


### PR DESCRIPTION
## Summary
Issue #2007 reported noisy web chat messages after upgrading to v0.2.4.

This patch aligns runtime and web-config fallback defaults with the documented/example default for agents.defaults.tool_feedback.enabled (disabled).

## Why config guidance alone was insufficient
A collaborator correctly noted that users can disable tool feedback in config. However, existing configs that omitted tool_feedback.enabled still inherited DefaultConfig() values during LoadConfig(). Since runtime defaults had become true, upgrades could start emitting tool feedback without explicit opt-in.

So this is not only a usage/configuration question; it is a default-regression issue affecting users with unset fields.

## Files changed
- pkg/config/defaults.go
- pkg/config/config_test.go
- web/frontend/src/components/config/form-model.ts

## Validation
Ran:

go test ./pkg/config -run 'TestDefaultConfig_ToolFeedbackDisabled|TestLoadConfig_ToolFeedbackDefaultsFalseWhenUnset|TestDefaultConfig_WebPreferNativeEnabled|TestLoadConfig_WebPreferNativeDefaultsTrueWhenUnset'
