### PR TITLE
fix(config): array placeholder

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,22 @@ var rrCounter atomic.Uint64
 type FlexibleStringSlice []string
 
 func (f *FlexibleStringSlice) UnmarshalJSON(data []byte) error {
+	// Accept a single JSON string for convenience, e.g.:
+	// "text": "Thinking..."
+	var singleString string
+	if err := json.Unmarshal(data, &singleString); err == nil {
+		*f = FlexibleStringSlice{singleString}
+		return nil
+	}
+
+	// Accept a single JSON number too, to keep symmetry with mixed allow_from
+	// payloads that may contain numeric identifiers.
+	var singleNumber float64
+	if err := json.Unmarshal(data, &singleNumber); err == nil {
+		*f = FlexibleStringSlice{fmt.Sprintf("%.0f", singleNumber)}
+		return nil
+	}
+
 	// Try []string first
 	var ss []string
 	if err := json.Unmarshal(data, &ss); err == nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -926,6 +926,91 @@ func TestFlexibleStringSlice_UnmarshalText_EmptySliceConsistency(t *testing.T) {
 	})
 }
 
+func TestFlexibleStringSlice_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "single string",
+			input:    `"Thinking..."`,
+			expected: []string{"Thinking..."},
+		},
+		{
+			name:     "single number",
+			input:    `123`,
+			expected: []string{"123"},
+		},
+		{
+			name:     "string array",
+			input:    `["Thinking...", "Still working..."]`,
+			expected: []string{"Thinking...", "Still working..."},
+		},
+		{
+			name:     "mixed array",
+			input:    `["123", 456]`,
+			expected: []string{"123", "456"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var f FlexibleStringSlice
+			if err := json.Unmarshal([]byte(tt.input), &f); err != nil {
+				t.Fatalf("json.Unmarshal(%s) error = %v", tt.input, err)
+			}
+			if len(f) != len(tt.expected) {
+				t.Fatalf("json.Unmarshal(%s) len = %d, want %d", tt.input, len(f), len(tt.expected))
+			}
+			for i, want := range tt.expected {
+				if f[i] != want {
+					t.Fatalf("json.Unmarshal(%s)[%d] = %q, want %q", tt.input, i, f[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadConfig_TelegramPlaceholderTextAcceptsSingleString(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	data := `{
+		"version": 1,
+		"agents": { "defaults": { "workspace": "", "model": "", "max_tokens": 0, "max_tool_iterations": 0 } },
+		"bindings": [],
+		"session": {},
+		"channels": {
+			"telegram": {
+				"enabled": true,
+				"bot_token": "",
+				"allow_from": [],
+				"placeholder": {
+					"enabled": true,
+					"text": "Thinking..."
+				}
+			}
+		},
+		"model_list": [],
+		"gateway": {},
+		"tools": {},
+		"heartbeat": {},
+		"devices": {},
+		"voice": {}
+	}`
+	if err := os.WriteFile(cfgPath, []byte(data), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if got := []string(cfg.Channels.Telegram.Placeholder.Text); len(got) != 1 || got[0] != "Thinking..." {
+		t.Fatalf("placeholder.text = %#v, want [\"Thinking...\"]", got)
+	}
+}
+
 // TestLoadConfig_WarnsForPlaintextAPIKey verifies that LoadConfig resolves a plaintext
 // api_key into memory but does NOT rewrite the config file. File writes are the sole
 // responsibility of SaveConfig.


### PR DESCRIPTION
## 📝 Description

This PR fixes a backward compatibility issue introduced in #1998, where the Telegram placeholder `text` configuration was changed from a `string` to an array (`[]string`). 

Existing users with a `config.json` containing a single string (e.g., `"text": "Thinking..."`) were experiencing picoclaw startup error

- Complete test coverage for the unmarshaling edge cases.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Follow-up to #1998

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/pull/1998
- **Reasoning:** Migrating config fields from strings to arrays often breaks existing deployments. By implementing custom JSON unmarshaling logic (`FlexibleStringSlice`), we ensure the application remains strictly typed internally as `[]string` while remaining completely forgiving and backward-compatible with older `config.json` structures.

## 🧪 Test Environment
- **Hardware:** - **OS:** Mac/Linux
- **Model/Provider:** - **Channels:** Telegram


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Unit tests `TestFlexibleStringSlice_UnmarshalJSON` and `TestLoadConfig_TelegramPlaceholderTextAcceptsSingleString` are passing successfully, confirming that both single strings and numbers are correctly parsed into `[]string`.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.