### PR TITLE
fix(config): clear Weixin dirty flag instead of Discord during save

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1770,7 +1770,7 @@ func SaveConfig(path string, cfg *Config) error {
 		cfg.security.Channels.Weixin = &WeixinSecurity{
 			Token: cfg.Channels.Weixin.Token(),
 		}
-		cfg.Channels.Discord.secDirty = false
+		cfg.Channels.Weixin.secDirty = false
 	}
 	if cfg.Channels.QQ.secDirty {
 		cfg.security.Channels.QQ = &QQSecurity{


### PR DESCRIPTION
## 📝 Description

Fixes a typo in SaveConfig where the Weixin branch accidentally cleared Discord.secDirty.
Updates the logic to correctly clear Weixin.secDirty after persisting Weixin security data.

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [ ] My code/docs follow the style of this project.
- [ ] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.