### PR TITLE
fix(telegram): resolve streaming redundant drafts and routing

### DIFF
--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -888,7 +888,7 @@ func (c *TelegramChannel) BeginStream(ctx context.Context, chatID string) (chann
 		return nil, fmt.Errorf("streaming disabled in config")
 	}
 
-	cid, _, err := parseTelegramChatID(chatID)
+	cid, tid, err := parseTelegramChatID(chatID)
 	if err != nil {
 		return nil, err
 	}
@@ -897,6 +897,7 @@ func (c *TelegramChannel) BeginStream(ctx context.Context, chatID string) (chann
 	return &telegramStreamer{
 		bot:              c.bot,
 		chatID:           cid,
+		threadID:         tid,
 		draftID:          cryptoRandInt(),
 		throttleInterval: time.Duration(streamCfg.ThrottleSeconds) * time.Second,
 		minGrowth:        streamCfg.MinGrowthChars,
@@ -909,6 +910,7 @@ func (c *TelegramChannel) BeginStream(ctx context.Context, chatID string) (chann
 type telegramStreamer struct {
 	bot              *telego.Bot
 	chatID           int64
+	threadID         int
 	draftID          int
 	throttleInterval time.Duration
 	minGrowth        int
@@ -936,10 +938,11 @@ func (s *telegramStreamer) Update(ctx context.Context, content string) error {
 	htmlContent := markdownToTelegramHTML(content)
 
 	err := s.bot.SendMessageDraft(ctx, &telego.SendMessageDraftParams{
-		ChatID:    s.chatID,
-		DraftID:   s.draftID,
-		Text:      htmlContent,
-		ParseMode: telego.ModeHTML,
+		ChatID:          s.chatID,
+		MessageThreadID: s.threadID,
+		DraftID:         s.draftID,
+		Text:            htmlContent,
+		ParseMode:       telego.ModeHTML,
 	})
 	if err != nil {
 		// First error → degrade silently (e.g. no forum mode)
@@ -958,6 +961,9 @@ func (s *telegramStreamer) Update(ctx context.Context, content string) error {
 func (s *telegramStreamer) Finalize(ctx context.Context, content string) error {
 	htmlContent := markdownToTelegramHTML(content)
 	tgMsg := tu.Message(tu.ID(s.chatID), htmlContent)
+	if s.threadID != 0 {
+		tgMsg.MessageThreadID = s.threadID
+	}
 	tgMsg.ParseMode = telego.ModeHTML
 
 	if _, err := s.bot.SendMessage(ctx, tgMsg); err != nil {
@@ -972,11 +978,29 @@ func (s *telegramStreamer) Finalize(ctx context.Context, content string) error {
 			return fmt.Errorf("telegram finalize: %w", err)
 		}
 	}
+
+	// Always clear the partial draft after final delivery to avoid UI ghosts (best-effort)
+	if !s.failed {
+		_ = s.bot.SendMessageDraft(ctx, &telego.SendMessageDraftParams{
+			ChatID:          s.chatID,
+			MessageThreadID: s.threadID,
+			DraftID:         s.draftID,
+			Text:            "",
+		})
+	}
+
 	return nil
 }
 
 func (s *telegramStreamer) Cancel(ctx context.Context) {
-	// Draft auto-expires on Telegram's side; nothing to clean up.
+	if !s.failed {
+		_ = s.bot.SendMessageDraft(ctx, &telego.SendMessageDraftParams{
+			ChatID:          s.chatID,
+			MessageThreadID: s.threadID,
+			DraftID:         s.draftID,
+			Text:            "",
+		})
+	}
 }
 
 // cryptoRandInt returns a non-zero random int using crypto/rand.


### PR DESCRIPTION
## 📝 Description

This PR fixes two significant bugs in PicoClaw's Telegram streaming implementation: the UI glitch where partial drafts linger after final message delivery, and a critical routing failure where streaming responses targeted the wrong conversation area in Forums/Topics.

Key improvements:
- **Best-Effort Draft Clear**: Explicitly clears partial drafts via `SendMessageDraft` with an empty string in `Finalize` and `Cancel`. This removes "ghost" duplicate messages in the Telegram UI.
- **Thread-ID Routing**: Plumbed the Telegram `thread_id` into the `telegramStreamer`. Partial updates and the final message now correctly respect the target Topic in multi-topic groups.
- **Graceful Failure**: Wrapped draft clearing in error-ignoring blocks (e.g., bot lacks forum permissions), ensuring no regressions for standard chats.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue
N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** Telegram briefly shows the draft alongside the delivered message if not explicitly cleared. Additionally, the previous streamer implementation ignored `MessageThreadID`, causing routing failures in Topics.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows 11
- **Model/Provider:** Anthropic Sonnet 3.7
- **Channels:** Telegram (Partial Streaming)


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.