### PR TITLE
fix: preserve media store across config reloads

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -281,13 +281,17 @@ func setupAndStartServices(
 	}
 	fmt.Println("✓ Heartbeat service started")
 
-	runningServices.MediaStore = media.NewFileMediaStoreWithCleanup(media.MediaCleanerConfig{
-		Enabled:  cfg.Tools.MediaCleanup.Enabled,
-		MaxAge:   time.Duration(cfg.Tools.MediaCleanup.MaxAge) * time.Minute,
-		Interval: time.Duration(cfg.Tools.MediaCleanup.Interval) * time.Minute,
-	})
-	if fms, ok := runningServices.MediaStore.(*media.FileMediaStore); ok {
-		fms.Start()
+	// Initialize MediaStore for file uploads
+	// Note: Changes to media_cleanup config require restart to take effect
+	if runningServices.MediaStore == nil {
+		runningServices.MediaStore = media.NewFileMediaStoreWithCleanup(media.MediaCleanerConfig{
+			Enabled:  cfg.Tools.MediaCleanup.Enabled,
+			MaxAge:   time.Duration(cfg.Tools.MediaCleanup.MaxAge) * time.Minute,
+			Interval: time.Duration(cfg.Tools.MediaCleanup.Interval) * time.Minute,
+		})
+		if fms, ok := runningServices.MediaStore.(*media.FileMediaStore); ok {
+			fms.Start()
+		}
 	}
 
 	runningServices.ChannelManager, err = channels.NewManager(cfg, msgBus, runningServices.MediaStore)
@@ -359,7 +363,9 @@ func stopAndCleanupServices(runningServices *services, shutdownTimeout time.Dura
 	if runningServices.CronService != nil {
 		runningServices.CronService.Stop()
 	}
-	if runningServices.MediaStore != nil {
+	// Don't stop MediaStore on reload to preserve file references
+	// and allow cleanup goroutine to continue running
+	if !isReload && runningServices.MediaStore != nil {
 		if fms, ok := runningServices.MediaStore.(*media.FileMediaStore); ok {
 			fms.Stop()
 		}
@@ -480,13 +486,17 @@ func restartServices(
 	}
 	fmt.Println("  ✓ Heartbeat service restarted")
 
-	runningServices.MediaStore = media.NewFileMediaStoreWithCleanup(media.MediaCleanerConfig{
-		Enabled:  cfg.Tools.MediaCleanup.Enabled,
-		MaxAge:   time.Duration(cfg.Tools.MediaCleanup.MaxAge) * time.Minute,
-		Interval: time.Duration(cfg.Tools.MediaCleanup.Interval) * time.Minute,
-	})
-	if fms, ok := runningServices.MediaStore.(*media.FileMediaStore); ok {
-		fms.Start()
+	// Reuse existing MediaStore to preserve file references across reloads
+	// Note: Changes to media_cleanup config require restart to take effect
+	if runningServices.MediaStore == nil {
+		runningServices.MediaStore = media.NewFileMediaStoreWithCleanup(media.MediaCleanerConfig{
+			Enabled:  cfg.Tools.MediaCleanup.Enabled,
+			MaxAge:   time.Duration(cfg.Tools.MediaCleanup.MaxAge) * time.Minute,
+			Interval: time.Duration(cfg.Tools.MediaCleanup.Interval) * time.Minute,
+		})
+		if fms, ok := runningServices.MediaStore.(*media.FileMediaStore); ok {
+			fms.Start()
+		}
 	}
 	al.SetMediaStore(runningServices.MediaStore)
 


### PR DESCRIPTION
## Bug Fix

Prevents loss of uploaded file references when using `/reload` command.

## Problem

When calling `/reload`, a new `FileMediaStore` was created with an empty `refs` map, causing all previously uploaded files to become inaccessible with error:
```
media store: unknown ref: media://...
```

## Solution

Reuse the existing `MediaStore` instance instead of recreating it on every reload.

## Changes

- `pkg/gateway/gateway.go`: Wrap media store creation in `if runningServices.MediaStore == nil`
- Formatted with `gofmt`
- Rebased onto latest `main`

## Testing

1. Start picoclaw with Telegram enabled
2. Upload a file to the bot
3. Run `/reload` command
4. Ask bot to read the previously uploaded file
5. File is now accessible (previously failed with "unknown ref" error)

## Note

Changes to `media_cleanup` config require restart to take effect. This is an acceptable tradeoff to preserve file references.