### PR TITLE
fix: use prior assistant text when LLM returns empty after tool execution

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1689,6 +1689,7 @@ func (al *AgentLoop) runTurn(ctx context.Context, ts *turnState) (turnResult, er
 	activeCandidates, activeModel := al.selectCandidates(ts.agent, ts.userMessage, messages)
 	pendingMessages := append([]providers.Message(nil), ts.opts.InitialSteeringMessages...)
 	var finalContent string
+	var lastAssistantTextContent string // text from last response that also had tool calls
 
 turnLoop:
 	for ts.currentIteration() < ts.agent.MaxIterations || len(pendingMessages) > 0 || func() bool {
@@ -2169,6 +2170,9 @@ turnLoop:
 			})
 
 		allResponsesHandled := len(normalizedToolCalls) > 0
+		if response.Content != "" {
+			lastAssistantTextContent = response.Content
+		}
 		assistantMsg := providers.Message{
 			Role:             "assistant",
 			Content:          response.Content,
@@ -2668,6 +2672,9 @@ turnLoop:
 	if finalContent == "" {
 		if ts.currentIteration() >= ts.agent.MaxIterations && ts.agent.MaxIterations > 0 {
 			finalContent = toolLimitResponse
+		} else if lastAssistantTextContent != "" {
+			// LLM returned empty after tool execution but already provided text in the tool-call response
+			finalContent = lastAssistantTextContent
 		} else {
 			finalContent = ts.opts.DefaultResponse
 		}


### PR DESCRIPTION
## Summary

- When the LLM returns both text content and tool calls in the same response, the follow-up LLM call after tool execution sometimes returns an empty response (the model considers the turn complete since it already answered)
- In this case, `finalContent` stays empty and the user sees the generic `"The model returned an empty response..."` error instead of the actual reply
- Fix: track the last non-empty assistant text content (`lastAssistantTextContent`) and use it as a fallback before falling back to `defaultResponse`

## Test plan

- [ ] Send a message that causes the LLM to respond with text + tool call simultaneously (e.g. `write_file` with memory update)
- [ ] Verify the user receives the text response instead of the error message
- [ ] Verify behavior is unchanged when the LLM returns empty with no prior text (still shows `defaultResponse`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)