### PR TITLE
fix(web): Web Launcher skills page dark mode contrast

### DIFF
--- a/web/frontend/src/components/skills/skills-page.tsx
+++ b/web/frontend/src/components/skills/skills-page.tsx
@@ -169,7 +169,7 @@ export function SkillsPage() {
                   {data.skills.map((skill) => (
                     <Card
                       key={`${skill.source}:${skill.name}`}
-                      className="border-border/60 gap-4 bg-white/80"
+                      className="border-border/60 gap-4"
                       size="sm"
                     >
                       <CardHeader>
@@ -211,7 +211,7 @@ export function SkillsPage() {
                         <div className="text-muted-foreground text-[11px] tracking-[0.18em] uppercase">
                           {t("pages.agent.skills.path")}
                         </div>
-                        <div className="bg-muted/60 overflow-x-auto rounded-lg px-3 py-2 font-mono text-xs leading-relaxed">
+                        <div className="bg-muted text-foreground overflow-x-auto rounded-lg px-3 py-2 font-mono text-xs leading-relaxed">
                           {skill.path}
                         </div>
                       </CardContent>


### PR DESCRIPTION
## Summary

Fixes **unreadable contrast** on the Web Launcher **Skills** (`/agent/skills`) page when **dark mode** is enabled. Skill cards used a forced semi-opaque white background while typography followed the dark-theme palette, producing **light-on-light** text.

## Root cause

- Each skill `<Card>` overrode the shared `Card` styles with `bg-white/80`, which stays visually light in dark mode.
- `CardTitle` / `CardDescription` and surrounding UI assume **`bg-card` + `text-card-foreground`** (and muted variants). Overriding only the background broke that contract.

## Changes

| Area | Before | After |
|------|--------|--------|
| Skill list cards | `className` included `bg-white/80` | Removed override; default `Card` **`bg-card`** / **`text-card-foreground`** apply in both themes |
| Skill path block | `bg-muted/60` (no explicit text color) | `bg-muted` + **`text-foreground`** for consistent readability on the muted strip |

**File:** `web/frontend/src/components/skills/skills-page.tsx`

## How to verify

1. Run the web launcher (or `pnpm dev` in `web/frontend` as usual).
2. Switch UI to **dark mode**.
3. Open **Skills** (`/agent/skills`).
4. Confirm: card titles, descriptions, and action icons are clearly readable; path monospace block remains legible.

## Scope / non-goals

- No i18n or API changes.
- No changes to other pages; only the skills grid card styling touched.

## Checklist

- [x] Minimal, targeted CSS class changes (Tailwind + design tokens).
- [x] Aligns with existing `Card` component theming (`bg-card`, semantic colors).

## Before / After


**Before**
<img width="1972" height="1516" alt="image" src="https://github.com/user-attachments/assets/02a7a46f-0d98-487b-b00c-79aff1b94aa7" />

**After**
<img width="1468" height="768" alt="image" src="https://github.com/user-attachments/assets/22143a0b-c3fc-46f6-b410-bc5d5a72386c" />


