### PR TITLE
perf(agent): avoid reloading bootstrap files on cache hits

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -45,6 +45,11 @@ type ContextBuilder struct {
 	// build time. This catches nested file creations/deletions/mtime changes
 	// that may not update the top-level skill root directory mtime.
 	skillFilesAtCache map[string]time.Time
+
+	// sourcePathsAtCache stores the active non-skill tracked paths captured
+	// when the cache was built, so cache hits do not need to re-detect the
+	// bootstrap file family.
+	sourcePathsAtCache []string
 }
 
 func (cb *ContextBuilder) WithToolDiscovery(useBM25, useRegex bool) *ContextBuilder {
@@ -209,6 +214,7 @@ func (cb *ContextBuilder) BuildSystemPromptWithCache() string {
 	cb.cachedAt = baseline.maxMtime
 	cb.existedAtCache = baseline.existed
 	cb.skillFilesAtCache = baseline.skillFiles
+	cb.sourcePathsAtCache = append(cb.sourcePathsAtCache[:0], baseline.sourcePaths...)
 
 	logger.DebugCF("agent", "System prompt cached",
 		map[string]any{
@@ -229,6 +235,7 @@ func (cb *ContextBuilder) InvalidateCache() {
 	cb.cachedAt = time.Time{}
 	cb.existedAtCache = nil
 	cb.skillFilesAtCache = nil
+	cb.sourcePathsAtCache = nil
 
 	logger.DebugCF("agent", "System prompt cache invalidated", nil)
 }
@@ -237,10 +244,25 @@ func (cb *ContextBuilder) InvalidateCache() {
 // invalidation (bootstrap files + memory). Skill roots are handled separately
 // because they require both directory-level and recursive file-level checks.
 func (cb *ContextBuilder) sourcePaths() []string {
-	agentDefinition := cb.LoadAgentDefinition()
-	paths := agentDefinition.trackedPaths(cb.workspace)
-	paths = append(paths, filepath.Join(cb.workspace, "memory", "MEMORY.md"))
-	return uniquePaths(paths)
+	agentPath := filepath.Join(cb.workspace, string(AgentDefinitionSourceAgent))
+	paths := []string{
+		agentPath,
+		filepath.Join(cb.workspace, "SOUL.md"),
+		filepath.Join(cb.workspace, "USER.md"),
+		filepath.Join(cb.workspace, "memory", "MEMORY.md"),
+	}
+
+	// Cache invalidation only needs to know which bootstrap path family is active.
+	// Avoid loading/parsing AGENT.md on every cache hit; existence is sufficient
+	// because the structured format always wins when present.
+	if _, err := os.Stat(agentPath); err == nil {
+		return paths
+	}
+
+	return append(paths,
+		filepath.Join(cb.workspace, string(AgentDefinitionSourceAgents)),
+		filepath.Join(cb.workspace, "IDENTITY.md"),
+	)
 }
 
 // skillRoots returns all skill root directories that can affect
@@ -260,9 +282,10 @@ func (cb *ContextBuilder) skillRoots() []string {
 // cacheBaseline holds the file existence snapshot and the latest observed
 // mtime across all tracked paths. Used as the cache reference point.
 type cacheBaseline struct {
-	existed    map[string]bool
-	skillFiles map[string]time.Time
-	maxMtime   time.Time
+	existed     map[string]bool
+	skillFiles  map[string]time.Time
+	sourcePaths []string
+	maxMtime    time.Time
 }
 
 // buildCacheBaseline records which tracked paths currently exist and computes
@@ -270,9 +293,10 @@ type cacheBaseline struct {
 // Called under write lock when the cache is built.
 func (cb *ContextBuilder) buildCacheBaseline() cacheBaseline {
 	skillRoots := cb.skillRoots()
+	sourcePaths := cb.sourcePaths()
 
 	// All paths whose existence we track: source files + all skill roots.
-	allPaths := append(cb.sourcePaths(), skillRoots...)
+	allPaths := append(append([]string(nil), sourcePaths...), skillRoots...)
 
 	existed := make(map[string]bool, len(allPaths))
 	skillFiles := make(map[string]time.Time)
@@ -312,7 +336,12 @@ func (cb *ContextBuilder) buildCacheBaseline() cacheBaseline {
 		maxMtime = time.Unix(1, 0)
 	}
 
-	return cacheBaseline{existed: existed, skillFiles: skillFiles, maxMtime: maxMtime}
+	return cacheBaseline{
+		existed:     existed,
+		skillFiles:  skillFiles,
+		sourcePaths: sourcePaths,
+		maxMtime:    maxMtime,
+	}
 }
 
 // sourceFilesChangedLocked checks whether any workspace source file has been
@@ -328,7 +357,10 @@ func (cb *ContextBuilder) sourceFilesChangedLocked() bool {
 	}
 
 	// Check tracked source files (bootstrap + memory).
-	if slices.ContainsFunc(cb.sourcePaths(), cb.fileChangedSince) {
+	if len(cb.sourcePathsAtCache) == 0 {
+		return true
+	}
+	if slices.ContainsFunc(cb.sourcePathsAtCache, cb.fileChangedSince) {
 		return true
 	}
 

--- a/pkg/agent/definition.go
+++ b/pkg/agent/definition.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/gomarkdown/markdown/parser"
@@ -117,21 +116,6 @@ func loadAgentDefinition(workspace string) AgentContextDefinition {
 	return definition
 }
 
-func (definition AgentContextDefinition) trackedPaths(workspace string) []string {
-	paths := []string{
-		filepath.Join(workspace, string(AgentDefinitionSourceAgent)),
-		filepath.Join(workspace, "SOUL.md"),
-		filepath.Join(workspace, "USER.md"),
-	}
-	if definition.Source != AgentDefinitionSourceAgent {
-		paths = append(paths,
-			filepath.Join(workspace, string(AgentDefinitionSourceAgents)),
-			filepath.Join(workspace, "IDENTITY.md"),
-		)
-	}
-	return uniquePaths(paths)
-}
-
 func loadUserDefinition(workspace string) *UserDefinition {
 	userPath := filepath.Join(workspace, "USER.md")
 	if content, err := os.ReadFile(userPath); err == nil {
@@ -232,21 +216,6 @@ func relativeWorkspacePath(workspace, path string) string {
 		return filepath.ToSlash(relativePath)
 	}
 	return filepath.Clean(path)
-}
-
-func uniquePaths(paths []string) []string {
-	result := make([]string, 0, len(paths))
-	for _, path := range paths {
-		if strings.TrimSpace(path) == "" {
-			continue
-		}
-		cleaned := filepath.Clean(path)
-		if slices.Contains(result, cleaned) {
-			continue
-		}
-		result = append(result, cleaned)
-	}
-	return result
 }
 
 func fileExists(path string) bool {


### PR DESCRIPTION
## 📝 Description

This is a proactive optimization for the agent context cache hit path.

Problem summary:
- `BuildSystemPromptWithCache()` already caches the assembled system prompt.
- On cache hits, the invalidation check still rebuilt the active bootstrap path set by calling `LoadAgentDefinition()`.
- That meant repeated file reads and frontmatter parsing even when the cached prompt was reused unchanged.

Root cause:
- `sourcePaths()` loaded the agent definition just to decide whether the structured `AGENT.md` family or the legacy `AGENTS.md`/`IDENTITY.md` family should be tracked.
- `sourceFilesChangedLocked()` called `sourcePaths()` on every cache hit.
- The cache therefore avoided prompt rebuilding, but still paid unnecessary I/O and allocation costs in the hot path.

What changed:
- Detect the active bootstrap family for invalidation using path state instead of loading the full agent definition.
- Capture the active non-skill tracked path set when the cache is built.
- Reuse that cached path set for subsequent cache-hit invalidation checks.
- Keep existing invalidation behavior for AGENT/AGENTS/SOUL/USER/IDENTITY and memory files unchanged.

Why this fix:
- It targets a real hot path in every agent turn.
- It keeps the change narrowly scoped to cache bookkeeping without altering prompt contents or routing behavior.
- I compared this against a simpler stat-only variant; the chosen version performed better in the same benchmark while keeping the semantics intact.

Risk / compatibility:
- Low risk. This does not change prompt content or API behavior.
- The change only affects how the context cache tracks and reuses its source path set between rebuilds.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

N/A (proactive optimization)

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** I evaluated two variants for this path. A first version replaced `LoadAgentDefinition()` with a cheap `os.Stat` check and reduced the benchmark from about `184-185µs / 92 allocs` to about `138-140µs / 66 allocs`. The final version goes one step further by caching the active tracked path set at cache-build time, which reduced the same benchmark to about `126-149µs / 55 allocs` while preserving the existing invalidation semantics.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows (local development environment)
- **Model/Provider:** N/A (unit tests + benchmark)
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Passed:
- `go test ./pkg/agent -run TestMtimeAutoInvalidation|TestStructuredAgentIgnoresIdentityChanges|TestStructuredAgentUserChangesInvalidateCache|TestEmptyWorkspaceBaselineDetectsNewFiles|TestConcurrentBuildSystemPromptWithCache -count=1`
- `go test -run '^$' -bench BenchmarkBuildMessagesWithCache -benchmem -count=3 ./pkg/agent`

Benchmark snapshots on this machine:
- Baseline: about `183725-185434 ns/op`, `18617-18692 B/op`, `92 allocs/op`
- Final patch: about `126297-149033 ns/op`, `13935-14016 B/op`, `55 allocs/op`

Additional notes:
- `go test ./pkg/agent -count=1` still fails due to pre-existing `TestGlobalSkillFileContentChange`; I confirmed that same failure on clean `upstream/main`, so it is unrelated to this PR.
- `codex review --base origin/main` could not run in this environment because the local Codex config rejected `approvals_reviewer = never`.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.