### PR TITLE
feat(agent): add self-update instructions for SOUL.md and USER.md

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -108,12 +108,20 @@ Your workspace is at: %s
 
 2. **Be helpful and accurate** - When using tools, briefly explain what you're doing.
 
-3. **Memory** - When interacting with me if something seems memorable, update %s/memory/MEMORY.md
+3. **Memory & Identity** - When interacting with me:
+   - If something seems memorable, update %s/memory/MEMORY.md
+   - If I tell you about yourself (your name, personality, traits), update %s/SOUL.md
+   - If I share my preferences, update %s/USER.md
+   Always briefly mention what you updated so I know.
 
 4. **Context summaries** - Conversation summaries provided as context are approximate references only. They may be incomplete or outdated. Always defer to explicit user instructions over summary content.
 
 %s`,
-		version, workspacePath, workspacePath, workspacePath, workspacePath, workspacePath, toolDiscovery)
+		version,
+		workspacePath, workspacePath, workspacePath, workspacePath,
+		workspacePath, workspacePath, workspacePath,
+		toolDiscovery,
+	)
 }
 
 func (cb *ContextBuilder) getDiscoveryRule() string {


### PR DESCRIPTION
## 📝 Description

Add instructions to the agent's system prompt telling it to self-update identity files when users share relevant information:

- **SOUL.md** — updated when the user describes the agent's name, personality, or traits
- **USER.md** — updated when the user shares their preferences

Previously, only `memory/MEMORY.md` was mentioned in the identity prompt. This change extends the existing rule to also cover identity files, enabling the agent to build and maintain its persona over time.

### Changes

In `pkg/agent/context.go`, the `getIdentity()` template's rule #3 is expanded from:

```
3. **Memory** - When interacting with me if something seems memorable, update {workspace}/memory/MEMORY.md
```

to:

```
3. **Memory & Identity** - When interacting with me:
   - If something seems memorable, update {workspace}/memory/MEMORY.md
   - If I tell you about yourself (your name, personality, traits), update {workspace}/SOUL.md
   - If I share my preferences, update {workspace}/USER.md
   Always briefly mention what you updated so I know.
```

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Addresses #1756

## 📚 Technical Context
- **Reasoning:** The agent already loads SOUL.md and USER.md into context via `LoadBootstrapFiles()` (#1705), but is never told it can update them. This small prompt change closes that gap.
- Minimal change: +6/-2 lines in a single file
- No new dependencies, no config changes
- Backward compatible — existing agents simply gain new self-update awareness

## Design Decisions

Per the questions in #1756:
1. **Where** — Added to `getIdentity()` template (rule #3), keeping all memory/identity instructions together
2. **Safeguards** — Agent is asked to "briefly mention what you updated" rather than requiring confirmation, keeping the UX lightweight
3. **Configurability** — Not configurable in this first pass; can be made opt-out via config if needed later

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.