### PR TITLE
perf: precompute BM25 index for repeated searches

### DIFF
--- a/pkg/utils/bm25.go
+++ b/pkg/utils/bm25.go
@@ -29,18 +29,18 @@ const (
 	DefaultBM25B = 0.75
 )
 
-// BM25Engine is a query-time BM25 search engine over a generic corpus.
+// BM25Engine is a BM25 search engine over a generic corpus.
 // T is the document type; the caller supplies a TextFunc that extracts the
 // searchable text from each document.
 //
-// The engine is stateless between queries: no caching, no invalidation logic.
-// All indexing work is performed inside Search() on every call, making it
-// safe to use on corpora that change frequently.
+// The engine precomputes its index once at construction time and reuses it for
+// subsequent searches. If the corpus content changes, construct a new engine.
 type BM25Engine[T any] struct {
 	corpus   []T
 	textFunc func(T) string
 	k1       float64
 	b        float64
+	index    *bm25Index
 }
 
 // BM25Option is a functional option to configure a BM25Engine.
@@ -49,6 +49,17 @@ type BM25Option func(*bm25Config)
 type bm25Config struct {
 	k1 float64
 	b  float64
+}
+
+type bm25Index struct {
+	entries    []bm25DocEntry
+	idf        map[string]float32
+	docLenNorm []float32
+	posting    map[string][]int32
+}
+
+type bm25DocEntry struct {
+	tf map[string]uint32
 }
 
 // WithK1 overrides the term-frequency saturation constant (default 1.2).
