### PR TITLE
preserve media store across config reloads

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -480,14 +480,17 @@ func restartServices(
 	}
 	fmt.Println("  ✓ Heartbeat service restarted")
 
-	runningServices.MediaStore = media.NewFileMediaStoreWithCleanup(media.MediaCleanerConfig{
-		Enabled:  cfg.Tools.MediaCleanup.Enabled,
-		MaxAge:   time.Duration(cfg.Tools.MediaCleanup.MaxAge) * time.Minute,
-		Interval: time.Duration(cfg.Tools.MediaCleanup.Interval) * time.Minute,
-	})
-	if fms, ok := runningServices.MediaStore.(*media.FileMediaStore); ok {
-		fms.Start()
-	}
+
+	if runningServices.MediaStore == nil {
+    runningServices.MediaStore = media.NewFileMediaStoreWithCleanup(media.MediaCleanerConfig{
+        Enabled:  cfg.Tools.MediaCleanup.Enabled,
+        MaxAge:   time.Duration(cfg.Tools.MediaCleanup.MaxAge) * time.Minute,
+        Interval: time.Duration(cfg.Tools.MediaCleanup.Interval) * time.Minute,
+    })
+    if fms, ok := runningServices.MediaStore.(*media.FileMediaStore); ok {
+        fms.Start()
+    }
+}
 	al.SetMediaStore(runningServices.MediaStore)
 
 	runningServices.ChannelManager, err = channels.NewManager(cfg, msgBus, runningServices.MediaStore)


### PR DESCRIPTION
## Bug Fix

Prevents loss of uploaded file references when using `/reload` command.

## Problem

When calling `/reload`, a new `FileMediaStore` was created with an empty `refs` map, causing all previously uploaded files to become inaccessible with error: media store: unknown ref: media://...

## Solution

Reuse the existing `MediaStore` instance instead of recreating it on every reload. The media store is now only created once on initial startup.

## Changes

- `pkg/gateway/gateway.go` (line 468): Wrap media store creation in `if runningServices.MediaStore == nil`

## Testing

1. Start picoclaw with Telegram enabled
2. Upload a file to the bot
3. Run `/reload` command
4. Ask bot to read the previously uploaded file
5. File should now be accessible (previously would fail with "unknown ref" error)

## Impact

- Users can now safely use `/reload` without breaking file uploads
- No breaking changes
- Backward compatible

## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.