### PR TITLE
fix(build): detect Windows shells in Makefile outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ UNAME_S:=$(shell uname -s)
 UNAME_M:=$(shell uname -m)
 
 # Platform-specific settings
+EXE=
 ifeq ($(UNAME_S),Linux)
 	PLATFORM=linux
 	ifeq ($(UNAME_M),x86_64)
@@ -101,12 +102,22 @@ else ifeq ($(UNAME_S),Darwin)
 	else
 		ARCH=$(UNAME_M)
 	endif
+else ifneq (,$(filter MINGW% MSYS% CYGWIN%,$(UNAME_S)))
+	PLATFORM=windows
+	EXE=.exe
+	ifeq ($(UNAME_M),x86_64)
+		ARCH=amd64
+	else ifeq ($(UNAME_M),aarch64)
+		ARCH=arm64
+	else
+		ARCH=$(UNAME_M)
+	endif
 else
 	PLATFORM=$(UNAME_S)
 	ARCH=$(UNAME_M)
 endif
 
-BINARY_PATH=$(BUILD_DIR)/$(BINARY_NAME)-$(PLATFORM)-$(ARCH)
+BINARY_PATH=$(BUILD_DIR)/$(BINARY_NAME)-$(PLATFORM)-$(ARCH)$(EXE)
 
 # Default target
 all: build
@@ -124,7 +135,7 @@ build: generate
 	@mkdir -p $(BUILD_DIR)
 	@$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BINARY_PATH) ./$(CMD_DIR)
 	@echo "Build complete: $(BINARY_PATH)"
-	@ln -sf $(BINARY_NAME)-$(PLATFORM)-$(ARCH) $(BUILD_DIR)/$(BINARY_NAME)
+	@ln -sf $(BINARY_NAME)-$(PLATFORM)-$(ARCH)$(EXE) $(BUILD_DIR)/$(BINARY_NAME)$(EXE)
 
 ## build-launcher: Build the picoclaw-launcher (web console) binary
 build-launcher:

--- a/Makefile
+++ b/Makefile
@@ -156,9 +156,9 @@ build-launcher-frontend:
 build-launcher-tui:
 	@echo "Building picoclaw-launcher-tui for $(PLATFORM)/$(ARCH)..."
 	@mkdir -p $(BUILD_DIR)
-	@$(GO) build $(GOFLAGS) -o $(BUILD_DIR)/picoclaw-launcher-tui-$(PLATFORM)-$(ARCH) ./cmd/picoclaw-launcher-tui
-	@ln -sf picoclaw-launcher-tui-$(PLATFORM)-$(ARCH) $(BUILD_DIR)/picoclaw-launcher-tui
-	@echo "Build complete: $(BUILD_DIR)/picoclaw-launcher-tui"
+	@$(GO) build $(GOFLAGS) -o $(BUILD_DIR)/picoclaw-launcher-tui-$(PLATFORM)-$(ARCH)$(EXE) ./cmd/picoclaw-launcher-tui
+	@ln -sf picoclaw-launcher-tui-$(PLATFORM)-$(ARCH)$(EXE) $(BUILD_DIR)/picoclaw-launcher-tui$(EXE)
+	@echo "Build complete: $(BUILD_DIR)/picoclaw-launcher-tui$(EXE)"
 
 ## build-whatsapp-native: Build with WhatsApp native (whatsmeow) support; larger binary
 build-whatsapp-native: generate
@@ -228,17 +228,17 @@ install: build
 	@echo "Installing $(BINARY_NAME)..."
 	@mkdir -p $(INSTALL_BIN_DIR)
 	# Copy binary with temporary suffix to ensure atomic update
