### PR TITLE
Feat/silent processing

### DIFF
--- a/docs/chat-apps.md
+++ b/docs/chat-apps.md
@@ -144,6 +144,27 @@ You can also trigger by keyword prefixes (e.g. `!bot`):
 }
 ```
 
+**Optional: Silent observer mode**
+
+To have the agent silently read all messages (e.g. for memory/context gathering) while only responding when explicitly addressed, use `agents.defaults.silent_processing` without `group_trigger.mention_only`. Setting `mention_only` would drop non-mention messages before the agent sees them, defeating the purpose:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "silent_processing": true
+    }
+  },
+  "channels": {
+    "discord": {
+      "allow_from": ["YOUR_USER_ID", "YOUR_SERVER_ID"]
+    }
+  }
+}
+```
+
+The agent processes every message (tool calls, memory writes) but sends nothing when the LLM produces no text. Instruct the LLM via `AGENT.md` to only produce text when directly addressed.
+
 **6. Run**
 
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -361,6 +361,57 @@ The `restrict_to_workspace` setting applies consistently across all execution pa
 
 All paths share the same workspace restriction — there's no way to bypass the security boundary through subagents or scheduled tasks.
 
+### Agent Response Behavior
+
+#### `silent_processing`
+
+When `silent_processing` is `true`, the agent runs fully on every inbound message — tool calls execute, session history is written, memory files are updated — but if the LLM produces no text output, nothing is sent to the channel. The automatic empty-response fallback message is suppressed.
+
+If the LLM does produce text, it is sent as normal. `silent_processing` only suppresses the fallback, not intentional responses.
+
+| Option | Default | Description |
+|---|---|---|
+| `silent_processing` | `false` | Suppress empty-response fallback; send nothing when LLM produces no text |
+
+**Config:**
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "silent_processing": true
+    }
+  }
+}
+```
+
+**Environment variable:** `PICOCLAW_AGENTS_DEFAULTS_SILENT_PROCESSING=true`
+
+**Use case — group observer agent:**
+
+An agent added to a group chat that silently reads every message, uses `write_file` to maintain a memory log, and only responds when explicitly addressed. Do not set `group_trigger.mention_only` — that would drop non-mention messages before the agent sees them, defeating the purpose. Instead, instruct the LLM via `AGENT.md` to only produce text when addressed:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "silent_processing": true
+    }
+  },
+  "channels": {
+    "telegram": {
+      "allow_from": ["YOUR_USER_ID", "-YOUR_GROUP_ID"]
+    }
+  }
+}
+```
+
+With this setup the agent processes every group message (for memory/analysis). When the LLM produces no text, `silent_processing` suppresses the fallback and nothing is sent. When the LLM does produce text (e.g. when @mentioned), it is sent as normal.
+
+> **Note:** In silent mode, the tool-iteration-limit message is also suppressed. Background observer agents should not surface internal diagnostics to the channel.
+
+---
+
 ### Heartbeat (Periodic Tasks)
 
 PicoClaw can perform periodic tasks automatically. Create a `HEARTBEAT.md` file in your workspace:

--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -51,6 +51,10 @@ type AgentInstance struct {
 	// LightProvider is the concrete provider instance for the configured light model.
 	// It is only used when routing selects the light tier for a turn.
 	LightProvider providers.LLMProvider
+	// SilentProcessing suppresses the automatic empty-response fallback when the
+	// LLM produces no text output (e.g. only tool calls). The agent still runs
+	// fully and sends a response when the LLM produces text.
+	SilentProcessing bool
 }
 
 // NewAgentInstance creates an agent instance from config.
@@ -225,6 +229,7 @@ func NewAgentInstance(
 		Router:                    router,
 		LightCandidates:           lightCandidates,
 		LightProvider:             lightProvider,
+		SilentProcessing:          defaults.SilentProcessing,
 	}
 }
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1311,6 +1311,10 @@ func (al *AgentLoop) processMessage(ctx context.Context, msg bus.InboundMessage)
 			"route_channel": route.Channel,
 		})
 
+	resolvedDefaultResponse := defaultResponse
+	if agent.SilentProcessing {
+		resolvedDefaultResponse = ""
+	}
 	opts := processOptions{
 		SessionKey:        sessionKey,
 		Channel:           msg.Channel,
@@ -1319,7 +1323,7 @@ func (al *AgentLoop) processMessage(ctx context.Context, msg bus.InboundMessage)
 		SenderDisplayName: msg.Sender.DisplayName,
 		UserMessage:       msg.Content,
 		Media:             msg.Media,
-		DefaultResponse:   defaultResponse,
+		DefaultResponse:   resolvedDefaultResponse,
 		EnableSummary:     true,
 		SendResponse:      false,
 	}
