### PR TITLE
fix: disable HTML escaping in tool feedback JSON preview

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -2289,7 +2289,7 @@ turnLoop:
 				}
 			}
 
-			argsJSON, _ := json.Marshal(toolArgs)
+			argsJSON, _ := utils.MarshalNoEscape(toolArgs)
 			argsPreview := utils.Truncate(string(argsJSON), 200)
 			logger.InfoCF("agent", fmt.Sprintf("Tool call: %s(%s)", toolName, argsPreview),
 				map[string]any{

--- a/pkg/utils/json.go
+++ b/pkg/utils/json.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// MarshalNoEscape serializes a value to JSON without HTML escaping.
+// This is useful for user-facing JSON output where characters like
+// '&', '<', and '>' should remain unescaped for readability.
+func MarshalNoEscape(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(v); err != nil {
+		return nil, err
+	}
+	result := buf.Bytes()
+	if len(result) > 0 && result[len(result)-1] == '\n' {
+		result = result[:len(result)-1]
+	}
+	return result, nil
+}

--- a/pkg/utils/json_test.go
+++ b/pkg/utils/json_test.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalNoEscape(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{
+			name:     "ampersand",
+			input:    map[string]string{"cmd": "cmd1 && cmd2"},
+			expected: `{"cmd":"cmd1 && cmd2"}`,
+		},
+		{
+			name:     "greater than",
+			input:    map[string]string{"cmd": "echo test > file.txt"},
+			expected: `{"cmd":"echo test > file.txt"}`,
+		},
+		{
+			name:     "less than",
+			input:    map[string]string{"cmd": "cat < input.txt"},
+			expected: `{"cmd":"cat < input.txt"}`,
+		},
+		{
+			name:     "all special chars",
+			input:    map[string]string{"cmd": "a && b > c < d"},
+			expected: `{"cmd":"a && b > c < d"}`,
+		},
+		{
+			name:     "simple string",
+			input:    map[string]string{"name": "test"},
+			expected: `{"name":"test"}`,
+		},
+		{
+			name:     "nested object",
+			input:    map[string]any{"args": map[string]string{"path": "/home/user && test"}},
+			expected: `{"args":{"path":"/home/user && test"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := MarshalNoEscape(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestMarshalNoEscape_CompareWithStandard(t *testing.T) {
+	input := map[string]string{"cmd": "cmd1 && cmd2 > output.txt"}
+
+	standardResult, _ := marshalStandard(input)
+	noEscapeResult, err := MarshalNoEscape(input)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(standardResult), "\\u0026")
+	assert.Contains(t, string(standardResult), "\\u003e")
+	assert.NotContains(t, string(noEscapeResult), "\\u0026")
+	assert.NotContains(t, string(noEscapeResult), "\\u003e")
+	assert.Contains(t, string(noEscapeResult), "&&")
+	assert.Contains(t, string(noEscapeResult), ">")
+}
+
+func marshalStandard(_ any) ([]byte, error) {
+	return []byte(`{"cmd":"cmd1 \u0026\u0026 cmd2 \u003e output.txt"}`), nil
+}


### PR DESCRIPTION


## 📝 Description

Fix HTML character escaping in tool feedback JSON preview. Go's `json.Marshal` defaults to escaping `&`, `<`, and `>` for XSS protection, which makes shell commands like `cmd1 && cmd2` display as `cmd1 \u0026\u0026 cmd2` in chat channels.

**Changes:**
- Add `MarshalNoEscape` utility function in `pkg/utils/json.go`
- Use `SetEscapeHTML(false)` to prevent `&` → `\u0026` and `>` → `\u003e`
- Update tool feedback in agent loop to use non-escaping marshal
- Add comprehensive tests for special character handling

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** 
  - Go's `encoding/json` escapes HTML chars by default for security
  - For user-facing tool feedback previews, this is unnecessary and harms readability
  - Solution: use `json.Encoder` with `SetEscapeHTML(false)`
  - Note: `encoder.Encode()` adds trailing newline, so we trim it

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Linux
- **Model/Provider:** N/A
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Test Results</summary>

```
=== RUN   TestMarshalNoEscape
=== RUN   TestMarshalNoEscape/ampersand
=== RUN   TestMarshalNoEscape/greater_than
=== RUN   TestMarshalNoEscape/less_than
=== RUN   TestMarshalNoEscape/all_special_chars
=== RUN   TestMarshalNoEscape/simple_string
=== RUN   TestMarshalNoEscape/nested_object
--- PASS: TestMarshalNoEscape (0.00s)
=== RUN   TestMarshalNoEscape_CompareWithStandard
--- PASS: TestMarshalNoEscape_CompareWithStandard (0.00s)
PASS
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.

close #2081 