### PR TITLE
make logger more clear with highlight component and use package name for default component

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -21,6 +21,8 @@ const (
 	WARN  = zerolog.WarnLevel
 	ERROR = zerolog.ErrorLevel
 	FATAL = zerolog.FatalLevel
+
+	Component = "component"
 )
 
 var (
@@ -50,6 +52,18 @@ func init() {
 
 			// Custom formatter to handle multiline strings and JSON objects
 			FormatFieldValue: formatFieldValue,
+			PartsOrder: []string{
+				zerolog.TimestampFieldName,
+				zerolog.LevelFieldName,
+				Component,
+				zerolog.CallerFieldName,
+				zerolog.MessageFieldName,
+			},
+			FieldsExclude: []string{Component},
+			FormatPrepare: func(fields map[string]any) error {
+				fields[Component] = fmt.Sprintf("\x1b[33m%v\x1b[0m", fields[Component])
+				return nil
+			},
 		}
 
 		logger = zerolog.New(consoleWriter).With().Timestamp().Caller().Logger()
@@ -193,7 +207,19 @@ func ConfigureFromEnv() {
 	}
 }
 
-func getCallerSkip() int {
+func getPackageNameFromFile(filePath string) string {
+	dir := filepath.Dir(filePath)
+	importPath := filepath.ToSlash(dir)
+
+	parts := strings.Split(importPath, "/")
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return parts[len(parts)-1]
+}
+
+func getCallerSkip() (int, string) {
 	for i := 2; i < 15; i++ {
 		pc, file, _, ok := runtime.Caller(i)
 		if !ok {
@@ -217,10 +243,10 @@ func getCallerSkip() int {
 			continue
 		}
 
-		return i - 1
+		return i - 1, getPackageNameFromFile(file)
 	}
 
-	return 3
+	return 3, "<unknown>"
 }
 
 //nolint:zerologlint
@@ -246,13 +272,15 @@ func logMessage(level LogLevel, component string, message string, fields map[str
 		return
 	}
 
-	skip := getCallerSkip()
+	skip, pkg := getCallerSkip()
 
 	event := getEvent(logger, level)
 
-	if component != "" {
-		event.Str("component", component)
+	if component == "" {
+		component = pkg
 	}
+
+	event.Str(Component, component)
 
 	appendFields(event, fields)
 	event.CallerSkipFrame(skip).Msg(message)
@@ -261,10 +289,7 @@ func logMessage(level LogLevel, component string, message string, fields map[str
 	if fileLogger.GetLevel() != zerolog.NoLevel {
 		fileEvent := getEvent(fileLogger, level)
 
-		if component != "" {
-			fileEvent.Str("component", component)
-		}
-		// fileEvent.Str("caller", fmt.Sprintf("%s:%d (%s)", callerFile, callerLine, callerFunc))
+		fileEvent.Str(Component, component)
 
 		appendFields(fileEvent, fields)
 		fileEvent.CallerSkipFrame(skip).Msg(message)


### PR DESCRIPTION

make logger more clear with highlight component and use package name for default component.

detail see screenshot

## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [X] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [X] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>
<img width="744" height="236" alt="CleanShot 2026-03-29 at 18 22 34@2x" src="https://github.com/user-attachments/assets/6105de2d-dc09-4e3e-8ba5-682d43c4f096" />

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [X] My code/docs follow the style of this project.
- [X] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.