### PR TITLE
Fix/qq channel reconnect and test coverage

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1941,23 +1941,41 @@ turnLoop:
 				return al.abortTurn(ts)
 			}
 
-			errMsg := strings.ToLower(err.Error())
-			isTimeoutError := errors.Is(err, context.DeadlineExceeded) ||
-				strings.Contains(errMsg, "deadline exceeded") ||
-				strings.Contains(errMsg, "client.timeout") ||
-				strings.Contains(errMsg, "timed out") ||
-				strings.Contains(errMsg, "timeout exceeded")
+			// Extract typed FailoverReason from the error chain.
+			// FallbackChain already classifies errors; the outer retry loop
+			// only handles specific recoverable scenarios.
+			var failErr *providers.FailoverError
+			failReason := providers.FailoverUnknown
+			if errors.As(err, &failErr) {
+				failReason = failErr.Reason
+			} else if errors.Is(err, context.DeadlineExceeded) {
+				failReason = providers.FailoverTimeout
+			} else {
+				// Single-candidate path: classify raw error via ClassifyError
+				// to maintain backward compatibility with provider error messages.
+				errMsg := strings.ToLower(err.Error())
+				if strings.Contains(errMsg, "deadline exceeded") ||
+					strings.Contains(errMsg, "client.timeout") ||
+					strings.Contains(errMsg, "timed out") ||
+					strings.Contains(errMsg, "timeout exceeded") {
+					failReason = providers.FailoverTimeout
+				} else if strings.Contains(errMsg, "context_length_exceeded") ||
+					strings.Contains(errMsg, "context window") ||
+					strings.Contains(errMsg, "context_window") ||
+					strings.Contains(errMsg, "maximum context length") ||
+					strings.Contains(errMsg, "token limit") ||
+					strings.Contains(errMsg, "too many tokens") ||
+					strings.Contains(errMsg, "max_tokens") ||
+					strings.Contains(errMsg, "invalidparameter") ||
+					strings.Contains(errMsg, "prompt is too long") ||
+					strings.Contains(errMsg, "request too large") {
+					failReason = providers.FailoverContextOverflow
+				}
+			}
 