@@ -74,12 +85,14 @@ func NewBM25Engine[T any](corpus []T, textFunc func(T) string, opts ...BM25Optio
 	for _, o := range opts {
 		o(&cfg)
 	}
-	return &BM25Engine[T]{
+	engine := &BM25Engine[T]{
 		corpus:   corpus,
 		textFunc: textFunc,
 		k1:       cfg.k1,
 		b:        cfg.b,
 	}
+	engine.index = buildBM25Index(corpus, textFunc, cfg.k1, cfg.b)
+	return engine
 }
 
 // BM25Result is a single ranked result from a Search call.
@@ -91,9 +104,8 @@ type BM25Result[T any] struct {
 // Search ranks the corpus against query and returns the top-k results.
 // Returns an empty slice (not nil) when there are no matches.
 //
-// Complexity: O(N×L) for indexing + O(|Q|×avgPostingLen) for scoring,
-// where N = corpus size, L = average document length, Q = query terms.
-// Top-k extraction uses a fixed-size min-heap: O(candidates × log k).
+// Complexity: O(|Q|×avgPostingLen + candidates × log k) per search after the
+// one-time indexing work performed by NewBM25Engine.
 func (e *BM25Engine[T]) Search(query string, topK int) []BM25Result[T] {
 	if topK <= 0 {
 		return []BM25Result[T]{}
@@ -104,62 +116,8 @@ func (e *BM25Engine[T]) Search(query string, topK int) []BM25Result[T] {
 		return []BM25Result[T]{}
 	}
 
-	N := len(e.corpus)
-	if N == 0 {
+	if len(e.corpus) == 0 || e.index == nil {
 		return []BM25Result[T]{}
-	}
-
-	// Step 1: build per-document tf + raw doc lengths
-	type docEntry struct {
-		tf     map[string]uint32
-		rawLen int
-	}
-
-	entries := make([]docEntry, N)
-	df := make(map[string]int, 64)
-	totalLen := 0
-
-	for i, doc := range e.corpus {
-		tokens := bm25Tokenize(e.textFunc(doc))
-		totalLen += len(tokens)
-
-		tf := make(map[string]uint32, len(tokens))
-		for _, t := range tokens {
-			tf[t]++
-		}
-		// df: each term counts once per document (iterate the map, keys are unique)
-		for t := range tf {
-			df[t]++
-		}
-
-		entries[i] = docEntry{tf: tf, rawLen: len(tokens)}
-	}
-
-	avgDocLen := float64(totalLen) / float64(N)
-
-	// Step 2: pre-compute IDF and per-doc length normalization
-	// IDF (Robertson smoothing): log( (N - df(t) + 0.5) / (df(t) + 0.5) + 1 )
-	idf := make(map[string]float32, len(df))
-	for term, freq := range df {
-		idf[term] = float32(math.Log(
-			(float64(N)-float64(freq)+0.5)/(float64(freq)+0.5) + 1,
-		))
-	}
-
-	// docLenNorm[i] = k1 * (1 - b + b * |doc_i| / avgDocLen)
-	// Stored as float32 — sufficient precision for ranking.
-	docLenNorm := make([]float32, N)
-	for i, entry := range entries {
-		docLenNorm[i] = float32(e.k1 * (1 - e.b + e.b*float64(entry.rawLen)/avgDocLen))
-	}
-
-	// Step 3: build inverted index (posting lists)
-	// Iterate the tf map directly — map keys are already unique, no seen-set needed.
-	posting := make(map[string][]int32, len(df))
-	for i, entry := range entries {
-		for term := range entry.tf {
-			posting[term] = append(posting[term], int32(i))
-		}
 	}
 
 	// Step 4: score via posting lists
@@ -168,14 +126,14 @@ func (e *BM25Engine[T]) Search(query string, topK int) []BM25Result[T] {
 
 	scores := make(map[int32]float32)
 	for _, term := range unique {
-		termIDF, ok := idf[term]
+		termIDF, ok := e.index.idf[term]
 		if !ok {
 			continue // term not in vocabulary → zero contribution
 		}
-		for _, docID := range posting[term] {
-			freq := float32(entries[docID].tf[term])
+		for _, docID := range e.index.posting[term] {
+			freq := float32(e.index.entries[docID].tf[term])
 			// TF_norm = freq * (k1+1) / (freq + docLenNorm)
-			tfNorm := freq * float32(e.k1+1) / (freq + docLenNorm[docID])
+			tfNorm := freq * float32(e.k1+1) / (freq + e.index.docLenNorm[docID])
 			scores[docID] += termIDF * tfNorm
 		}
 	}
@@ -210,6 +168,65 @@ func (e *BM25Engine[T]) Search(query string, topK int) []BM25Result[T] {
 		}
 	}
 	return out
+}
+
+func buildBM25Index[T any](corpus []T, textFunc func(T) string, k1, b float64) *bm25Index {
+	N := len(corpus)
+	if N == 0 {
+		return nil
+	}
+
+	entries := make([]bm25DocEntry, N)
+	rawLens := make([]int, N)
+	df := make(map[string]int, 64)
+	totalLen := 0
+
+	for i, doc := range corpus {
+		tokens := bm25Tokenize(textFunc(doc))
+		totalLen += len(tokens)
+		rawLens[i] = len(tokens)
+
+		tf := make(map[string]uint32, len(tokens))
+		for _, t := range tokens {
+			tf[t]++
+		}
+		for term := range tf {
+			df[term]++
+		}
+
+		entries[i] = bm25DocEntry{tf: tf}
+	}
+
+	avgDocLen := float64(totalLen) / float64(N)
+	if avgDocLen == 0 {
+		avgDocLen = 1
+	}
+
+	idf := make(map[string]float32, len(df))
+	for term, freq := range df {
+		idf[term] = float32(math.Log(
+			(float64(N)-float64(freq)+0.5)/(float64(freq)+0.5) + 1,
+		))
+	}
+
+	docLenNorm := make([]float32, N)
+	for i, rawLen := range rawLens {
+		docLenNorm[i] = float32(k1 * (1 - b + b*float64(rawLen)/avgDocLen))
+	}
+
+	posting := make(map[string][]int32, len(df))
+	for i, entry := range entries {
+		for term := range entry.tf {
+			posting[term] = append(posting[term], int32(i))
+		}
+	}
+
+	return &bm25Index{
+		entries:    entries,
+		idf:        idf,
+		docLenNorm: docLenNorm,
+		posting:    posting,
+	}
 }
 
 // bm25Tokenize splits s into lowercase tokens, stripping edge punctuation.

--- a/pkg/utils/bm25_test.go
+++ b/pkg/utils/bm25_test.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -172,4 +174,62 @@ func TestBM25Search_SortingStability(t *testing.T) {
 				i, results[i].Score, i-1, results[i-1].Score)
 		}
 	}
+}
+
+func BenchmarkBM25Search_ReusedIndex(b *testing.B) {
+	corpus := benchmarkBM25Corpus(2000)
+	engine := NewBM25Engine(corpus, extractText)
+	query := "hardware gpio i2c sensor controller latency"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		results := engine.Search(query, 10)
+		if len(results) == 0 {
+			b.Fatal("expected non-empty results")
+		}
+	}
+}
+
+func BenchmarkBM25Search_RebuildEachTime(b *testing.B) {
+	corpus := benchmarkBM25Corpus(2000)
+	query := "hardware gpio i2c sensor controller latency"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		engine := NewBM25Engine(corpus, extractText)
+		results := engine.Search(query, 10)
+		if len(results) == 0 {
+			b.Fatal("expected non-empty results")
+		}
+	}
+}
+
+func benchmarkBM25Corpus(size int) []testDoc {
+	corpus := make([]testDoc, size)
+	topics := []string{
+		"hardware gpio pwm adc sensor controller latency throughput",
+		"telegram markdown parser message escape formatting bot command",
+		"jsonl memory session history storage append compact recovery",
+		"openai provider routing agent tool search registry hidden tools",
+		"i2c spi uart serial device bus address transfer clock",
+	}
+
+	for i := range corpus {
+		topic := topics[i%len(topics)]
+		corpus[i] = testDoc{
+			ID: i,
+			Text: fmt.Sprintf(
+				"doc %d %s repeated repeated %s variant-%d %s",
+				i,
+				topic,
+				topic,
+				i%17,
+				strings.Repeat("token ", (i%7)+1),
+			),
+		}
+	}
+
+	return corpus
 }


