### PR TITLE
feat(agent): update requeueInboundMessage to publish back to inbound bus

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1393,11 +1393,7 @@ func (al *AgentLoop) requeueInboundMessage(msg bus.InboundMessage) error {
 	}
 	pubCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	return al.bus.PublishOutbound(pubCtx, bus.OutboundMessage{
-		Channel: msg.Channel,
-		ChatID:  msg.ChatID,
-		Content: msg.Content,
-	})
+	return al.bus.PublishInbound(pubCtx, msg)
 }
 
 func (al *AgentLoop) processSystemMessage(

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -225,6 +225,42 @@ func TestProcessMessage_UseCommandLoadsRequestedSkill(t *testing.T) {
 	}
 }
 
+func TestRequeueInboundMessage_PublishesBackToInboundBus(t *testing.T) {
+	msgBus := bus.NewMessageBus()
+	al := &AgentLoop{bus: msgBus}
+
+	original := bus.InboundMessage{
+		Channel:   "feishu",
+		SenderID:  "feishu:user-1",
+		ChatID:    "chat-1",
+		Content:   "follow-up message",
+		MessageID: "msg-1",
+	}
+
+	if err := al.requeueInboundMessage(original); err != nil {
+		t.Fatalf("requeueInboundMessage() error = %v", err)
+	}
+
+	select {
+	case got := <-msgBus.InboundChan():
+		if got.Channel != original.Channel ||
+			got.SenderID != original.SenderID ||
+			got.ChatID != original.ChatID ||
+			got.Content != original.Content ||
+			got.MessageID != original.MessageID {
+			t.Fatalf("requeued message = %+v, want %+v", got, original)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for requeued inbound message")
+	}
+
+	select {
+	case outbound := <-msgBus.OutboundChan():
+		t.Fatalf("unexpected outbound message after requeue: %+v", outbound)
+	default:
+	}
+}
+
 func TestHandleCommand_UseCommandRejectsUnknownSkill(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := &config.Config{


### PR DESCRIPTION
## 📝 Description

`drainBusToSteering` temporarily stores messages not belonging to the current scope and calls `requeueInboundMessage` when handling concurrent inbound traffic.
This path must return messages to the main inbound processing chain; otherwise, subsequent messages may fail to reach the agent layer (e.g., subsequent messages after the first Feishu message being lost) or be incorrectly sent to outbound.

- Fix `requeueInboundMessage`: Change the requeue target to `PublishInbound` to keep the message type consistent with processing semantics.
- Preserve timeout context to avoid prolonged blocking under abnormal conditions.
- Add tests to verify:
- After requeue, messages can be retrieved from `InboundChan()`;
- They will not appear in `OutboundChan()`.



## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [ ] My code/docs follow the style of this project.
- [ ] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.