### PR TITLE
fix(frontend): align dm_scope options with backend constants

### DIFF
--- a/web/frontend/src/components/config/form-model.ts
+++ b/web/frontend/src/components/config/form-model.ts
@@ -33,18 +33,18 @@ export interface LauncherForm {
 
 export const DM_SCOPE_OPTIONS = [
   {
+    value: "per-account-channel-peer",
+    labelKey: "pages.config.session_scope_per_account_channel_peer",
+    labelDefault: "Per Account + Channel + Peer",
+    descKey: "pages.config.session_scope_per_account_channel_peer_desc",
+    descDefault: "Separate context for each user in each channel for each account.",
+  },
+  {
     value: "per-channel-peer",
     labelKey: "pages.config.session_scope_per_channel_peer",
     labelDefault: "Per Channel + Peer",
     descKey: "pages.config.session_scope_per_channel_peer_desc",
     descDefault: "Separate context for each user in each channel.",
-  },
-  {
-    value: "per-channel",
-    labelKey: "pages.config.session_scope_per_channel",
-    labelDefault: "Per Channel",
-    descKey: "pages.config.session_scope_per_channel_desc",
-    descDefault: "One shared context per channel.",
   },
   {
     value: "per-peer",
@@ -54,10 +54,10 @@ export const DM_SCOPE_OPTIONS = [
     descDefault: "One context per user across channels.",
   },
   {
-    value: "global",
-    labelKey: "pages.config.session_scope_global",
-    labelDefault: "Global",
-    descKey: "pages.config.session_scope_global_desc",
+    value: "main",
+    labelKey: "pages.config.session_scope_main",
+    labelDefault: "Main",
+    descKey: "pages.config.session_scope_main_desc",
     descDefault: "All messages share one global context.",
   },
 ] as const


### PR DESCRIPTION
Fixes #1992

## Problem
The frontend `dm_scope` options did not match backend `DMScope` constants, causing potential issues:

**Frontend options:**
- `per-channel-peer` ✓
- `per-channel` ❌ (not recognized by backend)
- `per-peer` ✓
- `global` ❌ (not recognized by backend)

**Backend DMScope constants:**
- `main` ❌ (missing from frontend)
- `per-peer` ✓
- `per-channel-peer` ✓
- `per-account-channel-peer` ❌ (missing from frontend)

## Impact
- Users selecting `per-channel` or `global` in frontend would have their config sent to backend with unrecognized values
- The backend would fall back to `main` scope for unrecognized values, causing unexpected behavior
- The `per-account-channel-peer` option (supported by backend) was not available in frontend

## Solution
- Replace `per-channel` with `per-account-channel-peer` to expose a backend-supported option
- Replace `global` with `main` to match backend DMScope constant

## Files Changed
- `web/frontend/src/components/config/form-model.ts`