### PR TITLE
fix(slack): resolve mention race condition and unify chatID logic

### DIFF
--- a/pkg/channels/slack/slack.go
+++ b/pkg/channels/slack/slack.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
@@ -29,6 +30,7 @@ type SlackChannel struct {
 	ctx          context.Context
 	cancel       context.CancelFunc
 	pendingAcks  sync.Map
+	seenMessages sync.Map // "channel_id:ts" -> true (dedup message/app_mention race)
 }
 
 type slackMessageRef struct {
@@ -279,6 +281,14 @@ func (c *SlackChannel) handleMessageEvent(ev *slackevents.MessageEvent) {
 		return
 	}
 
+	// Deduplicate against app_mention events which Slack often sends in parallel.
+	dedupKey := ev.Channel + ":" + ev.TimeStamp
+	if _, loaded := c.seenMessages.LoadOrStore(dedupKey, true); loaded {
+		return
+	}
+	// Simple TTL: clean up from map after 1 minute (sufficient for Slack race)
+	time.AfterFunc(1*time.Minute, func() { c.seenMessages.Delete(dedupKey) })
+
 	// check allowlist to avoid downloading attachments for rejected users
 	sender := bus.SenderInfo{
 		Platform:    "slack",
@@ -307,12 +317,13 @@ func (c *SlackChannel) handleMessageEvent(ev *slackevents.MessageEvent) {
 		Timestamp: messageTS,
 	})
 
-	content := ev.Text
-	content = c.stripBotMention(content)
+	rawContent := ev.Text
+	content := c.stripBotMention(rawContent)
+	isMentioned := rawContent != content // Detect if bot was @mentioned
 
 	// In non-DM channels, apply group trigger filtering
 	if !strings.HasPrefix(channelID, "D") {
-		respond, cleaned := c.ShouldRespondInGroup(false, content)
+		respond, cleaned := c.ShouldRespondInGroup(isMentioned, content)
 		if !respond {
 			return
 		}
@@ -385,6 +396,14 @@ func (c *SlackChannel) handleAppMention(ev *slackevents.AppMentionEvent) {
 		return
 	}
 
+	// Deduplicate against message events which Slack often sends in parallel.
+	dedupKey := ev.Channel + ":" + ev.TimeStamp
+	if _, loaded := c.seenMessages.LoadOrStore(dedupKey, true); loaded {
+		return
+	}
+	// Simple TTL: clean up from map after 1 minute (sufficient for Slack race)
+	time.AfterFunc(1*time.Minute, func() { c.seenMessages.Delete(dedupKey) })
+
 	if !c.IsAllowedSender(bus.SenderInfo{
 		Platform:    "slack",
 		PlatformID:  ev.User,
@@ -406,11 +425,9 @@ func (c *SlackChannel) handleAppMention(ev *slackevents.AppMentionEvent) {
 	threadTS := ev.ThreadTimeStamp
 	messageTS := ev.TimeStamp
 
-	var chatID string
+	chatID := channelID
 	if threadTS != "" {
 		chatID = channelID + "/" + threadTS
-	} else {
-		chatID = channelID + "/" + messageTS
 	}
 
 	c.pendingAcks.Store(chatID, slackMessageRef{


### PR DESCRIPTION
## 📝 Description

This PR resolves the double-processing and session fragmentation issues that occur when Slack sends both `message` and `app_mention` events for the same @mention. It ensures that the bot reliably triggers a single, context-aware response regardless of event delivery order.

Key improvements:
- **Deduplication Cache**: Added a `sync.Map` with a 1-minute TTL to track unique Slack event timestamps. This prevents the bot from answering twice for the same interaction.
- **Harmonized ChatID**: Unified the session `chatID` construction across both handlers. This ensures mentions correctly follow the main channel or thread history rather than starting fragmented orphan sessions.
- **Enhanced Mention Detection**: The `message` handler now correctly detects @mentions by comparing raw and stripped text, ensuring the bot always knows when it has been addressed.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue
N/A

## 📚 Technical Context (Skip for Docs)
- **Problem**: Slack delivers unordered `message` and `app_mention` events for the same @mention. Previously, PicoClaw processed both separately and used different `chatID` formats for each, leading to split AI histories and double replies.
- **Reasoning**: By centralizing the deduplication in the Slack channel and unifying the `chatID` format to use `channelID` / `channelID/threadTS`, we ensure a single consistent session is maintained for the conversation.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows 11
- **Model/Provider:** Anthropic Sonnet 3.7
- **Channels:** Slack Socket Mode

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.