### PR TITLE
feat(mcp): support DisableStandaloneSSE for HTTP transport

### DIFF
--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -276,14 +276,25 @@ func (m *Manager) ConnectServer(
 		if cfg.URL == "" {
 			return fmt.Errorf("URL is required for SSE/HTTP transport")
 		}
+
+		// Configure DisableStandaloneSSE based on transport type.
+		// - "http": Request-response only mode. Disable the standalone SSE stream
+		//   to avoid compatibility issues with servers that don't support GET /mcp.
+		// - "sse": Bidirectional mode. Enable the standalone SSE stream to receive
+		//   server-initiated notifications (e.g., ToolListChangedNotification).
+		// - Empty or auto-detected: Defaults to "sse" behavior (standalone SSE enabled).
+		disableStandaloneSSE := (cfg.Type == "http")
+
 		logger.DebugCF("mcp", "Using SSE/HTTP transport",
 			map[string]any{
-				"server": name,
-				"url":    cfg.URL,
+				"server":               name,
+				"url":                  cfg.URL,
+				"disableStandaloneSSE": disableStandaloneSSE,
 			})
 
 		sseTransport := &mcp.StreamableClientTransport{
-			Endpoint: cfg.URL,
+			Endpoint:             cfg.URL,
+			DisableStandaloneSSE: disableStandaloneSSE,
 		}
 
 		// Add custom headers if provided


### PR DESCRIPTION
## 📝 Description

This PR adds support for `DisableStandaloneSSE` configuration in the MCP manager. 
- Automatically sets `DisableStandaloneSSE: true` when `cfg.Type == "http"`.
- This ensures compatibility with MCP servers that only support request-response mode and do not implement a standalone SSE stream.

## 🗣️ Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## 🤖 AI Code Generation
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## 📚 Technical Context
- **Reasoning:** Some MCP servers are strictly request-response. Forcing a standalone SSE connection can cause timeouts or 404 errors on those specific endpoints.

## 🧪 Test Environment
- **Hardware:** Mac mini M1
- **OS:** macOS (Darwin)

## ☑️ Checklist
- [x] My code follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.