-			isContextError := !isTimeoutError && (strings.Contains(errMsg, "context_length_exceeded") ||
-				strings.Contains(errMsg, "context window") ||
-				strings.Contains(errMsg, "context_window") ||
-				strings.Contains(errMsg, "maximum context length") ||
-				strings.Contains(errMsg, "token limit") ||
-				strings.Contains(errMsg, "too many tokens") ||
-				strings.Contains(errMsg, "max_tokens") ||
-				strings.Contains(errMsg, "invalidparameter") ||
-				strings.Contains(errMsg, "prompt is too long") ||
-				strings.Contains(errMsg, "request too large"))
+			isTimeoutError := failReason == providers.FailoverTimeout
+
+			isContextError := failReason == providers.FailoverContextOverflow
 
 			if isTimeoutError && retry < maxRetries {
 				backoff := time.Duration(retry+1) * 5 * time.Second

--- a/pkg/channels/qq/qq.go
+++ b/pkg/channels/qq/qq.go
@@ -35,12 +35,15 @@ import (
 )
 
 const (
-	dedupTTL      = 5 * time.Minute
-	dedupInterval = 60 * time.Second
-	dedupMaxSize  = 10000 // hard cap on dedup map entries
-	typingResend  = 8 * time.Second
-	typingSeconds = 10
-	bytesPerMiB   = 1024 * 1024
+	dedupTTL             = 5 * time.Minute
+	dedupInterval        = 60 * time.Second
+	dedupMaxSize         = 10000 // hard cap on dedup map entries
+	typingResend         = 8 * time.Second
+	typingSeconds        = 10
+	bytesPerMiB          = 1024 * 1024
+	reconnectInitial     = 5 * time.Second
+	reconnectMax         = 5 * time.Minute
+	reconnectMultiplier  = 2.0
 )
 
 type qqAPI interface {
@@ -127,6 +130,28 @@ func (c *QQChannel) Start(ctx context.Context) error {
 	// initialize OpenAPI client
 	c.api = botgo.NewOpenAPI(c.config.AppID, c.tokenSource).WithTimeout(5 * time.Second)
 
+	// start dedup janitor goroutine
+	go c.dedupJanitor()
+
+	// Pre-register reasoning_channel_id as group chat if configured,
+	// so outbound-only destinations are routed correctly.
+	if c.config.ReasoningChannelID != "" {
+		c.chatType.Store(c.config.ReasoningChannelID, "group")
+	}
+
+	// Start the reconnect loop. It handles both the initial connection and
+	// subsequent reconnection attempts with exponential backoff.
+	go c.reconnectLoop()
+
+	c.SetRunning(true)
+	logger.InfoC("qq", "QQ bot started successfully")
+
+	return nil
+}
+
+// startSession fetches a fresh WebSocket endpoint and starts the session manager.
+// It blocks until the session goroutine exits (i.e. the WebSocket connection drops).
+func (c *QQChannel) startSession() error {
 	// register event handlers
 	intent := event.RegisterHandlers(
 		c.handleC2CMessage(),
@@ -146,29 +171,59 @@ func (c *QQChannel) Start(ctx context.Context) error {
 	// create and save sessionManager
 	c.sessionManager = botgo.NewSessionManager()
 
-	// start WebSocket connection in goroutine to avoid blocking
-	go func() {
-		if err := c.sessionManager.Start(wsInfo, c.tokenSource, &intent); err != nil {
-			logger.ErrorCF("qq", "WebSocket session error", map[string]any{
-				"error": err.Error(),
-			})
-			c.SetRunning(false)
+	return c.sessionManager.Start(wsInfo, c.tokenSource, &intent)
+}
+
+// reconnectLoop manages the QQ WebSocket session lifecycle with exponential backoff.
+// On initial start or after a disconnect, it re-acquires the WebSocket endpoint
+// and re-initializes the session manager.
+func (c *QQChannel) reconnectLoop() {
+	backoff := reconnectInitial
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-c.done:
+			return
+		default:
 		}
-	}()
 
-	// start dedup janitor goroutine
-	go c.dedupJanitor()
+		// Check if channel was explicitly stopped.
+		if !c.IsRunning() {
+			return
+		}
 
-	// Pre-register reasoning_channel_id as group chat if configured,
-	// so outbound-only destinations are routed correctly.
-	if c.config.ReasoningChannelID != "" {
-		c.chatType.Store(c.config.ReasoningChannelID, "group")
+		logger.InfoCF("qq", "Starting QQ session", map[string]any{
+			"backoff": backoff.String(),
+		})
+
+		err := c.startSession()
+		if err == nil {
+			// Session exited cleanly (e.g. via Stop/cancel).
+			return
+		}
+
+		// Session failed or disconnected -- log and schedule retry.
+		logger.WarnCF("qq", "QQ session ended, reconnecting", map[string]any{
+			"error": err.Error(),
+		})
+
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-c.done:
+			return
+		case <-time.After(backoff):
+			if backoff < reconnectMax {
+				next := time.Duration(float64(backoff) * reconnectMultiplier)
+				if next > reconnectMax {
+					next = reconnectMax
+				}
+				backoff = next
+			}
+		}
 	}
-
-	c.SetRunning(true)
-	logger.InfoC("qq", "QQ bot started successfully")
-
-	return nil
 }
 
 func (c *QQChannel) Stop(ctx context.Context) error {

--- a/pkg/providers/error_classifier.go
+++ b/pkg/providers/error_classifier.go
@@ -102,6 +102,16 @@ var (
 		rxp(`image exceeds.*mb`),
 	}
 
+	modelNotFoundPatterns = []errorPattern{
+		rxp(`model[_ ]?not[_ ]?found`),
+		rxp(`does not exist.*model`),
+		rxp(`model.*does not exist`),
+		rxp(`invalid model`),
+		rxp(`model.*not available`),
+		rxp(`model.*not supported`),
+		rxp(`unknown model`),
+	}
+
 	// Transient HTTP status codes that map to timeout (server-side failures).
 	transientStatusCodes = map[int]bool{
 		500: true, 502: true, 503: true,
@@ -147,6 +157,21 @@ func ClassifyError(err error, provider, model string) *FailoverError {
 	// Try HTTP status code extraction first.
 	if status := extractHTTPStatus(msg); status > 0 {
 		if reason := classifyByStatus(status); reason != "" {
+			// For transient status codes (5xx), the message body may contain a
+			// more specific, non-transient error (e.g. zhipu returns 503 with
+			// "model_not_found"). Check message patterns and prefer them when
+			// they indicate a concrete, non-transient failure.
+			if isTransientStatus(status) {
+				if msgReason := classifyByMessage(msg); msgReason != "" && msgReason != FailoverTimeout {
+					return &FailoverError{
+						Reason:  msgReason,
+						Provider: provider,
+						Model:    model,
+						Status:   status,
+						Wrapped:  err,
+					}
+				}
+			}
 			return &FailoverError{
 				Reason:   reason,
 				Provider: provider,
@@ -192,6 +217,9 @@ func classifyByStatus(status int) FailoverReason {
 // classifyByMessage matches error messages against patterns.
 // Priority order matters (from OpenClaw classifyFailoverReason).
 func classifyByMessage(msg string) FailoverReason {
+	if matchesAny(msg, modelNotFoundPatterns) {
+		return FailoverFormat // model_not_found is a configuration error, not retriable
+	}
 	if matchesAny(msg, rateLimitPatterns) {
 		return FailoverRateLimit
 	}
@@ -262,4 +290,10 @@ func parseDigits(s string) int {
 		}
 	}
 	return n
+}
+
+// isTransientStatus returns true for 5xx status codes that represent
+// server-side transient failures (should be retried via fallback).
+func isTransientStatus(status int) bool {
+	return transientStatusCodes[status]
 }

--- a/pkg/providers/error_classifier_test.go
+++ b/pkg/providers/error_classifier_test.go
@@ -264,6 +264,97 @@ func TestClassifyError_UnknownError(t *testing.T) {
 	}
 }
 
+func TestClassifyError_ModelNotFoundPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     string
+		want    FailoverReason
+		wantOK  bool
+	}{
+		// Exact pattern: model_not_found (zhipu actual format)
+		{name: "model_not_found", msg: "model_not_found", want: FailoverFormat, wantOK: true},
+		// Space-separated
+		{name: "model not found", msg: "model not found", want: FailoverFormat, wantOK: true},
+		// invalid model
+		{name: "invalid model", msg: "invalid model", want: FailoverFormat, wantOK: true},
+		// model does not exist
+		{name: "model does not exist", msg: "model does not exist", want: FailoverFormat, wantOK: true},
+		// Case insensitive
+		{name: "Model_Not_Found upper", msg: "Model_Not_Found", want: FailoverFormat, wantOK: true},
+		// model not supported
+		{name: "model not supported", msg: "model not supported", want: FailoverFormat, wantOK: true},
+		// model not available
+		{name: "model not available", msg: "model not available", want: FailoverFormat, wantOK: true},
+		// unknown model
+		{name: "unknown model", msg: "unknown model", want: FailoverFormat, wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := errors.New(tt.msg)
+			result := ClassifyError(err, "zhipu", "glm-4")
+			if tt.wantOK {
+				if result == nil {
+					t.Fatalf("expected non-nil for %q", tt.msg)
+				}
+				if result.Reason != tt.want {
+					t.Errorf("reason = %q, want %q", result.Reason, tt.want)
+				}
+			} else {
+				if result != nil {
+					t.Errorf("expected nil for %q, got %+v", tt.msg, result)
+				}
+			}
+		})
+	}
+}
+
+func TestClassifyError_TransientStatusOverride(t *testing.T) {
+	// When a transient 5xx status (e.g. 503) is accompanied by a
+	// model_not_found message body, the message pattern should win over
+	// the status code classification. This verifies the isTransientStatus
+	// override logic in ClassifyError.
+	tests := []struct {
+		name   string
+		errMsg string
+		want   FailoverReason
+	}{
+		{
+			name:   "503 with model_not_found should be format not timeout",
+			errMsg: "API error: status: 503 model_not_found",
+			want:   FailoverFormat,
+		},
+		{
+			name:   "500 with model not found should be format not timeout",
+			errMsg: "API error: status: 500 model not found",
+			want:   FailoverFormat,
+		},
+		{
+			name:   "502 with invalid model should be format not timeout",
+			errMsg: "status 502 - invalid model",
+			want:   FailoverFormat,
+		},
+		{
+			name:   "503 without model pattern should remain timeout",
+			errMsg: "API error: status: 503 service unavailable",
+			want:   FailoverTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := errors.New(tt.errMsg)
+			result := ClassifyError(err, "zhipu", "glm-4")
+			if result == nil {
+				t.Fatalf("expected non-nil for %q", tt.errMsg)
+			}
+			if result.Reason != tt.want {
+				t.Errorf("reason = %q, want %q", result.Reason, tt.want)
+			}
+		})
+	}
+}
+
 func TestClassifyError_ProviderModelPropagation(t *testing.T) {
 	err := errors.New("rate limit exceeded")
 	result := ClassifyError(err, "my-provider", "my-model")

--- a/pkg/providers/fallback.go
+++ b/pkg/providers/fallback.go
@@ -302,3 +302,14 @@ func (e *FallbackExhaustedError) Error() string {
 	}
 	return sb.String()
 }
+
+// Unwrap returns the last non-skipped attempt's error for errors.Is/As traversal.
+// This allows errors.As(err, &FailoverError{}) to work through FallbackExhaustedError.
+func (e *FallbackExhaustedError) Unwrap() error {
+	for i := len(e.Attempts) - 1; i >= 0; i-- {
+		if !e.Attempts[i].Skipped && e.Attempts[i].Error != nil {
+			return e.Attempts[i].Error
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
 ## 📝 Description

  - Fix QQ channel WebSocket disconnect resulting in permanent channel death. Add `reconnectLoop()` with exponential backoff (5s→5min) that re-acquires WS endpoint and re-creates
   SessionManager on each reconnect.
  - Fix `model_not_found` errors (e.g. zhipu 503) being misclassified as `FailoverTimeout` (retriable) instead of `FailoverFormat` (non-retriable). Add transient status override
  logic and 7 regex patterns for model-not-found variants.
  - Add `FallbackExhaustedError.Unwrap()` to enable `errors.As` traversal through fallback chain.
  - Refactor `agent/loop.go` retry logic to use typed `FailoverReason` from error chain instead of raw string matching.
  - Add 12 unit tests covering model_not_found patterns and transient status override behavior.

  ## 🗣️ Type of Change
  - [x] 🐞 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 📖 Documentation update
  - [ ] ⚡ Code refactoring (no functional changes, no api changes)

  ## 🤖 AI Code Generation
  - [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
  - [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
  - [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

  ## 🔗 Related Issue

  Analysis from runtime logs at `/tmp/picoclaw.log` showing repeated QQ WebSocket failures (session timeout → auth fail → invalid session) and model_not_found misclassification.

  ## 📚 Technical Context (Skip for Docs)
  - **Reasoning:** QQ channel `sessionManager.Start()` failure permanently set `Running=false` with no retry. Zhipu returns 503 with `model_not_found` body, which was classified
  as transient timeout triggering pointless retries.

  ## 🧪 Test Environment
  - **Hardware:** macOS
  - **OS:** Darwin 24.6.0
  - **Model/Provider:** zhipu / MiniMax-M2.5-highspeed
  - **Channels:** QQ

  ## 📸 Evidence (Optional)
  <details>
  <summary>Click to view QQ WebSocket error pattern from logs</summary>

  23:44:58 ERR LLM call failed error="failover(format): provider=zhipu model=glm-5 status=503: model_not_found"
  00:26:53 ERR [ws] read message failed: can't assign requested address
  00:26:55 ERR [ws] Listening stop. err is code:9005, text:invalid session
  00:56:58 ERR [ws] read message failed: websocket: close 4009: Session timed out
  → repeats every ~30 minutes, channel never recovers

  </details>

  ## ☑️ Checklist
  - [x] My code/docs follow the style of this project.
  - [x] I have performed a self-review of my own changes.
  - [ ] I have updated the documentation accordingly.