### PR TITLE
docs(providers): add Z.AI Coding Plan to providers info

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -11,7 +11,7 @@
 | ------------ | --------------------------------------- | ------------------------------------------------------------ |
 | `gemini`     | LLM (Gemini direct)                     | [aistudio.google.com](https://aistudio.google.com)           |
 | `zhipu`      | LLM (Zhipu direct)                      | [bigmodel.cn](https://bigmodel.cn)                           |
-| `zai-coding` | LLM (Z.AI Coding Plan)                | [docs.z.ai](https://docs.z.ai/devpack/overview)           |
+| `zai-coding` | LLM (Z.AI Coding Plan)                | [z.ai](https://z.ai/manage-apikey/apikey-list)           |
 | `volcengine` | LLM(Volcengine direct)                  | [volcengine.com](https://www.volcengine.com/activity/codingplan?utm_campaign=PicoClaw&utm_content=PicoClaw&utm_medium=devrel&utm_source=OWO&utm_term=PicoClaw)                 |
 | `openrouter` | LLM (recommended, access to all models) | [openrouter.ai](https://openrouter.ai)                       |
 | `anthropic`  | LLM (Claude direct)                     | [console.anthropic.com](https://console.anthropic.com)       |
@@ -48,7 +48,7 @@ This design also enables **multi-agent support** with flexible provider selectio
 | **OpenAI**          | `openai/`         | `https://api.openai.com/v1`                         | OpenAI    | [Get Key](https://platform.openai.com)                           |
 | **Anthropic**       | `anthropic/`      | `https://api.anthropic.com/v1`                      | Anthropic | [Get Key](https://console.anthropic.com)                         |
 | **智谱 AI (GLM)**   | `zhipu/`          | `https://open.bigmodel.cn/api/paas/v4`              | OpenAI    | [Get Key](https://open.bigmodel.cn/usercenter/proj-mgmt/apikeys) |
-| **Z.AI Coding Plan** | `openai/`         | `https://api.z.ai/api/coding/paas/v4`              | OpenAI    | [Get Zhipu Key](https://bigmodel.cn/usercenter/proj-mgmt/apikeys) |
+| **Z.AI Coding Plan** | `openai/`         | `https://api.z.ai/api/coding/paas/v4`              | OpenAI    | [Get Key](https://z.ai/manage-apikey/apikey-list) |
 | **DeepSeek**        | `deepseek/`       | `https://api.deepseek.com/v1`                       | OpenAI    | [Get Key](https://platform.deepseek.com)                         |
 | **Google Gemini**   | `gemini/`         | `https://generativelanguage.googleapis.com/v1beta`  | OpenAI    | [Get Key](https://aistudio.google.com/api-keys)                  |
 | **Groq**            | `groq/`           | `https://api.groq.com/openai/v1`                    | OpenAI    | [Get Key](https://console.groq.com)                              |
@@ -161,6 +161,17 @@ If `voice.model_name` is not configured, PicoClaw will continue to fall back to 
   "model_name": "glm-4.7",
   "model": "zhipu/glm-4.7",
   "api_key": "your-key"
+}
+```
+
+**Z.AI Coding Plan (GLM)**
+> Z.AI and 智谱 AI are two brands of the same provider. For the Z.AI Coding Plan use the `openai` model key and the api base as follows, rather than the zhipu config
+```json
+{
+  "model_name": "glm-4.7",
+  "model": "openai/glm-4.7",
+  "api_key": "your-z.ai-key"
+  "api_base": "https://api.z.ai/api/coding/paas/v4"
 }
 ```
 


### PR DESCRIPTION
## 📝 Description

Z.AI and 智谱 AI are two brands of the same provider, which can be confusing. To utilize the low cost Z.AI Coding Plan in picoclaw you need to use the `openai` model key and the Z.AI api base, rather than the zhipu config.

The PR adds all relevant details and a sample Z.AI config.

## 🗣️ Type of Change
- [x] 📖 Documentation update

## 🤖 AI Code Generation
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

none

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.