### PR TITLE
fix(agent): use origin session key for system messages

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1451,8 +1451,10 @@ func (al *AgentLoop) processSystemMessage(
 		return "", fmt.Errorf("no default agent for system message")
 	}
 
-	// Use the origin session for context
-	sessionKey := routing.BuildAgentMainSessionKey(agent.ID)
+	sessionKey := msg.SessionKey
+	if sessionKey == "" {
+		sessionKey = routing.BuildAgentMainSessionKey(agent.ID)
+	}
 
 	return al.runAgentLoop(ctx, agent, processOptions{
 		SessionKey:      sessionKey,
@@ -2369,11 +2371,12 @@ turnLoop:
 
 				pubCtx, pubCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer pubCancel()
-				_ = al.bus.PublishInbound(pubCtx, bus.InboundMessage{
-					Channel:  "system",
-					SenderID: fmt.Sprintf("async:%s", asyncToolName),
-					ChatID:   fmt.Sprintf("%s:%s", ts.channel, ts.chatID),
-					Content:  content,
+				al.bus.PublishInbound(pubCtx, bus.InboundMessage{
+					Channel:    "system",
+					SenderID:   fmt.Sprintf("async:%s", asyncToolName),
+					ChatID:     fmt.Sprintf("%s:%s", ts.channel, ts.chatID),
+					Content:    content,
+					SessionKey: ts.sessionKey,
 				})
 			}
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -2926,3 +2926,49 @@ func TestProcessMessage_ContextOverflow_AnthropicStyle(t *testing.T) {
 		t.Fatalf("expected 2 calls for retry, got %d", provider.calls)
 	}
 }
+
+// TestProcessSystemMessage_UsesOriginSessionKey verifies that when an async tool
+// completes and publishes a system message with a SessionKey, the resulting turn
+// runs in that session rather than the default "agent:main:main" session.
+func TestProcessSystemMessage_UsesOriginSessionKey(t *testing.T) {
+	al := NewAgentLoop(&config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         t.TempDir(),
+				ModelName:         "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+			},
+		},
+	}, bus.NewMessageBus(), &mockProvider{})
+
+	const wantSessionKey = "agent:main:weixin:direct:testchatid"
+
+	sub := al.SubscribeEvents(32)
+	defer al.UnsubscribeEvents(sub.ID)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := al.processMessage(context.Background(), bus.InboundMessage{
+			Channel:    "system",
+			SenderID:   "async:spawn",
+			ChatID:     "weixin:testchatid",
+			Content:    "task completed",
+			SessionKey: wantSessionKey,
+		})
+		done <- err
+	}()
+
+	evt := waitForEvent(t, sub.C, 5*time.Second, func(e Event) bool {
+		return e.Kind == EventKindTurnStart
+	})
+
+	if evt.Meta.SessionKey != wantSessionKey {
+		t.Errorf("turn started with session_key=%q, want %q (got agent:main:main means bug is present)",
+			evt.Meta.SessionKey, wantSessionKey)
+	}
+
+	if err := <-done; err != nil {
+		t.Logf("processMessage returned error (acceptable in test env): %v", err)
+	}
+}


### PR DESCRIPTION
## 📝 Description

When an async spawn tool completes, its result is published as a system inbound message. Previously, `processSystemMessage` always resolved the session key via `BuildAgentMainSessionKey`, ignoring the origin turn's session and causing the follow-up turn to start in `agent:main:main` with an empty history instead of the caller's channel session (e.g. `agent:main:weixin:direct:<chatID>` ).

The root cause was two-fold: the async callback did not forward `ts.sessionKey` into the published `InboundMessage`, and `processSystemMessage` had no way to recover it. Unlike normal channel messages, system messages bypass `resolveMessageRoute`, so the session key cannot be re-derived from routing config — it must be carried explicitly.

Fix: pass `ts.sessionKey` in the system `InboundMessage.SessionKey` field, and have `processSystemMessage` prefer that value over the `BuildAgentMainSessionKey` fallback.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [ ] My code/docs follow the style of this project.
- [ ] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.