### PR TITLE
fix: resolve typecheck errors in loop_test.go and dingtalk_test.go

### DIFF
--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1783,20 +1783,16 @@ func TestProcessMessage_ModelRoutingUsesLightProvider(t *testing.T) {
 				ModelName: "gemini-main",
 				Model:     "gemini/gemini-2.5-flash",
 				APIBase:   heavyServer.URL,
+				APIKeys:   config.SimpleSecureStrings("heavy-key"),
 			},
 			{
 				ModelName: "qwen-light",
 				Model:     "ollama/qwen2.5:0.5b",
 				APIBase:   lightServer.URL,
+				APIKeys:   config.SimpleSecureStrings("light-key"),
 			},
 		},
 	}
-	cfg.WithSecurity(&config.SecurityConfig{
-		ModelList: map[string]config.ModelSecurityEntry{
-			"gemini-main": {APIKeys: []string{"heavy-key"}},
-			"qwen-light":  {APIKeys: []string{"light-key"}},
-		},
-	})
 
 	msgBus := bus.NewMessageBus()
 	provider, _, err := providers.CreateProvider(cfg)

--- a/pkg/channels/dingtalk/dingtalk_test.go
+++ b/pkg/channels/dingtalk/dingtalk_test.go
@@ -17,8 +17,8 @@ func newTestDingTalkChannel(t *testing.T, cfg config.DingTalkConfig) (*DingTalkC
 	if cfg.ClientID == "" {
 		cfg.ClientID = "test-client-id"
 	}
-	if cfg.ClientSecret() == "" {
-		cfg.SetClientSecret("test-client-secret")
+	if cfg.ClientSecret.String() == "" {
+		cfg.ClientSecret.Set("test-client-secret")
 	}
 
 	msgBus := bus.NewMessageBus()


### PR DESCRIPTION
## 📝 Description

Set APIKeys directly on ModelConfig using SimpleSecureStrings() instead of non-existent WithSecurity/SecurityConfig/ModelSecurityEntry.

Fix Lint Failed

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.