### PR TITLE
fix(channels): add security audit for open-by-default bots

### DIFF
--- a/pkg/channels/base.go
+++ b/pkg/channels/base.go
@@ -112,6 +112,18 @@ func NewBaseChannel(
 	for _, opt := range opts {
 		opt(bc)
 	}
+
+	// Security Audit: Check for open-by-default (unsecured) channels.
+	// PicoClaw aims to be secure-by-default. If allow_from is empty, the bot
+	// currently defaults to accepting messages from ANYONE. To explicitly
+	// acknowledge and permit this (e.g. for a public bot), use ["*"].
+	if len(bc.allowList) == 0 {
+		logger.WarnCF("channels", "SECURITY: Channel allows EVERYONE (allow_from is empty)", map[string]any{
+			"channel": bc.name,
+			"hint":    "Set allow_from to your ID, or use '*' to explicitly acknowledge open access.",
+		})
+	}
+
 	return bc
 }
 
@@ -187,6 +199,9 @@ func (c *BaseChannel) IsAllowed(senderID string) bool {
 	}
 
 	for _, allowed := range c.allowList {
+		if allowed == "*" {
+			return true
+		}
 		// Strip leading "@" from allowed value for username matching
 		trimmed := strings.TrimPrefix(allowed, "@")
 		allowedID := trimmed
@@ -221,7 +236,7 @@ func (c *BaseChannel) IsAllowedSender(sender bus.SenderInfo) bool {
 	}
 
 	for _, allowed := range c.allowList {
-		if identity.MatchAllowed(sender, allowed) {
+		if allowed == "*" || identity.MatchAllowed(sender, allowed) {
 			return true
 		}
 	}


### PR DESCRIPTION
## 📝 Description

This PR addresses a security risk where bots initialized with an empty `allow_from` list default to a "permissive" state, accepting messages from anyone. This change adds informational hardening to prevent users from unknowingly exposing their private AI agents.

Key improvements:
- **Startup Security Audit**: `NewBaseChannel` now logs a high-visibility warning at startup if an enabled channel has an empty `allow_from` list. This ensures users are aware if their bot is currently open.
- **Explicit Open Policy**: Introduced the `"*"` wildcard in `allow_from` lists. This provides a path for users to explicitly acknowledge and permit public access, which suppresses the security warning.
- **Consistent Matching**: Updated both `IsAllowed` and `IsAllowedSender` to support the explicit `"*"` policy while maintaining backward compatibility for existing "permissive-by-omission" setups.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue
N/A

## 📚 Technical Context (Skip for Docs)
- **Problem**: PicoClaw's `BaseChannel` defaults to `true` (allow all) if the `allowList` is empty. Many users are unaware of this exposure during initial setup.
- **Reasoning**: To avoid breaking existing users, we maintain the permissive default but log a startup warning. Adding `"*"` to the list allows for an intentional "public" state that bypasses the warning.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows 11
- **Model/Provider:** Anthropic Sonnet 3.7
- **Channels:** Telegram / Multi-channel

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.