### PR TITLE
fix(cron): keep deliver=false cron jobs silent

### DIFF
--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -411,7 +411,8 @@ func (t *CronTool) ExecuteJob(ctx context.Context, job *cron.CronJob) string {
 		return fmt.Sprintf("Error: %v", err)
 	}
 
-	if response != "" {
+	// deliver=false should execute silently: no outbound publish path.
+	if job.Payload.Deliver && response != "" {
 		t.executor.PublishResponseIfNeeded(ctx, channel, chatID, response)
 	}
 	return "ok"

--- a/pkg/tools/cron_test.go
+++ b/pkg/tools/cron_test.go
@@ -280,7 +280,7 @@ func TestCronTool_ExecuteJobPublishesErrorWhenExecDisabled(t *testing.T) {
 	}
 }
 
-func TestCronTool_ExecuteJobPublishesAgentResponse(t *testing.T) {
+func TestCronTool_ExecuteJobDeliverFalseRunsAgentSilently(t *testing.T) {
 	executor := &stubJobExecutor{response: "generated reply"}
 	tool := newTestCronToolWithExecutorAndConfig(t, executor, config.DefaultConfig())
 
@@ -302,11 +302,8 @@ func TestCronTool_ExecuteJobPublishesAgentResponse(t *testing.T) {
 	if executor.lastPrompt != "send me a poem" {
 		t.Fatalf("prompt = %q, want original message", executor.lastPrompt)
 	}
-	if executor.publishedResp != "generated reply" {
-		t.Fatalf("published response = %q, want generated reply", executor.publishedResp)
-	}
-	if executor.publishedChan != "telegram" || executor.publishedChatID != "chat-1" {
-		t.Fatalf("published target = %s/%s, want telegram/chat-1", executor.publishedChan, executor.publishedChatID)
+	if executor.publishedResp != "" {
+		t.Fatalf("expected no published response for deliver=false, got %q", executor.publishedResp)
 	}
 }
 
@@ -365,8 +362,8 @@ func TestCronTool_ExecuteJobDirectiveAddsPromptPrefix(t *testing.T) {
 	if executor.lastPrompt != wantPrompt {
 		t.Fatalf("prompt = %q, want exact %q", executor.lastPrompt, wantPrompt)
 	}
-	if executor.publishedResp != "directive result" {
-		t.Fatalf("published response = %q, want %q", executor.publishedResp, "directive result")
+	if executor.publishedResp != "" {
+		t.Fatalf("expected no published response for deliver=false directive job, got %q", executor.publishedResp)
 	}
 }
 
@@ -400,6 +397,29 @@ func TestCronTool_ExecuteJobDirectiveWithDeliverRoutesToAgent(t *testing.T) {
 		t.Fatalf("unexpected direct bus message: %+v", msg)
 	case <-ctx.Done():
 		// expected: no direct bus message
+	}
+}
+
+func TestCronTool_ExecuteJobDirectiveWithDeliverFalseStaysSilent(t *testing.T) {
+	executor := &stubJobExecutor{response: "agent processed"}
+	tool := newTestCronToolWithExecutorAndConfig(t, executor, config.DefaultConfig())
+
+	job := &cron.CronJob{ID: "job-dir-silent"}
+	job.Payload.Channel = "telegram"
+	job.Payload.To = "chat-1"
+	job.Payload.Message = "generate daily report"
+	job.Payload.Type = "directive"
+	job.Payload.Deliver = false
+
+	if got := tool.ExecuteJob(context.Background(), job); got != "ok" {
+		t.Fatalf("ExecuteJob() = %q, want ok", got)
+	}
+
+	if executor.lastPrompt == "" {
+		t.Fatal("expected agent to be called for directive+deliver=false, but ProcessDirectWithChannel was not invoked")
+	}
+	if executor.publishedResp != "" {
+		t.Fatalf("expected no published response for deliver=false directive job, got %q", executor.publishedResp)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep deliver:false cron jobs silent by preventing outbound publish of agent responses in CronTool.ExecuteJob
- preserve existing delivered behavior for deliver:true jobs
- add focused cron tests covering silent and delivered paths

Closes #2120

## Tests
- go test ./pkg/tools -run TestCronTool_ExecuteJob -count=1
- go test ./pkg/tools -run TestCronTool_ -count=1