### PR TITLE
fix(tools): message tool no longer suppresses reply to originating chat

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -608,21 +608,21 @@ func (al *AgentLoop) PublishResponseIfNeeded(ctx context.Context, channel, chatI
 		return
 	}
 
-	alreadySent := false
+	alreadySentToSameChat := false
 	defaultAgent := al.GetRegistry().GetDefaultAgent()
 	if defaultAgent != nil {
 		if tool, ok := defaultAgent.Tools.Get("message"); ok {
 			if mt, ok := tool.(*tools.MessageTool); ok {
-				alreadySent = mt.HasSentInRound()
+				alreadySentToSameChat = mt.HasSentTo(channel, chatID)
 			}
 		}
 	}
 
-	if alreadySent {
+	if alreadySentToSameChat {
 		logger.DebugCF(
 			"agent",
-			"Skipped outbound (message tool already sent)",
-			map[string]any{"channel": channel},
+			"Skipped outbound (message tool already sent to same chat)",
+			map[string]any{"channel": channel, "chat_id": chatID},
 		)
 		return
 	}

--- a/pkg/tools/message.go
+++ b/pkg/tools/message.go
@@ -3,14 +3,21 @@ package tools
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
+	"sync"
 )
 
 type SendCallback func(channel, chatID, content string) error
 
+// sentTarget records the channel+chatID that the message tool sent to.
+type sentTarget struct {
+	Channel string
+	ChatID  string
+}
+
 type MessageTool struct {
 	sendCallback SendCallback
-	sentInRound  atomic.Bool // Tracks whether a message was sent in the current processing round
+	mu           sync.Mutex
+	sentTargets  []sentTarget // Tracks all targets sent to in the current round
 }
 
 func NewMessageTool() *MessageTool {
@@ -49,12 +56,30 @@ func (t *MessageTool) Parameters() map[string]any {
 // ResetSentInRound resets the per-round send tracker.
 // Called by the agent loop at the start of each inbound message processing round.
 func (t *MessageTool) ResetSentInRound() {
-	t.sentInRound.Store(false)
+	t.mu.Lock()
+	t.sentTargets = t.sentTargets[:0]
+	t.mu.Unlock()
 }
 
 // HasSentInRound returns true if the message tool sent a message during the current round.
 func (t *MessageTool) HasSentInRound() bool {
-	return t.sentInRound.Load()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.sentTargets) > 0
+}
+
+// HasSentTo returns true if the message tool sent to the specific channel+chatID
+// during the current round. Used by PublishResponseIfNeeded to avoid suppressing
+// the final response when the message tool only sent to a different conversation.
+func (t *MessageTool) HasSentTo(channel, chatID string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, st := range t.sentTargets {
+		if st.Channel == channel && st.ChatID == chatID {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *MessageTool) SetSendCallback(callback SendCallback) {
@@ -93,7 +118,10 @@ func (t *MessageTool) Execute(ctx context.Context, args map[string]any) *ToolRes
 		}
 	}
 
-	t.sentInRound.Store(true)
+	t.mu.Lock()
+	t.sentTargets = append(t.sentTargets, sentTarget{Channel: channel, ChatID: chatID})
+	t.mu.Unlock()
+
 	// Silent: user already received the message directly
 	return &ToolResult{
 		ForLLM: fmt.Sprintf("Message sent to %s:%s", channel, chatID),


### PR DESCRIPTION
## 📝 Description

When the message tool sends to a **different** chat (e.g., from DM to a group), `PublishResponseIfNeeded` incorrectly skips the agent's final response to the originating chat. This causes the originating chat to hang on "Processing..." forever.

**Root cause:** `HasSentInRound()` is a simple bool — it doesn't distinguish send targets. Any message tool call in the round suppresses all outbound responses.

**Fix:** Replace `sentInRound atomic.Bool` with `sentTargets []sentTarget` that records each send target (channel + chatID). `PublishResponseIfNeeded` now calls `HasSentTo(channel, chatID)` and only suppresses when the target matches.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** `pkg/tools/message.go`, `pkg/agent/loop.go:606-628`
- **Reasoning:** Same-chat suppression still works (cron, direct reply). Only cross-chat sends now correctly allow the originating chat to receive the final response.

## 🧪 Test Environment
- **Hardware:** Mac
- **OS:** macOS
- **Model/Provider:** OpenAI GPT-5.4
- **Channels:** WeCom (reproduce: DM → group message tool → DM hangs)

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.