### PR TITLE
fix(loop): cpu usage continous polling

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -387,10 +387,17 @@ func (al *AgentLoop) Run(ctx context.Context) error {
 		return err
 	}
 
-	for al.running.Load() {
+	idleTicker := time.NewTicker(100 * time.Millisecond)
+	defer idleTicker.Stop()
+
+	for {
 		select {
 		case <-ctx.Done():
 			return nil
+		case <-idleTicker.C:
+			if !al.running.Load() {
+				return nil
+			}
 		case msg, ok := <-al.bus.InboundChan():
 			if !ok {
 				return nil
@@ -517,12 +524,8 @@ func (al *AgentLoop) Run(ctx context.Context) error {
 					al.publishResponseIfNeeded(ctx, target.Channel, target.ChatID, finalResponse)
 				}
 			}()
-		default:
-			time.Sleep(time.Microsecond * 200)
 		}
 	}
-
-	return nil
 }
 
 // drainBusToSteering consumes inbound messages and redirects messages from the


### PR DESCRIPTION
## 📝 Description

This PR optimizes the main event loop in `pkg/agent/loop.go` by replacing the semi-busy polling mechanism with a blocking, channel-based `select` statement.

Previously, the loop relied on a `default` case with a 200-microsecond sleep (`time.Sleep(time.Microsecond * 200)`), which caused unnecessary CPU wake-ups and higher-than-needed idle resource consumption. The new implementation listens directly to `ctx.Done()`, `al.bus.InboundChan()`, and a 100ms `idleTicker`, making the loop truly event-driven and significantly improving CPU efficiency when the agent is idle.

## 🗣️ Type of Change

  - [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 📖 Documentation update
  - [x] ⚡ Code refactoring (no functional changes, no api changes) *(Performance optimization)*

## 🤖 AI Code Generation

  - [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
  - [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
  - [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes \#\#\# 📚 Technical Context (Skip for Docs)

  - **Reference URL:** N/A
  - **Reasoning:** The `AgentLoop` should block efficiently when there are no incoming messages. Using a `select` statement with the `InboundChan` and context cancellation avoids the "busy wait" anti-pattern. The 100ms ticker is introduced to safely periodically check the `al.running` atomic flag without burning CPU cycles.

## 🧪 Test Environment

  - **Hardware:** [Please fill this in]
  - **OS:** [Please fill this in]
  - **Model/Provider:** N/A (Core Loop optimization)
  - **Channels:** N/A

## 📸 Evidence (Optional)

## ☑️ Checklist

  - [x] My code/docs follow the style of this project.
  - [x] I have performed a self-review of my own changes.
  - [x] I have updated the documentation accordingly.