### PR DESCRIPTION
## 📝 Description

Stop rebuilding the same search index for every query.

Precompute the BM25 index once in `NewBM25Engine()` and reuse it across repeated `Search()` calls instead of rebuilding tf/df/idf/posting data every time.

This happens in practice for hidden tool discovery: `tool_search` keeps the same hidden tool corpus while the agent retries with different natural-language queries such as `send image to user`, `upload file to chat`, or `scan i2c devices`. In that flow, only the query changes while the searchable tool set stays the same, so rebuilding the full BM25 index on every search is wasted work.

This PR also adds benchmarks showing the difference between reusing a prebuilt index and rebuilding the engine for each search.
On the added benchmark, the reused-index path is about 70x faster, with about 196x less allocated memory and about 600x fewer allocations.

This also makes the engine semantics explicit for mutable corpora: once constructed, a `BM25Engine` reflects the corpus and `textFunc` output at build time. If callers change corpus contents later and want those changes reflected in search results, they must construct a new engine.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** `pkg/tools/search_tool.go` already caches a `BM25Engine` for hidden tool discovery and reuses it until the tool registry version changes. Before this change, each `Search()` still rebuilt token frequencies, document frequencies, IDF values, and posting lists from the same corpus. The new implementation moves that one-time work into engine construction so repeated searches only score query terms against the precomputed index. This changes behavior for mutable corpora: updates made after engine construction are no longer picked up automatically, and callers must rebuild the engine when the corpus changes.

## 🧪 Test Environment
- **Hardware:** AMD Ryzen 7 7735HS PC
- **OS:** Linux
- **Model/Provider:** N/A
- **Channels:** N/A


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```text
$ go test ./pkg/utils
ok  	github.com/sipeed/picoclaw/pkg/utils	0.028s

$ go test ./pkg/utils ./pkg/tools
ok  	github.com/sipeed/picoclaw/pkg/utils	0.047s
ok  	github.com/sipeed/picoclaw/pkg/tools	12.697s

$ go test -run '^$' -bench '^BenchmarkBM25Search_' -benchmem ./pkg/utils
BenchmarkBM25Search_ReusedIndex-16           10060      115565 ns/op      19680 B/op         21 allocs/op
BenchmarkBM25Search_RebuildEachTime-16         148     8069672 ns/op    3861512 B/op      12603 allocs/op
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