@@ -2672,7 +2676,11 @@ turnLoop:
 		return al.abortTurn(ts)
 	}
 
-	if finalContent == "" {
+	if finalContent == "" && ts.opts.DefaultResponse != "" {
+		// In silent_processing mode DefaultResponse is "", so both the empty-response
+		// fallback and the tool-iteration-limit message are suppressed. This is
+		// intentional: a background observer agent must not surface internal
+		// diagnostics to the channel.
 		if ts.currentIteration() >= ts.agent.MaxIterations && ts.agent.MaxIterations > 0 {
 			finalContent = toolLimitResponse
 		} else {
@@ -2682,7 +2690,7 @@ turnLoop:
 
 	ts.setPhase(TurnPhaseFinalizing)
 	ts.setFinalContent(finalContent)
-	if !ts.opts.NoHistory {
+	if !ts.opts.NoHistory && finalContent != "" {
 		finalMsg := providers.Message{Role: "assistant", Content: finalContent}
 		ts.agent.Sessions.AddMessage(ts.sessionKey, finalMsg.Role, finalMsg.Content)
 		ts.recordPersistedMessage(finalMsg)

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -2690,10 +2690,12 @@ turnLoop:
 
 	ts.setPhase(TurnPhaseFinalizing)
 	ts.setFinalContent(finalContent)
-	if !ts.opts.NoHistory && finalContent != "" {
-		finalMsg := providers.Message{Role: "assistant", Content: finalContent}
-		ts.agent.Sessions.AddMessage(ts.sessionKey, finalMsg.Role, finalMsg.Content)
-		ts.recordPersistedMessage(finalMsg)
+	if !ts.opts.NoHistory {
+		if finalContent != "" {
+			finalMsg := providers.Message{Role: "assistant", Content: finalContent}
+			ts.agent.Sessions.AddMessage(ts.sessionKey, finalMsg.Role, finalMsg.Content)
+			ts.recordPersistedMessage(finalMsg)
+		}
 		if err := ts.agent.Sessions.Save(ts.sessionKey); err != nil {
 			turnStatus = TurnEndStatusError
 			al.emitEvent(

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -3030,3 +3030,115 @@ func TestProcessMessage_ContextOverflow_AnthropicStyle(t *testing.T) {
 		t.Fatalf("expected 2 calls for retry, got %d", provider.calls)
 	}
 }
+
+// emptyProvider returns an empty LLM response (no text, no tool calls).
+type emptyProvider struct{}
+
+func (e *emptyProvider) Chat(
+	ctx context.Context,
+	messages []providers.Message,
+	tools []providers.ToolDefinition,
+	model string,
+	opts map[string]any,
+) (*providers.LLMResponse, error) {
+	return &providers.LLMResponse{Content: "", ToolCalls: []providers.ToolCall{}}, nil
+}
+
+func (e *emptyProvider) GetDefaultModel() string { return "mock-model" }
+
+// TestSilentProcessing_EmptyResponseSuppressed verifies that when
+// silent_processing is enabled, an empty LLM response does not produce the
+// default error fallback — the agent returns "" so the channel sends nothing.
+func TestSilentProcessing_EmptyResponseSuppressed(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				ModelName:         "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+				SilentProcessing:  true,
+			},
+		},
+	}
+	msgBus := bus.NewMessageBus()
+	al := NewAgentLoop(cfg, msgBus, &emptyProvider{})
+
+	response, err := al.processMessage(context.Background(), bus.InboundMessage{
+		Channel:  "telegram",
+		SenderID: "telegram:123",
+		ChatID:   "group-1",
+		Content:  "hello from the group",
+	})
+	if err != nil {
+		t.Fatalf("processMessage() error = %v", err)
+	}
+	if response != "" {
+		t.Fatalf("processMessage() response = %q, want empty string in silent mode", response)
+	}
+}
+
+// TestSilentProcessing_TextResponseStillSent verifies that when
+// silent_processing is enabled, an LLM response that contains text is still
+// returned normally — silent mode only suppresses the empty-response fallback.
+func TestSilentProcessing_TextResponseStillSent(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				ModelName:         "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+				SilentProcessing:  true,
+			},
+		},
+	}
+	msgBus := bus.NewMessageBus()
+	al := NewAgentLoop(cfg, msgBus, &mockProvider{})
+
+	response, err := al.processMessage(context.Background(), bus.InboundMessage{
+		Channel:  "telegram",
+		SenderID: "telegram:123",
+		ChatID:   "group-1",
+		Content:  "hey @samanda what time is it?",
+	})
+	if err != nil {
+		t.Fatalf("processMessage() error = %v", err)
+	}
+	if response != "Mock response" {
+		t.Fatalf("processMessage() response = %q, want %q", response, "Mock response")
+	}
+}
+
+// TestDefaultMode_EmptyResponseGetsFallback verifies that without
+// silent_processing the default error message is returned for empty LLM output.
+func TestDefaultMode_EmptyResponseGetsFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				ModelName:         "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+			},
+		},
+	}
+	msgBus := bus.NewMessageBus()
+	al := NewAgentLoop(cfg, msgBus, &emptyProvider{})
+
+	response, err := al.processMessage(context.Background(), bus.InboundMessage{
+		Channel:  "telegram",
+		SenderID: "telegram:123",
+		ChatID:   "chat-1",
+		Content:  "hello",
+	})
+	if err != nil {
+		t.Fatalf("processMessage() error = %v", err)
+	}
+	if response != defaultResponse {
+		t.Fatalf("processMessage() response = %q, want default fallback %q", response, defaultResponse)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -327,6 +327,7 @@ type AgentDefaults struct {
 	SubTurn                   SubTurnConfig      `json:"subturn"                                                                                     envPrefix:"PICOCLAW_AGENTS_DEFAULTS_SUBTURN_"`
 	ToolFeedback              ToolFeedbackConfig `json:"tool_feedback,omitempty"`
 	SplitOnMarker             bool               `json:"split_on_marker"                 env:"PICOCLAW_AGENTS_DEFAULTS_SPLIT_ON_MARKER"` // split messages on <|[SPLIT]|> marker
+	SilentProcessing          bool               `json:"silent_processing,omitempty"     env:"PICOCLAW_AGENTS_DEFAULTS_SILENT_PROCESSING"`
 }
 
 const DefaultMaxMediaSize = 20 * 1024 * 1024 // 20 MB


### PR DESCRIPTION
## Description

Adds `silent_processing` to `agents.defaults`. When enabled, the agent processes every inbound message fully — tool calls execute, session history is written — but if the LLM produces no text output, no message is sent to the channel. The automatic empty-response fallback (`"The model returned an empty response..."`) is suppressed. Explicit LLM text responses are sent as normal.

This enables observer agents that monitor group conversations and perform background work (e.g. `write_file` calls to maintain memory) without producing chat noise on every silent turn.

## Type of Change

- [x] New feature (non-breaking, opt-in via config)

## 🤖 AI Code Generation

- [x] 🤖 Fully AI-generated — reviewed and tested by contributor

## Related Issue

Closes #2126

## Technical Context

PicoClaw's `processOptions.DefaultResponse` was already a string field, always set to the hardcoded constant. This PR makes the value conditional on a new `AgentDefaults.SilentProcessing` flag — when true, `DefaultResponse` is `""`. The existing guard `if finalContent == "" && ts.opts.DefaultResponse != ""` then leaves `finalContent` empty, and `publishResponseIfNeeded` already has an early-return for empty strings.

Two session history fixes: the assistant message write is gated on `finalContent != ""` to avoid writing empty assistant messages (which cause provider errors on the next turn); the `Session.Save` call is separated from the assistant write so the session is always flushed to disk — without this, user messages added to the in-memory session during a silent turn would be lost on restart.

Both the empty-response fallback and the tool-iteration-limit message are suppressed in silent mode. This is intentional: a background observer agent must not surface internal diagnostics to the channel.

## Test Environment

- Hardware: Raspberry Pi 4 (ARM64, Debian)
- Provider: Ollama (local, Qwen model)
- Channel: Telegram group chat
- Verified: agent writes to `memory/MEMORY.md` via `write_file` on each group message; no response appears in Telegram when LLM produces no text output

## Evidence

Config used for verification:
```json
{
  "agents": {
    "defaults": {
      "silent_processing": true
    }
  }
}
```

## Checklist

- [x] Code follows the existing style and passes `make check`
- [x] Tests added: empty response suppressed in silent mode, text response still sent in silent mode, default fallback preserved in normal mode
- [x] Docs updated: `docs/configuration.md` (new section with group observer pattern), `docs/chat-apps.md` (silent observer example); both clarify the distinction between `silent_processing` and `group_trigger.mention_only`
- [x] No breaking changes — existing deployments unaffected (`silent_processing` defaults to `false`)
- [x] Rebased onto current `main`