### PR TITLE
fix(gateway): avoid repeated local model probes during idle polling

### DIFF
--- a/web/backend/api/gateway.go
+++ b/web/backend/api/gateway.go
@@ -145,6 +145,12 @@ func (h *Handler) TryAutoStartGateway() {
 
 // gatewayStartReady validates whether current config can start the gateway.
 func (h *Handler) gatewayStartReady() (bool, string, error) {
+	return h.gatewayStartReadyWithRuntimeProbe(true)
+}
+
+// gatewayStartReadyWithRuntimeProbe validates whether current config can start
+// the gateway, with optional local runtime reachability probing.
+func (h *Handler) gatewayStartReadyWithRuntimeProbe(allowRuntimeProbe bool) (bool, string, error) {
 	cfg, err := config.LoadConfig(h.configPath)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to load config: %w", err)
@@ -163,7 +169,7 @@ func (h *Handler) gatewayStartReady() (bool, string, error) {
 	if !hasModelConfiguration(modelCfg) {
 		return false, fmt.Sprintf("default model %q has no credentials configured", modelName), nil
 	}
-	if requiresRuntimeProbe(modelCfg) && !probeLocalModelAvailability(modelCfg) {
+	if allowRuntimeProbe && requiresRuntimeProbe(modelCfg) && !probeLocalModelAvailability(modelCfg) {
 		return false, fmt.Sprintf("default model %q is not reachable", modelName), nil
 	}
 
@@ -878,7 +884,8 @@ func (h *Handler) gatewayStatusData() map[string]any {
 		gatewayStatus,
 	)
 
-	ready, reason, readyErr := h.gatewayStartReady()
+	// Avoid repeated local model probes in steady-state running status polling.
+	ready, reason, readyErr := h.gatewayStartReadyWithRuntimeProbe(gatewayStatus != "running")
 	if readyErr != nil {
 		data["gateway_start_allowed"] = false
 		data["gateway_start_reason"] = readyErr.Error()

--- a/web/backend/api/gateway.go
+++ b/web/backend/api/gateway.go
@@ -878,14 +878,17 @@ func (h *Handler) gatewayStatusData() map[string]any {
 	gateway.mu.Lock()
 	bootConfigSignature := gateway.bootConfigSignature
 	gateway.mu.Unlock()
-	data["gateway_restart_required"] = gatewayRestartRequiredBySignature(
+	restartRequired := gatewayRestartRequiredBySignature(
 		bootConfigSignature,
 		currentConfigSignature,
 		gatewayStatus,
 	)
+	data["gateway_restart_required"] = restartRequired
 
 	// Avoid repeated local model probes in steady-state running status polling.
-	ready, reason, readyErr := h.gatewayStartReadyWithRuntimeProbe(gatewayStatus != "running")
+	// Keep probe-based readiness when restart is required for the current config.
+	allowRuntimeProbe := gatewayStatus != "running" || restartRequired
+	ready, reason, readyErr := h.gatewayStartReadyWithRuntimeProbe(allowRuntimeProbe)
 	if readyErr != nil {
 		data["gateway_start_allowed"] = false
 		data["gateway_start_reason"] = readyErr.Error()

--- a/web/backend/api/gateway_test.go
+++ b/web/backend/api/gateway_test.go
@@ -402,7 +402,8 @@ func TestGatewayStatusRunningSkipsRuntimeProbeForStartCondition(t *testing.T) {
 		APIBase:   "http://127.0.0.1:8000/v1",
 	}}
 	cfg.Agents.Defaults.ModelName = "local-vllm"
-	if err := config.SaveConfig(configPath, cfg); err != nil {
+	err = config.SaveConfig(configPath, cfg)
+	if err != nil {
 		t.Fatalf("SaveConfig() error = %v", err)
 	}
 
@@ -710,7 +711,8 @@ func TestGatewayStatusRunningRestartRequiredUsesRuntimeProbeForNewLocalDefault(t
 	}
 	cfg.ModelList[0].SetAPIKey("remote-key")
 	cfg.Agents.Defaults.ModelName = "remote-openai"
-	if err := config.SaveConfig(configPath, cfg); err != nil {
+	err = config.SaveConfig(configPath, cfg)
+	if err != nil {
 		t.Fatalf("SaveConfig() error = %v", err)
 	}
 

--- a/web/backend/api/gateway_test.go
+++ b/web/backend/api/gateway_test.go
@@ -385,6 +385,141 @@ func TestGatewayStatusIncludesStartConditionWhenNotReady(t *testing.T) {
 	}
 }
 
+func TestGatewayStatusRunningSkipsRuntimeProbeForStartCondition(t *testing.T) {
+	resetGatewayTestState(t)
+	resetModelProbeHooks(t)
+
+	configPath, cleanup := setupOAuthTestEnv(t)
+	defer cleanup()
+
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	cfg.ModelList = []*config.ModelConfig{{
+		ModelName: "local-vllm",
+		Model:     "vllm/custom-model",
+		APIBase:   "http://127.0.0.1:8000/v1",
+	}}
+	cfg.Agents.Defaults.ModelName = "local-vllm"
+	if err := config.SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	h := NewHandler(configPath)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	process, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess() error = %v", err)
+	}
+	gateway.mu.Lock()
+	gateway.cmd = &exec.Cmd{Process: process}
+	gateway.bootDefaultModel = "local-vllm"
+	setGatewayRuntimeStatusLocked("running")
+	gateway.mu.Unlock()
+
+	probeCalls := 0
+	probeOpenAICompatibleModelFunc = func(apiBase, modelID, apiKey string) bool {
+		probeCalls++
+		return false
+	}
+	gatewayHealthGet = func(string, time.Duration) (*http.Response, error) {
+		return mockGatewayHealthResponse(http.StatusOK, os.Getpid()), nil
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/gateway/status", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if got := body["gateway_status"]; got != "running" {
+		t.Fatalf("gateway_status = %#v, want %q", got, "running")
+	}
+	if got := body["gateway_start_allowed"]; got != true {
+		t.Fatalf("gateway_start_allowed = %#v, want true", got)
+	}
+	if probeCalls != 0 {
+		t.Fatalf("runtime probe calls = %d, want 0 while running status is healthy", probeCalls)
+	}
+}
+
+func TestGatewayStatusStoppedStillUsesRuntimeProbeForStartCondition(t *testing.T) {
+	resetGatewayTestState(t)
+	resetModelProbeHooks(t)
+
+	configPath, cleanup := setupOAuthTestEnv(t)
+	defer cleanup()
+
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	cfg.ModelList = []*config.ModelConfig{{
+		ModelName: "local-vllm",
+		Model:     "vllm/custom-model",
+		APIBase:   "http://127.0.0.1:8000/v1",
+	}}
+	cfg.Agents.Defaults.ModelName = "local-vllm"
+	if err := config.SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	h := NewHandler(configPath)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	gateway.mu.Lock()
+	gateway.cmd = nil
+	gateway.bootDefaultModel = ""
+	setGatewayRuntimeStatusLocked("stopped")
+	gateway.mu.Unlock()
+
+	probeCalls := 0
+	probeOpenAICompatibleModelFunc = func(apiBase, modelID, apiKey string) bool {
+		probeCalls++
+		return false
+	}
+	gatewayHealthGet = func(string, time.Duration) (*http.Response, error) {
+		return nil, errors.New("no gateway running")
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/gateway/status", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if got := body["gateway_status"]; got != "stopped" {
+		t.Fatalf("gateway_status = %#v, want %q", got, "stopped")
+	}
+	if got := body["gateway_start_allowed"]; got != false {
+		t.Fatalf("gateway_start_allowed = %#v, want false", got)
+	}
+	if reason, _ := body["gateway_start_reason"].(string); !strings.Contains(reason, "not reachable") {
+		t.Fatalf("gateway_start_reason = %#v, want contains %q", body["gateway_start_reason"], "not reachable")
+	}
+	if probeCalls != 1 {
+		t.Fatalf("runtime probe calls = %d, want 1 while stopped status checks start-readiness", probeCalls)
+	}
+}
+
 func TestGatewayStatusKeepsRunningWhenHealthProbeFailsAfterRunning(t *testing.T) {
 	resetGatewayTestState(t)
 

--- a/web/backend/api/gateway_test.go
+++ b/web/backend/api/gateway_test.go
@@ -686,6 +686,99 @@ func TestGatewayStatusRequiresRestartAfterDefaultModelChange(t *testing.T) {
 	}
 }
 
+func TestGatewayStatusRunningRestartRequiredUsesRuntimeProbeForNewLocalDefault(t *testing.T) {
+	resetGatewayTestState(t)
+	resetModelProbeHooks(t)
+
+	configPath, cleanup := setupOAuthTestEnv(t)
+	defer cleanup()
+
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	cfg.ModelList = []*config.ModelConfig{
+		{
+			ModelName: "remote-openai",
+			Model:     "openai/gpt-5.4",
+		},
+		{
+			ModelName: "local-vllm",
+			Model:     "vllm/custom-model",
+			APIBase:   "http://127.0.0.1:8000/v1",
+		},
+	}
+	cfg.ModelList[0].SetAPIKey("remote-key")
+	cfg.Agents.Defaults.ModelName = "remote-openai"
+	if err := config.SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	h := NewHandler(configPath)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	process, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess() error = %v", err)
+	}
+
+	bootSignature := computeConfigSignature(cfg)
+	gateway.mu.Lock()
+	gateway.cmd = &exec.Cmd{Process: process}
+	gateway.bootDefaultModel = "remote-openai"
+	gateway.bootConfigSignature = bootSignature
+	setGatewayRuntimeStatusLocked("running")
+	gateway.mu.Unlock()
+
+	updatedCfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	updatedCfg.Agents.Defaults.ModelName = "local-vllm"
+	if err := config.SaveConfig(configPath, updatedCfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	probeCalls := 0
+	probeOpenAICompatibleModelFunc = func(apiBase, modelID, apiKey string) bool {
+		probeCalls++
+		return false
+	}
+	gatewayHealthGet = func(string, time.Duration) (*http.Response, error) {
+		return mockGatewayHealthResponse(http.StatusOK, os.Getpid()), nil
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/gateway/status", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if got := body["gateway_status"]; got != "running" {
+		t.Fatalf("gateway_status = %#v, want %q", got, "running")
+	}
+	if got := body["gateway_restart_required"]; got != true {
+		t.Fatalf("gateway_restart_required = %#v, want true", got)
+	}
+	if got := body["gateway_start_allowed"]; got != false {
+		t.Fatalf("gateway_start_allowed = %#v, want false", got)
+	}
+	if reason, _ := body["gateway_start_reason"].(string); !strings.Contains(reason, "not reachable") {
+		t.Fatalf("gateway_start_reason = %#v, want contains %q", body["gateway_start_reason"], "not reachable")
+	}
+	if probeCalls != 1 {
+		t.Fatalf("runtime probe calls = %d, want 1 when running status requires restart", probeCalls)
+	}
+}
+
 func TestGatewayStatusRequiresRestartAfterToolChange(t *testing.T) {
 	resetGatewayTestState(t)
 


### PR DESCRIPTION
## Summary
- avoid local model reachability probes during steady-state `GET /api/gateway/status` polling when the gateway is already running and the config still matches the running process
- keep runtime readiness probing when a restart is actually required so the UI does not enable restart for an unreachable new local default
- add backend regression coverage for steady running, stopped, and running-with-restart-required status cases

## Testing
- go test ./web/backend/api -run 'TestGatewayStatusRunningSkipsRuntimeProbeForStartCondition|TestGatewayStatusRunningRestartRequiredUsesRuntimeProbeForNewLocalDefault|TestGatewayStatusStoppedStillUsesRuntimeProbeForStartCondition'
- go test ./web/backend/api -run 'TestGatewayStatus|TestGatewayStartReady'
- go test ./web/backend/api

Closes #2172.
