### PR TITLE
fix: Matrix user IDs in allow_from incorrectly rejected by allowlist

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -44,18 +44,22 @@ func MatchAllowed(sender bus.SenderInfo, allowed string) bool {
 		return false
 	}
 
-	// Try canonical match first: "platform:id" format
-	if platform, id, ok := ParseCanonicalID(allowed); ok {
-		// Only treat as canonical if the platform portion looks like a known platform name
-		// (not a pure-numeric string, which could be a compound ID)
-		if !isNumeric(platform) {
-			candidate := BuildCanonicalID(platform, id)
-			if candidate != "" && sender.CanonicalID != "" {
-				return strings.EqualFold(sender.CanonicalID, candidate)
+	// Try canonical match first: "platform:id" format.
+	// Skip when allowed starts with "@" — that indicates a username
+	// (e.g., Matrix user IDs like "@alice:matrix.org"), not a canonical ID.
+	if !strings.HasPrefix(allowed, "@") {
+		if platform, id, ok := ParseCanonicalID(allowed); ok {
+			// Only treat as canonical if the platform portion looks like a known platform name
+			// (not a pure-numeric string, which could be a compound ID)
+			if !isNumeric(platform) {
+				candidate := BuildCanonicalID(platform, id)
+				if candidate != "" && sender.CanonicalID != "" {
+					return strings.EqualFold(sender.CanonicalID, candidate)
+				}
+				// If sender has no canonical ID, try matching platform + platformID
+				return strings.EqualFold(platform, sender.Platform) &&
+					sender.PlatformID == id
 			}
-			// If sender has no canonical ID, try matching platform + platformID
-			return strings.EqualFold(platform, sender.Platform) &&
-				sender.PlatformID == id
 		}
 	}
 
@@ -78,8 +82,18 @@ func MatchAllowed(sender bus.SenderInfo, allowed string) bool {
 		return true
 	}
 
-	// Match against Username only when explicitly requested via "@username"
-	if isAtUsername && sender.Username != "" && sender.Username == trimmed {
+	// Match against Username only when explicitly requested via "@username".
+	// Compare against both the trimmed value and the original allowed value,
+	// because some platforms (e.g., Matrix) include "@" in their user IDs.
+	if isAtUsername && sender.Username != "" {
+		if sender.Username == trimmed || sender.Username == allowed {
+			return true
+		}
+	}
+
+	// Also try matching PlatformID against the original "@..." value
+	// for platforms where PlatformID itself contains "@" (e.g., Matrix "@user:server").
+	if isAtUsername && sender.PlatformID != "" && sender.PlatformID == allowed {
 		return true
 	}
 

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -78,6 +78,14 @@ func TestMatchAllowed(t *testing.T) {
 		Username:   "carol",
 	}
 
+	matrixSender := bus.SenderInfo{
+		Platform:    "matrix",
+		PlatformID:  "@example:matrix.org",
+		CanonicalID: "matrix:@example:matrix.org",
+		Username:    "@example:matrix.org",
+		DisplayName: "@example:matrix.org",
+	}
+
 	tests := []struct {
 		name    string
 		sender  bus.SenderInfo
@@ -222,6 +230,25 @@ func TestMatchAllowed(t *testing.T) {
 			sender:  telegramSender,
 			allowed: "  123456  ",
 			want:    true,
+		},
+		// Matrix user ID format "@user:server"
+		{
+			name:    "matrix user ID matches via @username",
+			sender:  matrixSender,
+			allowed: "@example:matrix.org",
+			want:    true,
+		},
+		{
+			name:    "matrix canonical format also works",
+			sender:  matrixSender,
+			allowed: "matrix:@example:matrix.org",
+			want:    true,
+		},
+		{
+			name:    "matrix user ID wrong user does not match",
+			sender:  matrixSender,
+			allowed: "@other:matrix.org",
+			want:    false,
 		},
 	}
 


### PR DESCRIPTION
## 📝 Description

Matrix user IDs (`@user:homeserver`, e.g., `@vigossliao:matrix.org`) configured in `allow_from` are always rejected with `Message rejected by allowlist`.

Root cause: `MatchAllowed` in `pkg/identity/identity.go` incorrectly parses `@vigossliao:matrix.org` as a canonical ID (`platform="@vigossliao"`, `id="matrix.org"`), which doesn't match `sender.CanonicalID` (`matrix:@vigossliao:matrix.org`), and the function returns `false` before reaching the `@username` matching logic.

Fix:
1. Skip canonical ID parsing when the entry starts with `@`
2. Match PlatformID/Username against the original value (with `@` intact) for platforms like Matrix

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

<!-- N/A -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** `ParseCanonicalID` treats any string with `:` as canonical format, but Matrix user IDs (`@user:server`) are usernames, not canonical IDs. Additionally, the `@username` path strips the leading `@` before comparison, but Matrix IDs natively include `@`.

## 🧪 Test Environment
- **Hardware:** Mac (Apple Silicon)
- **OS:** macOS
- **Model/Provider:** N/A
- **Channels:** Matrix

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>
14:09:39 DBG Message rejected by allowlist component=matrix sender_id=@vigossliao:matrix.org
14:10:33 DBG Message rejected by allowlist component=matrix sender_id=@vigossliao:matrix.org

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly