### PR TITLE
feat(log): prompt tokens in log

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -2116,16 +2116,21 @@ turnLoop:
 			},
 		)
 
-		logger.DebugCF("agent", "LLM response",
-			map[string]any{
-				"agent_id":       ts.agent.ID,
-				"iteration":      iteration,
-				"content_chars":  len(response.Content),
-				"tool_calls":     len(response.ToolCalls),
-				"reasoning":      response.Reasoning,
-				"target_channel": al.targetReasoningChannelID(ts.channel),
-				"channel":        ts.channel,
-			})
+		llmResponseFields := map[string]any{
+			"agent_id":       ts.agent.ID,
+			"iteration":      iteration,
+			"content_chars":  len(response.Content),
+			"tool_calls":     len(response.ToolCalls),
+			"reasoning":      response.Reasoning,
+			"target_channel": al.targetReasoningChannelID(ts.channel),
+			"channel":        ts.channel,
+		}
+		if response.Usage != nil {
+			llmResponseFields["prompt_tokens"] = response.Usage.PromptTokens
+			llmResponseFields["completion_tokens"] = response.Usage.CompletionTokens
+			llmResponseFields["total_tokens"] = response.Usage.TotalTokens
+		}
+		logger.DebugCF("agent", "LLM response", llmResponseFields)
 
 		if len(response.ToolCalls) == 0 || gracefulTerminal {
 			responseContent := response.Content


### PR DESCRIPTION

## 📝 Description

This PR enhances the observability of the agent loop by logging token usage statistics for LLM responses.

Specifically, it refactors the `logger.DebugCF` call in `pkg/agent/loop.go` to construct the log fields dynamically. It now checks if `response.Usage` is available (not nil) and safely appends `prompt_tokens`, `completion_tokens`, and `total_tokens` to the log output.

## 🗣️ Type of Change

  - [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
  - [x] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 📖 Documentation update
  - [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation

  - [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
  - [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
  - [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none) *(Note: adjust this if you used AI to write the actual Go code)*

## 🔗 Related Issue

*N/A*

## 📚 Technical Context (Skip for Docs)

  - **Reference URL:** N/A
  - **Reasoning:** Tracking token usage per iteration is critical for debugging agent loops, optimizing prompts, and monitoring costs. By extracting the log fields into a `llmResponseFields` map and adding a nil-check for `response.Usage`, safely introduce this telemetry without risking nil-pointer panics on models/providers that might not return usage data.

## 🧪 Test Environment

  - **Hardware:** 
  - **OS:** 
  - **Model/Provider:** 
  - **Channels:**
## 📸 Evidence (Optional)

<details>
<summary>Click to view Logs/Screenshots</summary>

</details>

## ☑️ Checklist

  - [x] My code/docs follow the style of this project.
  - [x] I have performed a self-review of my own changes.
  - [ ] I have updated the documentation accordingly.