### PR TITLE
fix: resolve qq and dingtalk in hash secret

### DIFF
--- a/pkg/channels/manager_channel.go
+++ b/pkg/channels/manager_channel.go
@@ -51,9 +51,9 @@ func hiddenValues(key string, value map[string]any, ch config.ChannelsConfig) {
 	case "wecom":
 		value["secret"] = ch.WeCom.Secret()
 	case "dingtalk":
-		value["secret"] = ch.QQ.AppSecret()
-	case "qq":
 		value["secret"] = ch.DingTalk.ClientSecret()
+	case "qq":
+		value["secret"] = ch.QQ.AppSecret()
 	case "irc":
 		value["password"] = ch.IRC.Password()
 		value["serv_password"] = ch.IRC.NickServPassword()


### PR DESCRIPTION
## 📝 Description

This fixes a channel config hashing bug for `qq` and `dingtalk`.

Problem summary:
  - The hidden secret values used during channel hash generation were mapped to the wrong channel.
  - `qq` was reading the DingTalk secret source.
  - `dingtalk` was reading the QQ secret source.

  Impact:
  - Secret changes on QQ or DingTalk could fail to invalidate that channel's config hash correctly.
  - Hot reload / config change detection could miss real secret updates for these two channels.

  What changed:
  - `dingtalk` now hashes `ch.DingTalk.ClientSecret()`.
  - `qq` now hashes `ch.QQ.AppSecret()`.
  - Added a regression test to verify each channel secret only affects its own hash.

  Why this matters:
  - This is small, but it sits on the config reload path.
  - The fix is low risk and restores the expected behavior for channel change detection.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

N/A (proactive bug fix)

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**N/A
- **Reasoning:**Channel hashes are used to detect config changes for hot reload / manager lifecycle updates.
    Since secrets are hidden from normal serialized config output, they must be injected manually before hashing.
    The QQ and DingTalk secret sources were swapped, which made the hash bookkeeping incorrect for both channels.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Linux
- **Model/Provider:** DeepSeek-V3
- **Channels:** QQ, DingTalk

## 📸 Evidence (Optional)
<details>
  <summary>Click to view Logs/Screenshots</summary>
 
  Targeted regression test:
  ```bash
  go test ./pkg/channels -run 'TestToChannelHashes|TestToChannelHashes_QQAndDingTalkSecretsAffectOwnHashes' -count=1
 
  Files touched:
 
  - pkg/channels/manager_channel.go
  - pkg/channels/manager_channel_test.go
</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.