### PR TITLE
feat(web/chat): stream assistant responses

### DIFF
--- a/web/frontend/src/components/chat/assistant-message.tsx
+++ b/web/frontend/src/components/chat/assistant-message.tsx
@@ -12,20 +12,18 @@ const STREAM_FRAME_MS = 18
 const STREAM_STEPS = 60
 
 interface AssistantMessageProps {
-  messageId?: string
   content: string
   timestamp?: string | number
+  isStreaming?: boolean
 }
 
 export function AssistantMessage({
-  messageId = "",
   content,
   timestamp = "",
+  isStreaming = false,
 }: AssistantMessageProps) {
   const [isCopied, setIsCopied] = useState(false)
-  const [displayedContent, setDisplayedContent] = useState(
-    messageId.startsWith("hist-") ? content : "",
-  )
+  const [displayedContent, setDisplayedContent] = useState(content)
   const timerRef = useRef<number | null>(null)
   const displayedRef = useRef(displayedContent)
   const formattedTimestamp =
@@ -50,13 +48,12 @@ export function AssistantMessage({
   }, [])
 
   useEffect(() => {
-    const isHistoryMessage = messageId.startsWith("hist-")
     if (timerRef.current !== null) {
       window.clearInterval(timerRef.current)
       timerRef.current = null
     }
 
-    if (isHistoryMessage || content.trim() === "") {
+    if (!isStreaming || content.trim() === "") {
       queueMicrotask(() => syncDisplayedContent(content))
       return
     }
@@ -86,7 +83,7 @@ export function AssistantMessage({
         timerRef.current = null
       }
     }, STREAM_FRAME_MS)
-  }, [content, messageId])
+  }, [content, isStreaming])
 
   const handleCopy = () => {
     navigator.clipboard.writeText(content).then(() => {

--- a/web/frontend/src/components/chat/assistant-message.tsx
+++ b/web/frontend/src/components/chat/assistant-message.tsx
@@ -1,5 +1,5 @@
 import { IconCheck, IconCopy } from "@tabler/icons-react"
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import ReactMarkdown from "react-markdown"
 import rehypeRaw from "rehype-raw"
 import rehypeSanitize from "rehype-sanitize"
@@ -8,18 +8,85 @@ import remarkGfm from "remark-gfm"
 import { Button } from "@/components/ui/button"
 import { formatMessageTime } from "@/hooks/use-pico-chat"
 
+const STREAM_FRAME_MS = 18
+const STREAM_STEPS = 60
+
 interface AssistantMessageProps {
+  messageId?: string
   content: string
   timestamp?: string | number
 }
 
 export function AssistantMessage({
+  messageId = "",
   content,
   timestamp = "",
 }: AssistantMessageProps) {
   const [isCopied, setIsCopied] = useState(false)
+  const [displayedContent, setDisplayedContent] = useState(
+    messageId.startsWith("hist-") ? content : "",
+  )
+  const timerRef = useRef<number | null>(null)
+  const displayedRef = useRef(displayedContent)
   const formattedTimestamp =
     timestamp !== "" ? formatMessageTime(timestamp) : ""
+
+  const syncDisplayedContent = (nextContent: string) => {
+    setDisplayedContent((previous) =>
+      previous === nextContent ? previous : nextContent,
+    )
+  }
+
+  useEffect(() => {
+    displayedRef.current = displayedContent
+  }, [displayedContent])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearInterval(timerRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    const isHistoryMessage = messageId.startsWith("hist-")
+    if (timerRef.current !== null) {
+      window.clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+
+    if (isHistoryMessage || content.trim() === "") {
+      queueMicrotask(() => syncDisplayedContent(content))
+      return
+    }
+
+    const currentDisplayed = displayedRef.current
+    const targetRunes = Array.from(content)
+    const start = content.startsWith(currentDisplayed) ? currentDisplayed : ""
+    const startLen = Array.from(start).length
+
+    if (startLen >= targetRunes.length) {
+      queueMicrotask(() => syncDisplayedContent(content))
+      return
+    }
+
+    let cursor = startLen
+    const chunkSize = Math.max(
+      1,
+      Math.ceil((targetRunes.length - startLen) / STREAM_STEPS),
+    )
+
+    queueMicrotask(() => syncDisplayedContent(start))
+    timerRef.current = window.setInterval(() => {
+      cursor = Math.min(targetRunes.length, cursor + chunkSize)
+      setDisplayedContent(targetRunes.slice(0, cursor).join(""))
+      if (cursor >= targetRunes.length && timerRef.current !== null) {
+        window.clearInterval(timerRef.current)
+        timerRef.current = null
+      }
+    }, STREAM_FRAME_MS)
+  }, [content, messageId])
 
   const handleCopy = () => {
     navigator.clipboard.writeText(content).then(() => {
@@ -48,7 +115,7 @@ export function AssistantMessage({
             remarkPlugins={[remarkGfm]}
             rehypePlugins={[rehypeRaw, rehypeSanitize]}
           >
-            {content}
+            {displayedContent}
           </ReactMarkdown>
         </div>
         <Button

--- a/web/frontend/src/components/chat/chat-page.tsx
+++ b/web/frontend/src/components/chat/chat-page.tsx
@@ -150,6 +150,7 @@ export function ChatPage() {
             <div key={msg.id} className="flex w-full">
               {msg.role === "assistant" ? (
                 <AssistantMessage
+                  messageId={msg.id}
                   content={msg.content}
                   timestamp={msg.timestamp}
                 />

--- a/web/frontend/src/components/chat/chat-page.tsx
+++ b/web/frontend/src/components/chat/chat-page.tsx
@@ -66,6 +66,12 @@ export function ChatPage() {
     setIsAtBottom(scrollHeight - scrollTop <= clientHeight + 10)
   }
 
+  const liveAssistantMessageId = isTyping
+    ? [...messages]
+        .reverse()
+        .find((message) => message.role === "assistant")?.id
+    : undefined
+
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     syncScrollState(e.currentTarget)
   }
@@ -150,9 +156,9 @@ export function ChatPage() {
             <div key={msg.id} className="flex w-full">
               {msg.role === "assistant" ? (
                 <AssistantMessage
-                  messageId={msg.id}
                   content={msg.content}
                   timestamp={msg.timestamp}
+                  isStreaming={msg.id === liveAssistantMessageId}
                 />
               ) : (
                 <UserMessage content={msg.content} />


### PR DESCRIPTION
## Summary\nAnimate assistant responses on the web chat page so new content arrives character-by-character while history messages continue to render instantly. Scope is limited to the existing chat frontend; no provider/backend protocol changes.\n\n## Testing\n- pnpm lint (web/frontend)\n- pnpm build (web/frontend)\n\n## Linked issues\n- closes #1950