### PR TITLE
fix(web): honor forwarded headers for Pico websocket URLs

### DIFF
--- a/web/backend/api/gateway_host.go
+++ b/web/backend/api/gateway_host.go
@@ -47,6 +47,13 @@ func gatewayProbeHost(bindHost string) string {
 	return bindHost
 }
 
+func firstForwardedValue(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	return strings.TrimSpace(strings.Split(raw, ",")[0])
+}
+
 func (h *Handler) gatewayProxyURL() *url.URL {
 	cfg, err := config.LoadConfig(h.configPath)
 	port := 18790
@@ -62,17 +69,6 @@ func (h *Handler) gatewayProxyURL() *url.URL {
 		Scheme: "http",
 		Host:   net.JoinHostPort(gatewayProbeHost(bindHost), strconv.Itoa(port)),
 	}
-}
-
-func requestHostName(r *http.Request) string {
-	reqHost, _, err := net.SplitHostPort(r.Host)
-	if err == nil {
-		return reqHost
-	}
-	if strings.TrimSpace(r.Host) != "" {
-		return r.Host
-	}
-	return "127.0.0.1"
 }
 
 func requestWSScheme(r *http.Request) string {
@@ -93,16 +89,37 @@ func requestWSScheme(r *http.Request) string {
 	return "ws"
 }
 
-func (h *Handler) buildWsURL(r *http.Request, cfg *config.Config) string {
-	host := h.effectiveGatewayBindHost(cfg)
-	if host == "" || host == "0.0.0.0" {
-		host = requestHostName(r)
+func requestWSAuthority(r *http.Request) string {
+	scheme := requestWSScheme(r)
+	authority := firstForwardedValue(r.Header.Get("X-Forwarded-Host"))
+	if authority == "" {
+		authority = strings.TrimSpace(r.Host)
 	}
-	// Use web server port instead of gateway port to avoid exposing extra ports
-	// The WebSocket connection will be proxied by the backend to the gateway
-	wsPort := h.serverPort
-	if wsPort == 0 {
-		wsPort = 18800 // default web server port
+	if authority == "" {
+		return "127.0.0.1"
 	}
-	return requestWSScheme(r) + "://" + net.JoinHostPort(host, strconv.Itoa(wsPort)) + "/pico/ws"
+
+	parsed, err := url.Parse("//" + authority)
+	if err != nil {
+		return authority
+	}
+	if parsed.Port() != "" {
+		return authority
+	}
+
+	forwardedPort := firstForwardedValue(r.Header.Get("X-Forwarded-Port"))
+	if forwardedPort == "" {
+		return authority
+	}
+	if (scheme == "wss" && forwardedPort == "443") || (scheme == "ws" && forwardedPort == "80") {
+		return authority
+	}
+	if parsed.Hostname() == "" {
+		return authority
+	}
+	return net.JoinHostPort(parsed.Hostname(), forwardedPort)
+}
+
+func buildWsURL(r *http.Request) string {
+	return requestWSScheme(r) + "://" + requestWSAuthority(r) + "/pico/ws"
 }

--- a/web/backend/api/gateway_host_test.go
+++ b/web/backend/api/gateway_host_test.go
@@ -31,27 +31,11 @@ func TestGatewayHostOverrideUsesExplicitRuntimePublic(t *testing.T) {
 	}
 }
 
-func TestBuildWsURLUsesRequestHostWhenLauncherPublicSaved(t *testing.T) {
-	configPath := filepath.Join(t.TempDir(), "config.json")
-	launcherPath := launcherconfig.PathForAppConfig(configPath)
-	if err := launcherconfig.Save(launcherPath, launcherconfig.Config{
-		Port:   18800,
-		Public: true,
-	}); err != nil {
-		t.Fatalf("launcherconfig.Save() error = %v", err)
-	}
-
-	h := NewHandler(configPath)
-	h.SetServerOptions(18800, false, false, nil)
-
-	cfg := config.DefaultConfig()
-	cfg.Gateway.Host = "127.0.0.1"
-	cfg.Gateway.Port = 18790
-
+func TestBuildWsURLUsesRequestHostWhenNoForwardedHost(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://launcher.local/api/pico/token", nil)
 	req.Host = "192.168.1.9:18800"
 
-	if got := h.buildWsURL(req, cfg); got != "ws://192.168.1.9:18800/pico/ws" {
+	if got := buildWsURL(req); got != "ws://192.168.1.9:18800/pico/ws" {
 		t.Fatalf("buildWsURL() = %q, want %q", got, "ws://192.168.1.9:18800/pico/ws")
 	}
 }
@@ -136,53 +120,56 @@ func TestGetGatewayHealthUsesProbeHostForPublicLauncher(t *testing.T) {
 }
 
 func TestBuildWsURLUsesWSSWhenForwardedProtoIsHTTPS(t *testing.T) {
-	configPath := filepath.Join(t.TempDir(), "config.json")
-	h := NewHandler(configPath)
-
-	cfg := config.DefaultConfig()
-	cfg.Gateway.Host = "0.0.0.0"
-	cfg.Gateway.Port = 18790
-
 	req := httptest.NewRequest("GET", "http://launcher.local/api/pico/token", nil)
 	req.Host = "chat.example.com"
 	req.Header.Set("X-Forwarded-Proto", "https")
 
-	if got := h.buildWsURL(req, cfg); got != "wss://chat.example.com:18800/pico/ws" {
-		t.Fatalf("buildWsURL() = %q, want %q", got, "wss://chat.example.com:18800/pico/ws")
+	if got := buildWsURL(req); got != "wss://chat.example.com/pico/ws" {
+		t.Fatalf("buildWsURL() = %q, want %q", got, "wss://chat.example.com/pico/ws")
 	}
 }
 
 func TestBuildWsURLUsesWSSWhenRequestIsTLS(t *testing.T) {
-	configPath := filepath.Join(t.TempDir(), "config.json")
-	h := NewHandler(configPath)
-
-	cfg := config.DefaultConfig()
-	cfg.Gateway.Host = "0.0.0.0"
-	cfg.Gateway.Port = 18790
-
 	req := httptest.NewRequest("GET", "https://launcher.local/api/pico/token", nil)
 	req.Host = "secure.example.com"
 	req.TLS = &tls.ConnectionState{}
 
-	if got := h.buildWsURL(req, cfg); got != "wss://secure.example.com:18800/pico/ws" {
-		t.Fatalf("buildWsURL() = %q, want %q", got, "wss://secure.example.com:18800/pico/ws")
+	if got := buildWsURL(req); got != "wss://secure.example.com/pico/ws" {
+		t.Fatalf("buildWsURL() = %q, want %q", got, "wss://secure.example.com/pico/ws")
 	}
 }
 
 func TestBuildWsURLPrefersForwardedHTTPOverTLS(t *testing.T) {
-	configPath := filepath.Join(t.TempDir(), "config.json")
-	h := NewHandler(configPath)
-
-	cfg := config.DefaultConfig()
-	cfg.Gateway.Host = "0.0.0.0"
-	cfg.Gateway.Port = 18790
-
 	req := httptest.NewRequest("GET", "https://launcher.local/api/pico/token", nil)
 	req.Host = "chat.example.com"
 	req.TLS = &tls.ConnectionState{}
 	req.Header.Set("X-Forwarded-Proto", "http")
 
-	if got := h.buildWsURL(req, cfg); got != "ws://chat.example.com:18800/pico/ws" {
-		t.Fatalf("buildWsURL() = %q, want %q", got, "ws://chat.example.com:18800/pico/ws")
+	if got := buildWsURL(req); got != "ws://chat.example.com/pico/ws" {
+		t.Fatalf("buildWsURL() = %q, want %q", got, "ws://chat.example.com/pico/ws")
+	}
+}
+
+func TestBuildWsURLUsesForwardedHostWithoutDefaultHTTPSPort(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://launcher.local/api/pico/token", nil)
+	req.Host = "127.0.0.1:18800"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "pico.rex.cc")
+	req.Header.Set("X-Forwarded-Port", "443")
+
+	if got := buildWsURL(req); got != "wss://pico.rex.cc/pico/ws" {
+		t.Fatalf("buildWsURL() = %q, want %q", got, "wss://pico.rex.cc/pico/ws")
+	}
+}
+
+func TestBuildWsURLUsesForwardedHostWithNonDefaultPort(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://launcher.local/api/pico/token", nil)
+	req.Host = "127.0.0.1:18800"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "pico.rex.cc")
+	req.Header.Set("X-Forwarded-Port", "8443")
+
+	if got := buildWsURL(req); got != "wss://pico.rex.cc:8443/pico/ws" {
+		t.Fatalf("buildWsURL() = %q, want %q", got, "wss://pico.rex.cc:8443/pico/ws")
 	}
 }

--- a/web/backend/api/pico.go
+++ b/web/backend/api/pico.go
@@ -53,7 +53,7 @@ func (h *Handler) handleGetPicoToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wsURL := h.buildWsURL(r, cfg)
+	wsURL := buildWsURL(r)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
@@ -81,7 +81,7 @@ func (h *Handler) handleRegenPicoToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wsURL := h.buildWsURL(r, cfg)
+	wsURL := buildWsURL(r)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
@@ -146,7 +146,7 @@ func (h *Handler) handlePicoSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wsURL := h.buildWsURL(r, cfg)
+	wsURL := buildWsURL(r)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{


### PR DESCRIPTION
## 📝 Description

This PR fixes Pico WebUI websocket URL generation for reverse-proxied deployments.

Before this change, the backend could return a websocket URL that exposed the internal launcher port, for example `wss://<domain>:18800/pico/ws`. In reverse-proxy setups where the public WebUI is served through `443` or another forwarded port, the browser would try to connect to the internal port directly and fail.

This change:
- builds Pico websocket URLs from the externally visible request authority instead of the internal launcher port
- honors `X-Forwarded-Host`, `X-Forwarded-Port`, and `X-Forwarded-Proto`
- keeps request host fallback behavior when no forwarded headers are present
- adds regression coverage for default HTTPS and custom forwarded ports

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Related to #1737

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
  - [#1737](https://github.com/sipeed/picoclaw/issues/1737)
  - [Comment: Nginx reverse proxy still connects to `:18800`](https://github.com/sipeed/picoclaw/issues/1737#issuecomment-4096398136)
  - [Comment: `gateway_host.go` should not force `18800`](https://github.com/sipeed/picoclaw/issues/1737#issuecomment-4102342011)
  - [Comment: `/api/pico/token` returns a websocket URL tied to `18800`](https://github.com/sipeed/picoclaw/issues/1737#issuecomment-4115852770)
- **Reasoning:**
  - Multiple users reported that reverse-proxied WebUI deployments still received websocket URLs such as `wss://<domain>:18800/pico/ws`, which breaks when the public endpoint is served through `443` or another forwarded port.
  - The current implementation built the Pico websocket URL from the internal launcher port instead of the externally visible request authority.
  - This patch derives the websocket authority from forwarded request headers or the request host so reverse-proxied deployments can connect through the public endpoint without exposing the internal launcher port.

## 🧪 Test Environment
- **Hardware:** Apple Silicon Mac
- **OS:** macOS (darwin 25.3.0)
- **Model/Provider:** N/A (not model/provider specific; verified on the Pico WebUI websocket bootstrap path)
- **Channels:** Pico

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Validated locally with:
- `make check`
- `go test ./web/backend/api`

Regression coverage added for:
- request host fallback when no forwarded host is present
- `X-Forwarded-Proto: https`
- TLS requests without forwarded headers
- `X-Forwarded-Host` with `X-Forwarded-Port: 443`
- `X-Forwarded-Host` with `X-Forwarded-Port: 8443`

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have reviewed the documentation impact and confirmed no documentation update is needed for this bug fix.