### PR TITLE
feat(feishu): refactor file download with deduplication and directory indexing

### DIFF
--- a/docs/channels/feishu/README.md
+++ b/docs/channels/feishu/README.md
@@ -30,6 +30,7 @@ Feishu (international name: Lark) is an enterprise collaboration platform by Byt
 | verification_token    | string | No       | Token used for Webhook event verification                          |
 | allow_from            | array  | No       | Allowlist of user IDs; empty means all users are allowed           |
 | random_reaction_emoji | array  | No       | List of random reaction emojis; empty uses the default "Pin"       |
+| download_dir          | string | No       | Custom directory for downloaded files (relative/absolute paths)    |
 
 ## Setup
 
@@ -50,3 +51,63 @@ Feishu (international name: Lark) is an enterprise collaboration platform by Byt
 ## Platform Limitations
 
 > ⚠️ **Feishu channel does not support 32-bit devices.** The Feishu SDK only provides 64-bit builds. Devices running armv6, armv7, mipsle, or other 32-bit architectures cannot use the Feishu channel. For messaging on 32-bit devices, use Telegram, Discord, or OneBot instead.
+
+## Download Directory Configuration
+
+The `download_dir` field specifies where files received from Feishu (images, documents, etc.) are stored.
+
+### Path Resolution
+
+1. **Relative path** (recommended): Resolved relative to the PicoClaw workspace directory
+   - Default workspace: `~/.picoclaw/workspace` (or `$PICOCLAW_HOME/workspace`)
+   - Example: If workspace is `~/.picoclaw/workspace`, `download_dir: "downloads"` resolves to `~/.picoclaw/workspace/downloads`
+   ```json
+   {
+     "channels": {
+       "feishu": {
+         "download_dir": "downloads"
+       }
+     }
+   }
+   ```
+
+2. **Absolute path**: Use an absolute path directly
+   ```json
+   {
+     "channels": {
+       "feishu": {
+         "download_dir": "/Users/username/Downloads/feishu"
+       }
+     }
+   }
+   ```
+
+3. **Home directory shorthand**: Use `~` for your home directory
+   ```json
+   {
+     "channels": {
+       "feishu": {
+         "download_dir": "~/Downloads/feishu"
+       }
+     }
+   }
+   ```
+
+4. **Default (not configured)**: Files are downloaded to the system temp directory
+   - macOS: `/var/folders/.../picoclaw_media`
+   - Linux: `/tmp/picoclaw_media`
+   - Windows: `C:\Users\xxx\AppData\Local\Temp\picoclaw_media`
+
+### Safety & Fallback
+
+- The directory will be created automatically if it doesn't exist
+- Write permissions are verified before use
+- If the configured directory cannot be accessed (no permission, path conflicts, etc.), the system automatically falls back to the system temp directory to ensure files are received successfully
+
+### Environment Variable
+
+You can also configure via environment variable:
+
+```bash
+export PICOCLAW_CHANNELS_FEISHU_DOWNLOAD_DIR="downloads"
+```

