### PR TITLE
fix(agent): normalize subagent model IDs before spawn

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -285,7 +285,11 @@ func registerSharedTools(
 		spawnEnabled := cfg.Tools.IsToolEnabled("spawn")
 		spawnStatusEnabled := cfg.Tools.IsToolEnabled("spawn_status")
 		if (spawnEnabled || spawnStatusEnabled) && cfg.Tools.IsToolEnabled("subagent") {
-			subagentManager := tools.NewSubagentManager(provider, agent.Model, agent.Workspace)
+			subagentManager := tools.NewSubagentManager(
+				provider,
+				resolveSubagentDefaultModel(agent),
+				agent.Workspace,
+			)
 			subagentManager.SetLLMOptions(agent.MaxTokens, agent.Temperature)
 
 			// Set the spawner that links into AgentLoop's turnState
@@ -375,6 +379,16 @@ func registerSharedTools(
 			logger.WarnCF("agent", "spawn/spawn_status tools require subagent to be enabled", nil)
 		}
 	}
+}
+
+func resolveSubagentDefaultModel(agent *AgentInstance) string {
+	if agent == nil {
+		return ""
+	}
+	if len(agent.Candidates) > 0 && strings.TrimSpace(agent.Candidates[0].Model) != "" {
+		return strings.TrimSpace(agent.Candidates[0].Model)
+	}
+	return agent.Model
 }
 
 func (al *AgentLoop) Run(ctx context.Context) error {

--- a/pkg/agent/subagent_default_model_test.go
+++ b/pkg/agent/subagent_default_model_test.go
@@ -1,0 +1,36 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/sipeed/picoclaw/pkg/providers"
+)
+
+func TestResolveSubagentDefaultModel(t *testing.T) {
+	t.Run("prefers resolved candidate model", func(t *testing.T) {
+		agent := &AgentInstance{
+			Model: "openrouter/minimax/minimax-m2.5",
+			Candidates: []providers.FallbackCandidate{
+				{Provider: "openrouter", Model: "minimax/minimax-m2.5"},
+			},
+		}
+
+		if got := resolveSubagentDefaultModel(agent); got != "minimax/minimax-m2.5" {
+			t.Fatalf("resolveSubagentDefaultModel() = %q, want %q", got, "minimax/minimax-m2.5")
+		}
+	})
+
+	t.Run("falls back to raw agent model when no candidates exist", func(t *testing.T) {
+		agent := &AgentInstance{Model: "claude-sonnet-4.6"}
+
+		if got := resolveSubagentDefaultModel(agent); got != "claude-sonnet-4.6" {
+			t.Fatalf("resolveSubagentDefaultModel() = %q, want %q", got, "claude-sonnet-4.6")
+		}
+	})
+
+	t.Run("returns empty string for nil agent", func(t *testing.T) {
+		if got := resolveSubagentDefaultModel(nil); got != "" {
+			t.Fatalf("resolveSubagentDefaultModel(nil) = %q, want empty string", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- make spawn/subagent default to the resolved candidate model ID instead of the raw agent model string
- keep OpenRouter subagents from forwarding prefixed `openrouter/...` model refs into `RunToolLoop`
- add a regression test for candidate-model preference and fallback behavior

## Testing
- `go test ./pkg/agent -run TestResolveSubagentDefaultModel -count=1`

Closes #1678