-	@cp $(BUILD_DIR)/$(BINARY_NAME) $(INSTALL_BIN_DIR)/$(BINARY_NAME)$(INSTALL_TMP_SUFFIX)
-	@chmod +x $(INSTALL_BIN_DIR)/$(BINARY_NAME)$(INSTALL_TMP_SUFFIX)
-	@mv -f $(INSTALL_BIN_DIR)/$(BINARY_NAME)$(INSTALL_TMP_SUFFIX) $(INSTALL_BIN_DIR)/$(BINARY_NAME)
-	@echo "Installed binary to $(INSTALL_BIN_DIR)/$(BINARY_NAME)"
+	@cp $(BUILD_DIR)/$(BINARY_NAME)$(EXE) $(INSTALL_BIN_DIR)/$(BINARY_NAME)$(EXE)$(INSTALL_TMP_SUFFIX)
+	@chmod +x $(INSTALL_BIN_DIR)/$(BINARY_NAME)$(EXE)$(INSTALL_TMP_SUFFIX)
+	@mv -f $(INSTALL_BIN_DIR)/$(BINARY_NAME)$(EXE)$(INSTALL_TMP_SUFFIX) $(INSTALL_BIN_DIR)/$(BINARY_NAME)$(EXE)
+	@echo "Installed binary to $(INSTALL_BIN_DIR)/$(BINARY_NAME)$(EXE)"
 	@echo "Installation complete!"
 
 ## uninstall: Remove picoclaw from system
 uninstall:
 	@echo "Uninstalling $(BINARY_NAME)..."
-	@rm -f $(INSTALL_BIN_DIR)/$(BINARY_NAME)
-	@echo "Removed binary from $(INSTALL_BIN_DIR)/$(BINARY_NAME)"
+	@rm -f $(INSTALL_BIN_DIR)/$(BINARY_NAME)$(EXE)
+	@echo "Removed binary from $(INSTALL_BIN_DIR)/$(BINARY_NAME)$(EXE)"
 	@echo "Note: Only the executable file has been deleted."
 	@echo "If you need to delete all configurations (config.json, workspace, etc.), run 'make uninstall-all'"
 
@@ -293,7 +293,7 @@ check: deps fmt vet test
 
 ## run: Build and run picoclaw
 run: build
-	@$(BUILD_DIR)/$(BINARY_NAME) $(ARGS)
+	@$(BUILD_DIR)/$(BINARY_NAME)$(EXE) $(ARGS)
 
 ## docker-build: Build Docker image (minimal Alpine-based)
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ UNAME_M:=$(shell uname -m)
 
 # Platform-specific settings
 EXE=
+GO_BUILD_ENV=
 ifeq ($(UNAME_S),Linux)
 	PLATFORM=linux
 	ifeq ($(UNAME_M),x86_64)
@@ -105,6 +106,7 @@ else ifeq ($(UNAME_S),Darwin)
 else ifneq (,$(filter MINGW% MSYS% CYGWIN%,$(UNAME_S)))
 	PLATFORM=windows
 	EXE=.exe
+	GO_BUILD_ENV=GOOS=windows GOARCH=$(ARCH)
 	ifeq ($(UNAME_M),x86_64)
 		ARCH=amd64
 	else ifeq ($(UNAME_M),aarch64)
@@ -133,21 +135,29 @@ generate:
 build: generate
 	@echo "Building $(BINARY_NAME) for $(PLATFORM)/$(ARCH)..."
 	@mkdir -p $(BUILD_DIR)
-	@$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BINARY_PATH) ./$(CMD_DIR)
+	@$(GO_BUILD_ENV) $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BINARY_PATH) ./$(CMD_DIR)
 	@echo "Build complete: $(BINARY_PATH)"
-	@ln -sf $(BINARY_NAME)-$(PLATFORM)-$(ARCH)$(EXE) $(BUILD_DIR)/$(BINARY_NAME)$(EXE)
+	@if [ "$(PLATFORM)" = "windows" ]; then \
+		cp -f $(BINARY_PATH) $(BUILD_DIR)/$(BINARY_NAME)$(EXE); \
+	else \
+		ln -sf $(BINARY_NAME)-$(PLATFORM)-$(ARCH)$(EXE) $(BUILD_DIR)/$(BINARY_NAME)$(EXE); \
+	fi
 
 ## build-launcher: Build the picoclaw-launcher (web console) binary
 build-launcher:
 	@echo "Building picoclaw-launcher for $(PLATFORM)/$(ARCH)..."
 	@mkdir -p $(BUILD_DIR)
 	@$(MAKE) -C web build \