--- a/pkg/channels/feishu/feishu_32.go
+++ b/pkg/channels/feishu/feishu_32.go
@@ -19,7 +19,7 @@ type FeishuChannel struct {
 var errUnsupported = errors.New("feishu channel is not supported on 32-bit architectures")
 
 // NewFeishuChannel returns an error on 32-bit architectures where the Feishu SDK is not supported
-func NewFeishuChannel(cfg config.FeishuConfig, bus *bus.MessageBus) (*FeishuChannel, error) {
+func NewFeishuChannel(cfg config.FeishuConfig, bus *bus.MessageBus, globalCfg *config.Config) (*FeishuChannel, error) {
 	return nil, errors.New(
 		"feishu channel is not supported on 32-bit architectures (armv7l, 386, etc.). Please use a 64-bit system or disable feishu in your config",
 	)

--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -4,6 +4,8 @@ package feishu
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -35,6 +38,26 @@ import (
 // on this error, so we do it ourselves.
 const errCodeTenantTokenInvalid = 99991663
 
+const indexFileName = ".feishu_index.json"
+const maxFilenameConflictRetries = 10000 // Maximum iterations to find unique filename
+const readOnlyFileMode = 0o444           // Read-only file permission (user=r, group=r, other=r)
+
+// DirectoryIndex represents a per-directory index file.
+type DirectoryIndex struct {
+	Version int        `json:"version"`
+	Files   []FileMeta `json:"files"`
+}
+
+// FileMeta represents a single downloaded file in the directory index.
+type FileMeta struct {
+	Filename     string    `json:"filename"`     // Local filename
+	Hash         string    `json:"hash"`         // SHA-256 hash
+	Size         int64     `json:"size"`         // File size in bytes
+	FileKey      string    `json:"file_key"`     // Feishu file key (for re-downloading)
+	MessageID    string    `json:"message_id"`   // Message ID
+	DownloadedAt time.Time `json:"downloaded_at"` // Download time
+}
+
 type FeishuChannel struct {
 	*channels.BaseChannel
 	config     config.FeishuConfig
@@ -45,8 +68,9 @@ type FeishuChannel struct {
 
 	botOpenID atomic.Value // stores string; populated lazily for @mention detection
 
-	mu     sync.Mutex
-	cancel context.CancelFunc
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	indexMu sync.Map // map[string]*sync.Mutex - one lock per directory for index updates
 }
 
 func NewFeishuChannel(cfg config.FeishuConfig, bus *bus.MessageBus, globalCfg *config.Config) (*FeishuChannel, error) {
@@ -722,6 +746,180 @@ func (c *FeishuChannel) validateAndCreateDir(dir string) error {
 	return fmt.Errorf("failed to access directory: %w", err)
 }
 
+// loadDirectoryIndex loads the directory index file.
+// Returns an empty index if the file doesn't exist or cannot be read.
+func (c *FeishuChannel) loadDirectoryIndex(dirPath string) (*DirectoryIndex, error) {
+	indexPath := filepath.Join(dirPath, indexFileName)
+
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Index doesn't exist, return empty index
+			return &DirectoryIndex{Version: 1, Files: []FileMeta{}}, nil
+		}
+		return nil, err
+	}
+
+	var index DirectoryIndex
+	if err := json.Unmarshal(data, &index); err != nil {
+		return nil, err
+	}
+
+	return &index, nil
+}
+
+// saveDirectoryIndex saves the directory index file.
+func (c *FeishuChannel) saveDirectoryIndex(dirPath string, index *DirectoryIndex) error {
+	indexPath := filepath.Join(dirPath, indexFileName)
+
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// Atomic write: write to temp file first, then rename
+	tmpPath := indexPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpPath, indexPath)
+}
+
+// updateIndexWithFile updates the index, adding or updating file metadata.
+// getIndexLock returns a mutex for the given directory path.
+func (c *FeishuChannel) getIndexLock(dirPath string) *sync.Mutex {
+	lock, _ := c.indexMu.LoadOrStore(dirPath, &sync.Mutex{})
+	return lock.(*sync.Mutex)
+}
+
+func (c *FeishuChannel) updateIndexWithFile(dirPath string, meta FileMeta) error {
+	// Acquire lock for this directory to prevent concurrent index corruption
+	lock := c.getIndexLock(dirPath)
+	lock.Lock()
+	defer lock.Unlock()
+
+	index, err := c.loadDirectoryIndex(dirPath)
+	if err != nil {
+		return err
+	}
+
+	// Find if this file already exists in the index
+	found := false
+	for i, file := range index.Files {
+		if file.Filename == meta.Filename {
+			index.Files[i] = meta // Update
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		index.Files = append(index.Files, meta) // Add
+	}
+
+	return c.saveDirectoryIndex(dirPath, index)
+}
+
+// findFileByKeyInIndex searches for a file by file_key in the index.
+// Returns the FileMeta if found, nil otherwise.
+func (c *FeishuChannel) findFileByKeyInIndex(dirPath, fileKey string) (*FileMeta, error) {
+	index, err := c.loadDirectoryIndex(dirPath)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range index.Files {
+		if file.FileKey == fileKey {
+			return &file, nil
+		}
+	}
+
+	return nil, nil // Not found
+}
+
+// generateFilePath generates a file path: {year}/{month}/{filename}.
+func (c *FeishuChannel) generateFilePath(downloadDir, filename string) string {
+	now := time.Now()
+	yearMonth := now.Format("2006/01") // 2026/03
+	monthPath := filepath.Join(downloadDir, yearMonth)
+	return filepath.Join(monthPath, utils.SanitizeFilename(filename))
+}
+
+// generateUniqueFilename intelligently handles filename conflicts.
+// Returns: unique file path, whether existing file is reused, error.
+func (c *FeishuChannel) generateUniqueFilename(basePath, tmpPath string) (string, bool, error) {
+	// Check if file exists
+	if _, err := os.Stat(basePath); os.IsNotExist(err) {
+		return basePath, false, nil // File doesn't exist, use it directly
+	}
+
+	// File exists, check if it's the same file (hash + size)
+	existingHash, err := c.calculateFileHash(basePath)
+	if err == nil {
+		newHash, _ := c.calculateFileHash(tmpPath)
+		existingSize, _ := getFileSize(basePath)
+		newSize, _ := getFileSize(tmpPath)
+
+		// hash and size match, reuse existing file
+		if existingHash == newHash && existingSize == newSize {
+			return basePath, true, nil
+		}
+	}
+
+	// Not the same file, add serial number suffix
+	ext := filepath.Ext(basePath)
+	nameWithoutExt := strings.TrimSuffix(basePath, ext)
+
+	for i := 1; i <= maxFilenameConflictRetries; i++ {
+		// Use -1, -2 format
+		newPath := fmt.Sprintf("%s-%d%s", nameWithoutExt, i, ext)
+		if _, err := os.Stat(newPath); os.IsNotExist(err) {
+			return newPath, false, nil
+		}
+
+		// Check if new path has same content as temp file
+		if existingHash, err := c.calculateFileHash(newPath); err == nil {
+			newHash, _ := c.calculateFileHash(tmpPath)
+			if existingHash == newHash {
+				existingSize, _ := getFileSize(newPath)
+				newSize, _ := getFileSize(tmpPath)
+				if existingSize == newSize {
+					return newPath, true, nil
+				}
+			}
+		}
+	}
+
+	// Should never happen, but return error to be safe
+	return "", false, fmt.Errorf("too many filename conflicts (>%d), could not generate unique filename", maxFilenameConflictRetries)
+}
+
+// getFileSize gets the size of a file.
+func getFileSize(filePath string) (int64, error) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return 0, err
+	}
+	return info.Size(), nil
+}
+
+// calculateFileHash calculates SHA-256 hash of a file and returns it as hex string.
+func (c *FeishuChannel) calculateFileHash(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
 // downloadResource downloads a message resource (image/file) from Feishu,
 // writes it to the configured media directory, and stores the reference in MediaStore.
 // fallbackExt (e.g. ".jpg") is appended when the resolved filename has no extension.
@@ -772,38 +970,124 @@ func (c *FeishuChannel) downloadResource(
 		filename += fallbackExt
 	}
 
-	// Determine download directory
-	mediaDir := c.resolveDownloadDir()
-	if mediaDir == "" {
+	// 1. Determine download directory
+	downloadDir := c.resolveDownloadDir()
+	if downloadDir == "" {
 		// Fallback to TempDir
-		mediaDir = media.TempDir()
+		downloadDir = media.TempDir()
 	}
 
-	logger.DebugCF("feishu", "Downloading resource to directory", map[string]any{
-		"directory": mediaDir,
-	})
-	ext := filepath.Ext(filename)
-	localPath := filepath.Join(mediaDir, utils.SanitizeFilename(messageID+"-"+fileKey+ext))
-
-	out, err := os.Create(localPath)
+	// 2. Download to temporary file
+	tmpFile, err := os.CreateTemp("", "feishu_download_*")
 	if err != nil {
-		logger.ErrorCF("feishu", "Failed to create local file for resource", map[string]any{
+		logger.ErrorCF("feishu", "Failed to create temporary file", map[string]any{
+			"error": err.Error(),
+		})
+		return ""
+	}
+	tmpPath := tmpFile.Name()
+
+	// Write downloaded content to temp file
+	size, err := io.Copy(tmpFile, resp.File)
+	tmpFile.Close()
+	if err != nil {
+		os.Remove(tmpPath)
+		logger.ErrorCF("feishu", "Failed to write resource to temp file", map[string]any{
 			"error": err.Error(),
 		})
 		return ""
 	}
 
-	if _, copyErr := io.Copy(out, resp.File); copyErr != nil {
-		out.Close()
-		os.Remove(localPath)
-		logger.ErrorCF("feishu", "Failed to write resource to file", map[string]any{
-			"error": copyErr.Error(),
+	// 3. Generate target path: {year}/{month}/{filename}
+	basePath := c.generateFilePath(downloadDir, filename)
+
+	// 4. Intelligently handle filename conflicts
+	targetPath, reused, err := c.generateUniqueFilename(basePath, tmpPath)
+	if err != nil {
+		os.Remove(tmpPath)
+		logger.ErrorCF("feishu", "Failed to generate unique filename", map[string]any{
+			"error": err.Error(),
 		})
 		return ""
 	}
-	out.Close()
 
-	ref, err := store.Store(localPath, media.MediaMeta{
+	if reused {
+		// Reuse existing file, delete temp file
+		os.Remove(tmpPath)
+		logger.InfoCF("feishu", "Reusing existing file (deduplication)", map[string]any{
+			"existing_path": targetPath,
+		})
+
+		// Store the reference in MediaStore
+		ref, err := store.Store(targetPath, media.MediaMeta{
+			Filename:      filename,
+			Source:        "feishu",
+			CleanupPolicy: media.CleanupPolicyDeleteOnCleanup,
+		}, scope)
+		if err != nil {
+			logger.ErrorCF("feishu", "Failed to store downloaded resource", map[string]any{
+				"file_key": fileKey,
+				"error":    err.Error(),
+			})
+			return ""
+		}
+		return ref
+	}
+
+	// 5. Create directory and move file
+	monthDir := filepath.Dir(targetPath)
+	if err := os.MkdirAll(monthDir, 0o755); err != nil {
+		os.Remove(tmpPath)
+		logger.ErrorCF("feishu", "Failed to create month directory", map[string]any{
+			"error": err.Error(),
+		})
+		return ""
+	}
+
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		os.Remove(tmpPath)
+		logger.ErrorCF("feishu", "Failed to move temp file to final location", map[string]any{
+			"error": err.Error(),
+		})
+		return ""
+	}
+
+	// 6. Set file permissions (according to config)
+	if !c.config.DownloadReadonlyDisable {
+		// Set to read-only (prevent accidental deletion or modification)
+		if err := os.Chmod(targetPath, readOnlyFileMode); err != nil {
+			logger.WarnCF("feishu", "Failed to set file read-only", map[string]any{
+				"path":  targetPath,
+				"error": err.Error(),
+			})
+		}
+	}
+
+	// 7. Update index file
+	hash, _ := c.calculateFileHash(targetPath)
+	meta := FileMeta{
+		Filename:     filepath.Base(targetPath),
+		Hash:         hash,
+		Size:         size,
+		FileKey:      fileKey,
+		MessageID:    messageID,
+		DownloadedAt: time.Now(),
+	}
+
+	if err := c.updateIndexWithFile(monthDir, meta); err != nil {
+		// Index update failed, log warning but don't affect download
+		logger.WarnCF("feishu", "Failed to update index file", map[string]any{
+			"error": err.Error(),
+		})
+	}
+
+	logger.InfoCF("feishu", "Saved new file to download directory", map[string]any{
+		"filename":  filename,
+		"local_path": targetPath,
+		"hash":      hash,
+	})
+
+	ref, err := store.Store(targetPath, media.MediaMeta{
 		Filename:      filename,
 		Source:        "feishu",
 		CleanupPolicy: media.CleanupPolicyDeleteOnCleanup,
@@ -813,7 +1097,6 @@ func (c *FeishuChannel) downloadResource(
 			"file_key": fileKey,
 			"error":    err.Error(),
 		})
-		os.Remove(localPath)
 		return ""
 	}
 

--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -38,6 +38,7 @@ const errCodeTenantTokenInvalid = 99991663
 type FeishuChannel struct {
 	*channels.BaseChannel
 	config     config.FeishuConfig
+	globalCfg  *config.Config // Access to workspace configuration
 	client     *lark.Client
 	wsClient   *larkws.Client
 	tokenCache *tokenCache // custom cache that supports invalidation
@@ -48,7 +49,7 @@ type FeishuChannel struct {
 	cancel context.CancelFunc
 }
 
-func NewFeishuChannel(cfg config.FeishuConfig, bus *bus.MessageBus) (*FeishuChannel, error) {
+func NewFeishuChannel(cfg config.FeishuConfig, bus *bus.MessageBus, globalCfg *config.Config) (*FeishuChannel, error) {
 	base := channels.NewBaseChannel("feishu", cfg, bus, cfg.AllowFrom,
 		channels.WithGroupTrigger(cfg.GroupTrigger),
 		channels.WithReasoningChannelID(cfg.ReasoningChannelID),
@@ -62,6 +63,7 @@ func NewFeishuChannel(cfg config.FeishuConfig, bus *bus.MessageBus) (*FeishuChan
 	ch := &FeishuChannel{
 		BaseChannel: base,
 		config:      cfg,
+		globalCfg:   globalCfg,
 		tokenCache:  tc,
 		client:      lark.NewClient(cfg.AppID, cfg.AppSecret(), opts...),
 	}
@@ -642,8 +644,86 @@ func (c *FeishuChannel) downloadInboundMedia(
 	return refs
 }
 
+// resolveDownloadDir resolves the download directory based on configuration.
+// Returns the resolved directory path, or empty string if TempDir should be used.
+func (c *FeishuChannel) resolveDownloadDir() string {
+	downloadDir := c.config.DownloadDir
+	if downloadDir == "" {
+		// Default to system TempDir
+		return ""
+	}
+
+	// Expand ~ if present
+	if strings.HasPrefix(downloadDir, "~") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			logger.WarnCF("feishu", "Failed to expand home directory, falling back to TempDir", map[string]any{
+				"error": err.Error(),
+			})
+			return ""
+		}
+		downloadDir = filepath.Join(homeDir, downloadDir[1:])
+	}
+
+	// If path is relative, resolve it relative to workspace
+	if !filepath.IsAbs(downloadDir) {
+		downloadDir = filepath.Join(c.globalCfg.WorkspacePath(), downloadDir)
+	}
+
+	// Convert to absolute path (clean any .. or . components)
+	absPath, err := filepath.Abs(downloadDir)
+	if err != nil {
+		logger.WarnCF("feishu", "Failed to resolve download directory, falling back to TempDir", map[string]any{
+			"path":  downloadDir,
+			"error": err.Error(),
+		})
+		return ""
+	}
+
+	// Validate the resolved path is accessible
+	if err := c.validateAndCreateDir(absPath); err != nil {
+		logger.WarnCF("feishu", "Configured download_dir not accessible, falling back to TempDir", map[string]any{
+			"path":  absPath,
+			"error": err.Error(),
+		})
+		return ""
+	}
+
+	return absPath
+}
+
+// validateAndCreateDir validates that a directory path is accessible and creates it if needed.
+func (c *FeishuChannel) validateAndCreateDir(dir string) error {
+	// Check if path exists and is a directory
+	info, err := os.Stat(dir)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("path exists but is not a directory")
+		}
+		// Test write permission by creating a temporary file
+		testFile := filepath.Join(dir, ".picoclaw_write_test")
+		f, err := os.Create(testFile)
+		if err != nil {
+			return fmt.Errorf("directory not writable: %w", err)
+		}
+		f.Close()
+		os.Remove(testFile)
+		return nil
+	}
+
+	// Directory doesn't exist, try to create it
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("failed to access directory: %w", err)
+}
+
 // downloadResource downloads a message resource (image/file) from Feishu,
-// writes it to the project media directory, and stores the reference in MediaStore.
+// writes it to the configured media directory, and stores the reference in MediaStore.
 // fallbackExt (e.g. ".jpg") is appended when the resolved filename has no extension.
 func (c *FeishuChannel) downloadResource(
 	ctx context.Context,
@@ -692,14 +772,16 @@ func (c *FeishuChannel) downloadResource(
 		filename += fallbackExt
 	}
 
-	// Write to the shared picoclaw_media directory using a unique name to avoid collisions.
-	mediaDir := media.TempDir()
-	if mkdirErr := os.MkdirAll(mediaDir, 0o700); mkdirErr != nil {
-		logger.ErrorCF("feishu", "Failed to create media directory", map[string]any{
-			"error": mkdirErr.Error(),
-		})
-		return ""
+	// Determine download directory
+	mediaDir := c.resolveDownloadDir()
+	if mediaDir == "" {
+		// Fallback to TempDir
+		mediaDir = media.TempDir()
 	}
+
+	logger.DebugCF("feishu", "Downloading resource to directory", map[string]any{
+		"directory": mediaDir,
+	})
 	ext := filepath.Ext(filename)
 	localPath := filepath.Join(mediaDir, utils.SanitizeFilename(messageID+"-"+fileKey+ext))
 

--- a/pkg/channels/feishu/feishu_64_test.go
+++ b/pkg/channels/feishu/feishu_64_test.go
@@ -3,8 +3,10 @@
 package feishu
 
 import (
+	"os"
 	"testing"
 
+	"github.com/sipeed/picoclaw/pkg/config"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 )
 
@@ -275,6 +277,220 @@ func TestExtractFeishuSenderID(t *testing.T) {
 			got := extractFeishuSenderID(tt.sender)
 			if got != tt.want {
 				t.Errorf("extractFeishuSenderID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateAndCreateDir(t *testing.T) {
+	tests := []struct {
+		name    string
+		dir     string
+		setup   func() string // 创建测试目录并返回路径，返回空字符串表示不创建
+		wantErr bool
+		cleanup func(string)  // 清理函数
+	}{
+		{
+			name: "directory exists and is writable",
+			setup: func() string {
+				dir := t.TempDir()
+				return dir
+			},
+			wantErr: false,
+		},
+		{
+			name: "directory does not exist - creates successfully",
+			setup: func() string {
+				baseDir := t.TempDir()
+				newDir := baseDir + "/newdir/subdir"
+				return newDir
+			},
+			wantErr: false,
+		},
+		{
+			name: "path exists but is a file not directory",
+			setup: func() string {
+				dir := t.TempDir()
+				filePath := dir + "/notadir"
+				// 创建一个文件
+				if err := os.WriteFile(filePath, []byte("test"), 0o644); err != nil {
+					t.Fatalf("failed to create test file: %v", err)
+				}
+				return filePath
+			},
+			wantErr: true,
+		},
+		{
+			name: "directory exists but not writable",
+			setup: func() string {
+				dir := t.TempDir()
+				// 在 Unix 系统上，通过 chmod 移除写权限来测试
+				// 注意：这在 Windows 上可能不工作
+				return dir
+			},
+			wantErr: false, // 实际上 TempDir 通常是可写的，这个测试场景较难模拟
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.setup()
+			if dir == "" {
+				t.Skip("test setup returned empty directory")
+			}
+
+			// 创建一个测试用的 FeishuChannel 实例
+			channel := &FeishuChannel{
+				globalCfg: &config.Config{},
+			}
+			err := channel.validateAndCreateDir(dir)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateAndCreateDir() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// 如果期望成功，验证目录确实存在且是目录
+			if !tt.wantErr && err == nil {
+				info, statErr := os.Stat(dir)
+				if statErr != nil {
+					t.Errorf("directory %s does not exist after validation: %v", dir, statErr)
+				}
+				if info != nil && !info.IsDir() {
+					t.Errorf("path %s exists but is not a directory", dir)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveDownloadDir(t *testing.T) {
+	tests := []struct {
+		name        string
+		downloadDir string
+		workspace   string
+		setup       func() string // 创建测试目录并返回路径
+		wantEmpty   bool          // 是否期望返回空字符串
+		cleanup     func(string)  // 清理函数
+	}{
+		{
+			name:        "no download dir configured returns empty",
+			downloadDir: "",
+			workspace:   "/workspace",
+			wantEmpty:   true,
+		},
+		{
+			name:        "existing directory returns as-is",
+			downloadDir: "",
+			workspace:   "/workspace",
+			setup: func() string {
+				dir := t.TempDir()
+				return dir
+			},
+			wantEmpty: false,
+		},
+		{
+			name:        "non-existing directory is created",
+			downloadDir: "",
+			workspace:   "/workspace",
+			setup: func() string {
+				baseDir := t.TempDir()
+				newDir := baseDir + "/newdir/subdir"
+				return newDir
+			},
+			wantEmpty: false,
+		},
+		{
+			name:        "path exists but is a file returns empty",
+			downloadDir: "",
+			workspace:   "/workspace",
+			setup: func() string {
+				dir := t.TempDir()
+				filePath := dir + "/notadir"
+				if err := os.WriteFile(filePath, []byte("test"), 0o644); err != nil {
+					t.Fatalf("failed to create test file: %v", err)
+				}
+				return filePath
+			},
+			wantEmpty: true,
+		},
+		{
+			name:        "relative path resolves relative to workspace",
+			downloadDir: "downloads",
+			workspace:   "",
+			setup:       func() string { return "" }, // Dummy setup
+			wantEmpty:   false,
+		},
+		{
+			name:        "absolute path remains absolute",
+			downloadDir: "",
+			workspace:   "",
+			setup: func() string {
+				// Return absolute path
+				return t.TempDir()
+			},
+			wantEmpty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var downloadDir string
+			var workspace string
+
+			if tt.downloadDir != "" {
+				downloadDir = tt.downloadDir
+			}
+
+			// For relative path test, create a temp workspace
+			if tt.name == "relative path resolves relative to workspace" {
+				workspace = t.TempDir()
+			} else if tt.setup != nil {
+				downloadDir = tt.setup()
+			} else {
+				workspace = tt.workspace
+			}
+
+			// 创建测试用的 FeishuChannel 实例
+			channel := &FeishuChannel{
+				config: config.FeishuConfig{
+					DownloadDir: downloadDir,
+				},
+				globalCfg: &config.Config{
+					Agents: config.AgentsConfig{
+						Defaults: config.AgentDefaults{
+							Workspace: workspace,
+						},
+					},
+				},
+			}
+
+			// 调用被测试的函数
+			got := channel.resolveDownloadDir()
+
+			// 验证结果
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("resolveDownloadDir() = %q, want empty string", got)
+				}
+			} else {
+				if got == "" {
+					t.Errorf("resolveDownloadDir() returned empty string, want non-empty")
+				}
+
+				// 验证目录存在且可访问
+				if got != "" {
+					info, err := os.Stat(got)
+					if err != nil {
+						t.Errorf("resolveDownloadDir() returned %q but stat failed: %v", got, err)
+					} else if !info.IsDir() {
+						t.Errorf("resolveDownloadDir() returned %q but it's not a directory", got)
+					}
+				}
+			}
+
+			// 清理
+			if tt.cleanup != nil {
+				tt.cleanup(got)
 			}
 		})
 	}

--- a/pkg/channels/feishu/feishu_64_test.go
+++ b/pkg/channels/feishu/feishu_64_test.go
@@ -3,8 +3,13 @@
 package feishu
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/sipeed/picoclaw/pkg/config"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
@@ -493,5 +498,440 @@ func TestResolveDownloadDir(t *testing.T) {
 				tt.cleanup(got)
 			}
 		})
+	}
+}
+
+func TestGenerateUniqueFilename(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseName   string
+		tmpContent string
+		setupFiles func(string) // 创建已存在的文件
+		wantSuffix string       // 期望的文件名后缀（空表示原名）
+		wantReused bool         // 期望是否重用
+	}{
+		{
+			name:       "returns base path when file doesn't exist",
+			baseName:   "test.jpg",
+			tmpContent: "new content",
+			setupFiles: func(string) {},
+			wantSuffix: "",
+			wantReused: false,
+		},
+		{
+			name:       "reuses file when hash and size match",
+			baseName:   "test.jpg",
+			tmpContent: "same content",
+			setupFiles: func(dir string) {
+				_ = os.WriteFile(filepath.Join(dir, "test.jpg"), []byte("same content"), 0o644)
+			},
+			wantSuffix: "",
+			wantReused: true,
+		},
+		{
+			name:       "adds suffix when file exists with different content",
+			baseName:   "test.jpg",
+			tmpContent: "different content",
+			setupFiles: func(dir string) {
+				_ = os.WriteFile(filepath.Join(dir, "test.jpg"), []byte("old content"), 0o644)
+			},
+			wantSuffix: "-1.jpg",
+			wantReused:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			basePath := filepath.Join(dir, tt.baseName)
+			tt.setupFiles(dir)
+
+			// Create temporary file with test content
+			tmpFile, err := os.CreateTemp("", "test_*")
+			if err != nil {
+				t.Fatalf("failed to create temp file: %v", err)
+			}
+			if _, err := tmpFile.WriteString(tt.tmpContent); err != nil {
+				t.Fatalf("failed to write to temp file: %v", err)
+			}
+			tmpFile.Close()
+
+			channel := &FeishuChannel{}
+			gotPath, gotReused, err := channel.generateUniqueFilename(basePath, tmpFile.Name())
+
+			if err != nil {
+				t.Errorf("generateUniqueFilename() error = %v", err)
+				return
+			}
+
+			// Check suffix
+			gotBase := filepath.Base(gotPath)
+			wantBase := tt.baseName
+			if tt.wantSuffix != "" {
+				ext := filepath.Ext(tt.baseName)
+				nameWithoutExt := strings.TrimSuffix(tt.baseName, ext)
+				wantBase = nameWithoutExt + tt.wantSuffix
+			}
+
+			if gotBase != wantBase {
+				t.Errorf("generateUniqueFilename() filename = %q, want %q", gotBase, wantBase)
+			}
+
+			if gotReused != tt.wantReused {
+				t.Errorf("generateUniqueFilename() reused = %v, want %v", gotReused, tt.wantReused)
+			}
+
+			// Clean up
+			os.Remove(tmpFile.Name())
+		})
+	}
+}
+
+func TestCalculateFileHash(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantHash  string
+		wantError bool
+	}{
+		{
+			name:      "calculates SHA-256 hash correctly",
+			content:   "hello world",
+			wantHash:  "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9", // SHA-256 of "hello world"
+			wantError: false,
+		},
+		{
+			name:      "handles empty content",
+			content:   "",
+			wantHash:  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", // SHA-256 of empty string
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFile := filepath.Join(t.TempDir(), "test.txt")
+
+			if err := os.WriteFile(testFile, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("failed to create test file: %v", err)
+			}
+
+			channel := &FeishuChannel{}
+			got, err := channel.calculateFileHash(testFile)
+
+			if (err != nil) != tt.wantError {
+				t.Errorf("calculateFileHash() error = %v, wantError %v", err, tt.wantError)
+				return
+			}
+
+			if got != tt.wantHash {
+				t.Errorf("calculateFileHash() = %q, want %q", got, tt.wantHash)
+			}
+		})
+	}
+}
+
+func TestGenerateFilePath(t *testing.T) {
+	tests := []struct {
+		name       string
+		downloadDir string
+		filename    string
+		wantPrefix  string // 期望路径前缀（年/月部分会变化）
+	}{
+		{
+			name:       "generates correct path structure",
+			downloadDir: "/downloads",
+			filename:    "report.pdf",
+			wantPrefix:  "/downloads/",
+		},
+		{
+			name:       "sanitizes filename",
+			downloadDir: "/downloads",
+			filename:    "report:name.pdf",
+			wantPrefix:  "/downloads/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			channel := &FeishuChannel{}
+			got := channel.generateFilePath(tt.downloadDir, tt.filename)
+
+			if !filepath.IsAbs(got) {
+				t.Errorf("generateFilePath() returned relative path, want absolute")
+			}
+
+			// Check path format: {download_dir}/{year}/{month}/{sanitized_filename}
+			if !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("generateFilePath() = %q, want prefix %q", got, tt.wantPrefix)
+			}
+
+			// Check that filename is sanitized
+			base := filepath.Base(got)
+			if strings.Contains(base, ":") || strings.Contains(base, "*") {
+				t.Errorf("generateFilePath() filename not sanitized: %q", base)
+			}
+		})
+	}
+}
+
+func TestLoadDirectoryIndex(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupIndex    func(string) error
+		wantFileCount int
+		wantVersion   int
+	}{
+		{
+			name:          "returns empty index when file doesn't exist",
+			setupIndex:    func(string) error { return nil },
+			wantFileCount: 0,
+			wantVersion:   1,
+		},
+		{
+			name: "loads valid index file",
+			setupIndex: func(dir string) error {
+				index := DirectoryIndex{
+					Version: 1,
+					Files: []FileMeta{
+						{
+							Filename:     "test.pdf",
+							Hash:         "abc123",
+							Size:         1024,
+							FileKey:      "key123",
+							MessageID:    "msg123",
+							DownloadedAt: time.Now(),
+						},
+					},
+				}
+				data, err := json.Marshal(index)
+				if err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(dir, indexFileName), data, 0o644)
+			},
+			wantFileCount: 1,
+			wantVersion:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			_ = tt.setupIndex(dir)
+
+			channel := &FeishuChannel{}
+			index, err := channel.loadDirectoryIndex(dir)
+
+			if err != nil {
+				t.Errorf("loadDirectoryIndex() error = %v", err)
+				return
+			}
+
+			if len(index.Files) != tt.wantFileCount {
+				t.Errorf("loadDirectoryIndex() file count = %d, want %d", len(index.Files), tt.wantFileCount)
+			}
+
+			if index.Version != tt.wantVersion {
+				t.Errorf("loadDirectoryIndex() version = %d, want %d", index.Version, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestSaveDirectoryIndex(t *testing.T) {
+	dir := t.TempDir()
+
+	index := &DirectoryIndex{
+		Version: 1,
+		Files: []FileMeta{
+			{
+				Filename:     "test.pdf",
+				Hash:         "abc123",
+				Size:         1024,
+				FileKey:      "key123",
+				MessageID:    "msg123",
+				DownloadedAt: time.Now(),
+			},
+		},
+	}
+
+	channel := &FeishuChannel{}
+	err := channel.saveDirectoryIndex(dir, index)
+
+	if err != nil {
+		t.Errorf("saveDirectoryIndex() error = %v", err)
+		return
+	}
+
+	// Verify file was created
+	indexPath := filepath.Join(dir, indexFileName)
+	if _, err := os.Stat(indexPath); os.IsNotExist(err) {
+		t.Errorf("saveDirectoryIndex() file not created")
+		return
+	}
+
+	// Verify content
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Errorf("failed to read index file: %v", err)
+		return
+	}
+
+	var loaded DirectoryIndex
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Errorf("failed to unmarshal index: %v", err)
+		return
+	}
+
+	if len(loaded.Files) != 1 {
+		t.Errorf("saveDirectoryIndex() saved wrong number of files: got %d, want 1", len(loaded.Files))
+	}
+}
+
+func TestUpdateIndexWithFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(string) (*DirectoryIndex, error)
+		meta     FileMeta
+		verify   func(*DirectoryIndex) error
+	}{
+		{
+			name: "adds new file to empty index",
+			setup: func(dir string) (*DirectoryIndex, error) {
+				return &DirectoryIndex{Version: 1, Files: []FileMeta{}}, nil
+			},
+			meta: FileMeta{
+				Filename:     "new.pdf",
+				Hash:         "abc123",
+				Size:         1024,
+				FileKey:      "key123",
+				MessageID:    "msg123",
+				DownloadedAt: time.Now(),
+			},
+			verify: func(index *DirectoryIndex) error {
+				if len(index.Files) != 1 {
+					return fmt.Errorf("expected 1 file, got %d", len(index.Files))
+				}
+				if index.Files[0].Filename != "new.pdf" {
+					return fmt.Errorf("expected filename new.pdf, got %s", index.Files[0].Filename)
+				}
+				return nil
+			},
+		},
+		{
+			name: "updates existing file in index",
+			setup: func(dir string) (*DirectoryIndex, error) {
+				index := &DirectoryIndex{
+					Version: 1,
+					Files: []FileMeta{
+						{
+							Filename:     "existing.pdf",
+							Hash:         "old123",
+							Size:         512,
+							FileKey:      "key123",
+							MessageID:    "msg123",
+							DownloadedAt: time.Now(),
+						},
+					},
+				}
+				return index, nil
+			},
+			meta: FileMeta{
+				Filename:     "existing.pdf",
+				Hash:         "new456",
+				Size:         2048,
+				FileKey:      "key456",
+				MessageID:    "msg456",
+				DownloadedAt: time.Now(),
+			},
+			verify: func(index *DirectoryIndex) error {
+				if len(index.Files) != 1 {
+					return fmt.Errorf("expected 1 file, got %d", len(index.Files))
+				}
+				if index.Files[0].Hash != "new456" {
+					return fmt.Errorf("expected hash new456, got %s", index.Files[0].Hash)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			_, _ = tt.setup(dir)
+
+			channel := &FeishuChannel{}
+			err := channel.updateIndexWithFile(dir, tt.meta)
+
+			if err != nil {
+				t.Errorf("updateIndexWithFile() error = %v", err)
+				return
+			}
+
+			// Verify
+			index, err := channel.loadDirectoryIndex(dir)
+			if err != nil {
+				t.Errorf("failed to load index for verification: %v", err)
+				return
+			}
+
+			if err := tt.verify(index); err != nil {
+				t.Errorf("verification failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestFindFileByKeyInIndex(t *testing.T) {
+	dir := t.TempDir()
+
+	// Setup: Create index with test data
+	index := &DirectoryIndex{
+		Version: 1,
+		Files: []FileMeta{
+			{
+				Filename:     "file1.pdf",
+				Hash:         "abc123",
+				Size:         1024,
+				FileKey:      "key1",
+				MessageID:    "msg1",
+				DownloadedAt: time.Now(),
+			},
+			{
+				Filename:     "file2.pdf",
+				Hash:         "def456",
+				Size:         2048,
+				FileKey:      "key2",
+				MessageID:    "msg2",
+				DownloadedAt: time.Now(),
+			},
+		},
+	}
+
+	channel := &FeishuChannel{}
+	_ = channel.saveDirectoryIndex(dir, index)
+
+	// Test: Find existing file
+	meta, err := channel.findFileByKeyInIndex(dir, "key1")
+	if err != nil {
+		t.Errorf("findFileByKeyInIndex() error = %v", err)
+		return
+	}
+
+	if meta == nil {
+		t.Errorf("findFileByKeyInIndex() = nil, want file metadata")
+		return
+	}
+
+	if meta.Filename != "file1.pdf" {
+		t.Errorf("findFileByKeyInIndex() filename = %q, want file1.pdf", meta.Filename)
+	}
+
+	// Test: Find non-existing file
+	meta, _ = channel.findFileByKeyInIndex(dir, "key999")
+	if meta != nil {
+		t.Errorf("findFileByKeyInIndex() = %v, want nil", meta)
 	}
 }

--- a/pkg/channels/feishu/init.go
+++ b/pkg/channels/feishu/init.go
@@ -8,6 +8,6 @@ import (
 
 func init() {
 	channels.RegisterFactory("feishu", func(cfg *config.Config, b *bus.MessageBus) (channels.Channel, error) {
-		return NewFeishuChannel(cfg.Channels.Feishu, b)
+		return NewFeishuChannel(cfg.Channels.Feishu, b, cfg)
 	})
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -452,7 +452,8 @@ type FeishuConfig struct {
 	ReasoningChannelID  string              `json:"reasoning_channel_id"    env:"PICOCLAW_CHANNELS_FEISHU_REASONING_CHANNEL_ID"`
 	RandomReactionEmoji FlexibleStringSlice `json:"random_reaction_emoji"   env:"PICOCLAW_CHANNELS_FEISHU_RANDOM_REACTION_EMOJI"`
 	IsLark              bool                `json:"is_lark"                 env:"PICOCLAW_CHANNELS_FEISHU_IS_LARK"`
-	DownloadDir         string              `json:"download_dir,omitempty"  env:"PICOCLAW_CHANNELS_FEISHU_DOWNLOAD_DIR"`
+	DownloadDir             string              `json:"download_dir,omitempty"              env:"PICOCLAW_CHANNELS_FEISHU_DOWNLOAD_DIR"`
+	DownloadReadonlyDisable bool                `json:"download_readonly_disable,omitempty" env:"PICOCLAW_CHANNELS_FEISHU_DOWNLOAD_READONLY_DISABLE"`
 	secDirty            bool
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -452,6 +452,7 @@ type FeishuConfig struct {
 	ReasoningChannelID  string              `json:"reasoning_channel_id"    env:"PICOCLAW_CHANNELS_FEISHU_REASONING_CHANNEL_ID"`
 	RandomReactionEmoji FlexibleStringSlice `json:"random_reaction_emoji"   env:"PICOCLAW_CHANNELS_FEISHU_RANDOM_REACTION_EMOJI"`
 	IsLark              bool                `json:"is_lark"                 env:"PICOCLAW_CHANNELS_FEISHU_IS_LARK"`
+	DownloadDir         string              `json:"download_dir,omitempty"  env:"PICOCLAW_CHANNELS_FEISHU_DOWNLOAD_DIR"`
 	secDirty            bool
 }
 

--- a/pkg/utils/media.go
+++ b/pkg/utils/media.go
@@ -56,8 +56,23 @@ func SanitizeFilename(filename string) string {
 
 	// Remove any directory traversal attempts
 	base = strings.ReplaceAll(base, "..", "")
-	base = strings.ReplaceAll(base, "/", "_")
-	base = strings.ReplaceAll(base, "\\", "_")
+
+	// Replace filesystem invalid characters with underscore
+	// These characters are not allowed in filenames on various OS:
+	// Windows: < > : " / \ | ? *
+	// Unix/macOS: / (and : can cause issues in Finder)
+	invalidChars := []string{"/", "\\", ":", "*", "?", "\"", "<", ">", "|"}
+	for _, char := range invalidChars {
+		base = strings.ReplaceAll(base, char, "_")
+	}
+
+	// Trim spaces and dots from start/end
+	base = strings.Trim(base, " .")
+
+	// Ensure filename is not empty after sanitization
+	if base == "" {
+		base = "unnamed_file"
+	}
 
 	return base
 }

--- a/web/frontend/src/components/channels/channel-forms/feishu-form.tsx
+++ b/web/frontend/src/components/channels/channel-forms/feishu-form.tsx
@@ -126,6 +126,16 @@ export function FeishuForm({
           placeholder={t("channels.field.allowFromPlaceholder")}
         />
       </Field>
+      <Field
+        label={t("channels.field.downloadDir")}
+        hint={t("channels.form.desc.downloadDir")}
+      >
+        <Input
+          value={asString(config.download_dir)}
+          onChange={(e) => onChange("download_dir", e.target.value)}
+          placeholder={t("channels.field.downloadDirPlaceholder")}
+        />
+      </Field>
     </div>
   )
 }

--- a/web/frontend/src/components/channels/channel-forms/feishu-form.tsx
+++ b/web/frontend/src/components/channels/channel-forms/feishu-form.tsx
@@ -136,6 +136,12 @@ export function FeishuForm({
           placeholder={t("channels.field.downloadDirPlaceholder")}
         />
       </Field>
+      <SwitchCardField
+        label={t("channels.field.downloadReadonlyDisable")}
+        hint={t("channels.form.desc.downloadReadonlyDisable")}
+        checked={asBool(config.download_readonly_disable)}
+        onCheckedChange={(checked) => onChange("download_readonly_disable", checked)}
+      />
     </div>
   )
 }

--- a/web/frontend/src/i18n/locales/en.json
+++ b/web/frontend/src/i18n/locales/en.json
@@ -300,6 +300,8 @@
       "allowFromPlaceholder": "e.g. 123456, 789012",
       "allowOrigins": "Allow Origins",
       "allowOriginsPlaceholder": "e.g. https://example.com, http://localhost:5173",
+      "downloadDir": "Download Directory",
+      "downloadDirPlaceholder": "downloads or /absolute/path",
       "secretPlaceholder": "Enter secret",
       "secretHintSet": "A value is already set. Leave blank to keep it unchanged."
     },
@@ -331,6 +333,7 @@
         "groupTriggerPrefixes": "Custom group-chat trigger prefixes, separated by commas.",
         "isLark": "Use Lark international domain (open.larksuite.com) instead of Feishu domain (open.feishu.cn).",
         "allowFrom": "Allowed user or group IDs, separated by commas.",
+        "downloadDir": "Custom directory for downloaded files. Relative paths are resolved from the workspace directory. Leave empty to use system temp directory.",
         "allowOrigins": "Allowed origin domains, separated by commas.",
         "wsUrl": "WebSocket service URL.",
         "reconnectInterval": "Reconnect interval after disconnection (seconds).",

--- a/web/frontend/src/i18n/locales/en.json
+++ b/web/frontend/src/i18n/locales/en.json
@@ -302,6 +302,7 @@
       "allowOriginsPlaceholder": "e.g. https://example.com, http://localhost:5173",
       "downloadDir": "Download Directory",
       "downloadDirPlaceholder": "downloads or /absolute/path",
+      "downloadReadonlyDisable": "Disable Download Readonly",
       "secretPlaceholder": "Enter secret",
       "secretHintSet": "A value is already set. Leave blank to keep it unchanged."
     },
@@ -334,6 +335,7 @@
         "isLark": "Use Lark international domain (open.larksuite.com) instead of Feishu domain (open.feishu.cn).",
         "allowFrom": "Allowed user or group IDs, separated by commas.",
         "downloadDir": "Custom directory for downloaded files. Relative paths are resolved from the workspace directory. Leave empty to use system temp directory.",
+        "downloadReadonlyDisable": "Disable read-only protection for downloaded files (default: read-only enabled). When enabled, files can be edited directly.",
         "allowOrigins": "Allowed origin domains, separated by commas.",
         "wsUrl": "WebSocket service URL.",
         "reconnectInterval": "Reconnect interval after disconnection (seconds).",

--- a/web/frontend/src/i18n/locales/zh.json
+++ b/web/frontend/src/i18n/locales/zh.json
@@ -302,6 +302,7 @@
       "allowOriginsPlaceholder": "例如 https://example.com, http://localhost:5173",
       "downloadDir": "下载目录",
       "downloadDirPlaceholder": "downloads 或 /absolute/path",
+      "downloadReadonlyDisable": "禁用下载文件只读",
       "secretPlaceholder": "输入密钥",
       "secretHintSet": "已设置密钥，留空表示不修改。"
     },
@@ -334,6 +335,7 @@
         "isLark": "使用 Lark 国际版域名（open.larksuite.com）替代飞书域名（open.feishu.cn）。",
         "allowFrom": "允许访问的用户或群组 ID，多个值用逗号分隔。",
         "downloadDir": "自定义下载文件目录。相对路径将基于工作目录解析，留空则使用系统临时目录。",
+        "downloadReadonlyDisable": "禁用下载文件的只读保护（默认：启用只读）。开启后，下载的文件可以直接编辑。",
         "allowOrigins": "允许访问的来源域名，多个值用逗号分隔。",
         "wsUrl": "WebSocket 服务地址。",
         "reconnectInterval": "断线后的重连间隔（秒）。",

--- a/web/frontend/src/i18n/locales/zh.json
+++ b/web/frontend/src/i18n/locales/zh.json
@@ -300,6 +300,8 @@
       "allowFromPlaceholder": "例如 123456, 789012",
       "allowOrigins": "允许来源域名",
       "allowOriginsPlaceholder": "例如 https://example.com, http://localhost:5173",
+      "downloadDir": "下载目录",
+      "downloadDirPlaceholder": "downloads 或 /absolute/path",
       "secretPlaceholder": "输入密钥",
       "secretHintSet": "已设置密钥，留空表示不修改。"
     },
@@ -331,6 +333,7 @@
         "groupTriggerPrefixes": "群聊触发前缀，多个值用逗号分隔。",
         "isLark": "使用 Lark 国际版域名（open.larksuite.com）替代飞书域名（open.feishu.cn）。",
         "allowFrom": "允许访问的用户或群组 ID，多个值用逗号分隔。",
+        "downloadDir": "自定义下载文件目录。相对路径将基于工作目录解析，留空则使用系统临时目录。",
         "allowOrigins": "允许访问的来源域名，多个值用逗号分隔。",
         "wsUrl": "WebSocket 服务地址。",
         "reconnectInterval": "断线后的重连间隔（秒）。",


### PR DESCRIPTION
## 📝 Description

Refactor Feishu channel file download mechanism with improved organization and intelligent deduplication.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [X] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

#2030

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

While using feishu, receiving file will save to tmp directory, I add a new option to allow user to save in species dir.

Is an optional config, leave it empty means the same behiver like before.

  **Directory Structure Simplification:**
  - Human-readable structure: `{download_dir}/{year}/{month}/{filename}`
  - Files are now organized by time (e.g., `downloads/2026/03/report.pdf`)
  - Preserves original filenames with comprehensive character sanitization

  **Intelligent Deduplication:**
  - Smart hash-based deduplication only checks when same-month + same-filename conflicts occur
  - Same hash + size → reuse existing file (avoid duplicate downloads)
  - Different hash/size → auto-generate suffix (`file-1.pdf`, `file-2.pdf`)

  **Lightweight Directory Indexing:**
  - Each directory has its own `.feishu_index.json` for metadata tracking
  - Records file hash, size, Feishu file_key, message_id, and download time
  - Enables file re-downloading if local files are lost
  - Independent indexes minimize impact of corruption

  **Configurable Read-Only Protection:**
  - New config field `download_readonly_disable` (default: `false`)
  - When disabled (default), downloaded files are set to read-only (0o444) to prevent accidental modification
  - Users can enable editing by setting `download_readonly_disable: true`

  **Files Modified:**
  - `pkg/channels/feishu/feishu_64.go`: Refactored download logic, added index operations
  - `pkg/channels/feishu/feishu_64_test.go`: Comprehensive unit tests for new functionality
  - `pkg/utils/media.go`: Enhanced `SanitizeFilename()` with comprehensive invalid character filtering
  - `pkg/config/config.go`: Added `DownloadReadonlyDisable` field
  - `web/frontend/src/components/channels/channel-forms/feishu-form.tsx`: Added UI toggle
  - `web/frontend/src/i18n/locales/en.json` and `zh.json`: Added translations

## 🧪 Test Environment
- **Hardware:** Remote PC
- **OS:** Windows Server 2022
- **Model/Provider:** DoubaoSeed
- **Channels:** Feishu


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<img width="1038" height="266" alt="image" src="https://github.com/user-attachments/assets/6cb6ecc1-41e6-4d52-8958-16f3f6919340" />

<img width="751" height="180" alt="image" src="https://github.com/user-attachments/assets/0e8a64c1-e223-4f6f-bfdf-25619340d9db" />


</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.