### PR TITLE
fix(web): merge _secret edit fields when GET omits public secret keys

### DIFF
--- a/web/frontend/src/components/channels/channel-config-page.tsx
+++ b/web/frontend/src/components/channels/channel-config-page.tsx
@@ -105,6 +105,22 @@ function buildSavePayload(
     payload[key] = value
   }
 
+  // When GET config omits secret fields (redacted), editConfig may only have `_secret`
+  // keys; the loop above skips `_` keys and never sees a public `app_secret` etc., so
+  // merge those edit-buffer values here. Only touch secrets that appear in edit state
+  // so we do not inject unrelated empty secret keys for every channel type.
+  for (const [secretKey, editKey] of Object.entries(SECRET_FIELD_MAP)) {
+    if (Object.prototype.hasOwnProperty.call(payload, secretKey)) {
+      continue
+    }
+    if (!(editKey in editConfig) && !(secretKey in editConfig)) {
+      continue
+    }
+    const incoming = asString(editConfig[editKey])
+    const stored = asString(editConfig[secretKey])
+    payload[secretKey] = incoming !== "" ? incoming : stored
+  }
+
   if (channel.name === "whatsapp_native") {
     payload.use_native = true
   }


### PR DESCRIPTION
## 📝 Description

buildSavePayload only iterated non-_ keys, so when the API omits redacted secrets (e.g. no app_secret in the loaded config), users could fill _app_secret in the form but the saved payload never received app_secret, triggering false “required field” validation (e.g. Feishu).

Add a second pass over SECRET_FIELD_MAP to merge _secret / secret into payload when the public key was not set in the first loop, only if that secret appears in editConfig, avoiding unrelated empty keys for other channel types.
<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.