### PR TITLE
fix(openai_compat): parse Hermes-style XML tool calls as fallback

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -41,6 +42,18 @@ type Provider struct {
 type Option func(*Provider)
 
 const defaultRequestTimeout = common.DefaultRequestTimeout
+
+// xmlToolCallPattern matches <toolcall>…</toolcall> blocks used by models such as
+// Qwen/Hermes-derived ones (e.g. mimo-v2-pro) that do not emit OpenAI function-call
+// JSON but instead produce a lightweight XML format:
+//
+//	<toolcall><shell>{"command":"ls"}</shell></toolcall>
+//
+// The inner tag name is the tool name; its text content is a JSON argument object.
+var (
+	xmlToolCallPattern = regexp.MustCompile(`(?is)<toolcall>\s*(.*?)\s*</toolcall>`)
+	xmlTagOpenPattern  = regexp.MustCompile(`(?i)^<(\w+)>`)
+)
 
 func WithMaxTokensField(maxTokensField string) Option {
 	return func(p *Provider) {
@@ -194,7 +207,12 @@ func (p *Provider) Chat(
 		return nil, common.HandleErrorResponse(resp, p.apiBase)
 	}
 
-	return common.ReadAndParseResponse(resp, p.apiBase)
+	out, err := common.ReadAndParseResponse(resp, p.apiBase)
+	if err != nil {
+		return nil, err
+	}
+	applyXMLToolCallFallback(out)
+	return out, nil
 }
 
 // ChatStream implements streaming via OpenAI-compatible SSE (stream: true).
@@ -378,12 +396,85 @@ func parseStreamResponse(
 		finishReason = "stop"
 	}
 
-	return &LLMResponse{
+	out := &LLMResponse{
 		Content:      textContent.String(),
 		ToolCalls:    toolCalls,
 		FinishReason: finishReason,
 		Usage:        usage,
-	}, nil
+	}
+	applyXMLToolCallFallback(out)
+	return out, nil
+}
+
+// applyXMLToolCallFallback detects and parses Hermes-style XML tool calls from
+// response content when no standard OpenAI tool_calls were returned. It mutates
+// resp in place: extracted calls are moved to ToolCalls, matched text is stripped
+// from Content, and FinishReason is set to "tool_calls".
+func applyXMLToolCallFallback(resp *LLMResponse) {
+	if resp == nil || len(resp.ToolCalls) > 0 {
+		return
+	}
+	if !strings.Contains(resp.Content, "<toolcall>") && !strings.Contains(resp.Content, "<toolcall ") {
+		return
+	}
+	toolCalls, stripped := parseXMLToolCalls(resp.Content)
+	if len(toolCalls) == 0 {
+		return
+	}
+	resp.ToolCalls = toolCalls
+	resp.Content = stripped
+	resp.FinishReason = "tool_calls"
+}
+
+// parseXMLToolCalls extracts tool calls from Hermes-style XML blocks and returns
+// them along with the content with those blocks removed.
+func parseXMLToolCalls(content string) ([]ToolCall, string) {
+	matches := xmlToolCallPattern.FindAllStringSubmatch(content, -1)
+	if len(matches) == 0 {
+		return nil, content
+	}
+
+	var toolCalls []ToolCall
+	for _, m := range matches {
+		inner := strings.TrimSpace(m[1])
+		// Extract opening tag name (Go regexp has no backreferences, so parse manually).
+		nm := xmlTagOpenPattern.FindStringSubmatch(inner)
+		if nm == nil {
+			continue
+		}
+		name := nm[1]
+		// Content is between the opening and closing tag.
+		after := inner[len(nm[0]):]
+		closeTag := "</" + name + ">"
+		closeIdx := strings.LastIndex(strings.ToLower(after), strings.ToLower(closeTag))
+		argsStr := after
+		if closeIdx >= 0 {
+			argsStr = after[:closeIdx]
+		}
+		argsStr = strings.TrimSpace(argsStr)
+
+		var args map[string]any
+		if err := json.Unmarshal([]byte(argsStr), &args); err != nil {
+			continue
+		}
+		argsJSON, _ := json.Marshal(args)
+		toolCalls = append(toolCalls, ToolCall{
+			ID:        fmt.Sprintf("call_%d", len(toolCalls)+1),
+			Type:      "function",
+			Name:      name,
+			Arguments: args,
+			Function: &FunctionCall{
+				Name:      name,
+				Arguments: string(argsJSON),
+			},
+		})
+	}
+
+	if len(toolCalls) == 0 {
+		return nil, content
+	}
+	stripped := strings.TrimSpace(xmlToolCallPattern.ReplaceAllString(content, ""))
+	return toolCalls, stripped
 }
 
 func normalizeModel(model, apiBase string) string {

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -158,6 +158,131 @@ func TestProviderChat_ParsesToolCallsWithObjectArguments(t *testing.T) {
 	}
 }
 
+func TestProviderChat_ParsesXMLToolCalls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{
+					"message": map[string]any{
+						"content": "<toolcall><shell>{\"command\":\"pwd && ls -la\"}</shell></toolcall>",
+					},
+					"finish_reason": "stop",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	out, err := p.Chat(t.Context(), []Message{{Role: "user", Content: "ls please"}}, nil, "mimo-v2-pro", nil)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(out.ToolCalls))
+	}
+	if out.ToolCalls[0].Name != "shell" {
+		t.Fatalf("ToolCalls[0].Name = %q, want shell", out.ToolCalls[0].Name)
+	}
+	if out.ToolCalls[0].Arguments["command"] != "pwd && ls -la" {
+		t.Fatalf("command = %v, want pwd && ls -la", out.ToolCalls[0].Arguments["command"])
+	}
+	if out.Content != "" {
+		t.Fatalf("Content = %q, want empty after stripping toolcall block", out.Content)
+	}
+	if out.FinishReason != "tool_calls" {
+		t.Fatalf("FinishReason = %q, want tool_calls", out.FinishReason)
+	}
+}
+
+func TestProviderChat_XMLToolCallsNotParsedWhenStandardCallsPresent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{
+					"message": map[string]any{
+						"content": "",
+						"tool_calls": []map[string]any{
+							{
+								"id":   "call_1",
+								"type": "function",
+								"function": map[string]any{
+									"name":      "shell",
+									"arguments": `{"command":"ls"}`,
+								},
+							},
+						},
+					},
+					"finish_reason": "tool_calls",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	out, err := p.Chat(t.Context(), []Message{{Role: "user", Content: "ls"}}, nil, "gpt-4o", nil)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+	if len(out.ToolCalls) != 1 || out.ToolCalls[0].Name != "shell" {
+		t.Fatalf("unexpected ToolCalls: %v", out.ToolCalls)
+	}
+}
+
+func TestParseXMLToolCalls(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantCalls int
+		wantTool  string
+		wantArg   string
+		wantVal   string
+	}{
+		{
+			name:      "simple shell call",
+			content:   "<toolcall><shell>{\"command\":\"ls\"}</shell></toolcall>",
+			wantCalls: 1, wantTool: "shell", wantArg: "command", wantVal: "ls",
+		},
+		{
+			name:      "with surrounding text",
+			content:   "Let me check:\n<toolcall><list_dir>{\"path\":\"/tmp\"}</list_dir></toolcall>",
+			wantCalls: 1, wantTool: "list_dir", wantArg: "path", wantVal: "/tmp",
+		},
+		{
+			name: "no toolcall tag — not parsed",
+			content:   "<shell>{\"command\":\"ls\"}</shell>",
+			wantCalls: 0,
+		},
+		{
+			name:      "invalid json inside — skipped",
+			content:   "<toolcall><shell>not json</shell></toolcall>",
+			wantCalls: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			calls, _ := parseXMLToolCalls(tc.content)
+			if len(calls) != tc.wantCalls {
+				t.Fatalf("len(calls) = %d, want %d", len(calls), tc.wantCalls)
+			}
+			if tc.wantCalls > 0 {
+				if calls[0].Name != tc.wantTool {
+					t.Fatalf("Name = %q, want %q", calls[0].Name, tc.wantTool)
+				}
+				if calls[0].Arguments[tc.wantArg] != tc.wantVal {
+					t.Fatalf("arg %q = %v, want %q", tc.wantArg, calls[0].Arguments[tc.wantArg], tc.wantVal)
+				}
+			}
+		})
+	}
+}
+
 func TestProviderChat_ParsesReasoningContent(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]any{


### PR DESCRIPTION
## Problem

Models derived from Qwen/Hermes fine-tunes (e.g. mimo-v2-pro) do not emit standard OpenAI function-call JSON. Instead they produce a lightweight XML format when tool use is requested:

\`\`\`xml
<toolcall><shell>{"command":"pwd && ls -la"}</shell></toolcall>
\`\`\`

The \`openai_compat\` provider does not recognise this format, so the raw XML leaks into the chat response as plain text instead of being executed as a tool call.

## Solution

After parsing the standard response, if \`tool_calls\` is empty but the content contains a \`<toolcall>\` block, fall back to XML parsing:

- Outer \`<toolcall>…</toolcall>\` delimits one call per block
- Inner tag name → tool name
- Inner text content → JSON-decoded argument map

The fallback is applied in both the non-streaming (\`Chat\`) and streaming (\`parseStreamResponse\`) paths.

**Safety gates** (no false positives):
- Only triggers when \`<toolcall>\` is present in content
- Skipped entirely when standard \`tool_calls\` are already populated
- Invalid JSON inside a block is silently skipped

Follows the same pattern as #2049 (LongCat markup tool calls).