-		OUTPUT="$(CURDIR)/$(BUILD_DIR)/picoclaw-launcher-$(PLATFORM)-$(ARCH)" \
-		WEB_GO='$(WEB_GO)' \
+		OUTPUT="$(CURDIR)/$(BUILD_DIR)/picoclaw-launcher-$(PLATFORM)-$(ARCH)$(EXE)" \
+		WEB_GO='$(strip $(GO_BUILD_ENV) $(WEB_GO))' \
 		GO_BUILD_TAGS='$(GO_BUILD_TAGS)' \
 		LDFLAGS='$(LDFLAGS)'
-	@ln -sf picoclaw-launcher-$(PLATFORM)-$(ARCH) $(BUILD_DIR)/picoclaw-launcher
-	@echo "Build complete: $(BUILD_DIR)/picoclaw-launcher"
+	@if [ "$(PLATFORM)" = "windows" ]; then \
+		cp -f $(BUILD_DIR)/picoclaw-launcher-$(PLATFORM)-$(ARCH)$(EXE) $(BUILD_DIR)/picoclaw-launcher$(EXE); \
+	else \
+		ln -sf picoclaw-launcher-$(PLATFORM)-$(ARCH)$(EXE) $(BUILD_DIR)/picoclaw-launcher$(EXE); \
+	fi
+	@echo "Build complete: $(BUILD_DIR)/picoclaw-launcher$(EXE)"
 
 build-launcher-frontend:
 	@$(MAKE) -C web build-frontend
@@ -156,8 +166,12 @@ build-launcher-frontend:
 build-launcher-tui:
 	@echo "Building picoclaw-launcher-tui for $(PLATFORM)/$(ARCH)..."
 	@mkdir -p $(BUILD_DIR)
-	@$(GO) build $(GOFLAGS) -o $(BUILD_DIR)/picoclaw-launcher-tui-$(PLATFORM)-$(ARCH)$(EXE) ./cmd/picoclaw-launcher-tui
-	@ln -sf picoclaw-launcher-tui-$(PLATFORM)-$(ARCH)$(EXE) $(BUILD_DIR)/picoclaw-launcher-tui$(EXE)
+	@$(GO_BUILD_ENV) $(GO) build $(GOFLAGS) -o $(BUILD_DIR)/picoclaw-launcher-tui-$(PLATFORM)-$(ARCH)$(EXE) ./cmd/picoclaw-launcher-tui
+	@if [ "$(PLATFORM)" = "windows" ]; then \
+		cp -f $(BUILD_DIR)/picoclaw-launcher-tui-$(PLATFORM)-$(ARCH)$(EXE) $(BUILD_DIR)/picoclaw-launcher-tui$(EXE); \
+	else \
+		ln -sf picoclaw-launcher-tui-$(PLATFORM)-$(ARCH)$(EXE) $(BUILD_DIR)/picoclaw-launcher-tui$(EXE); \
+	fi
 	@echo "Build complete: $(BUILD_DIR)/picoclaw-launcher-tui$(EXE)"
 
 ## build-whatsapp-native: Build with WhatsApp native (whatsmeow) support; larger binary


### PR DESCRIPTION
## Summary
- detect MINGW/MSYS/CYGWIN `uname -s` values as Windows in the top-level Makefile
- emit `.exe` output names and Windows-friendly symlink aliases for both `build` and `build-launcher` targets
- keep Linux/macOS build naming behavior unchanged

## Validation
- `make -n build UNAME_S=MINGW64_NT-10.0-19045 UNAME_M=x86_64`
- `make -n build-launcher UNAME_S=MINGW64_NT-10.0-19045 UNAME_M=x86_64`
- `make -n build UNAME_S=Linux UNAME_M=x86_64`

Closes #2050
