### PR TITLE
fix(provider): anthropic_messages sends system as content blocks with cache_control

### DIFF
--- a/pkg/providers/anthropic_messages/provider.go
+++ b/pkg/providers/anthropic_messages/provider.go
@@ -178,17 +178,34 @@ func buildRequestBody(
 	}
 
 	// Process messages
-	var systemPrompt string
+	var systemBlocks []map[string]any
 	var apiMessages []any
 
 	for _, msg := range messages {
 		switch msg.Role {
 		case "system":
-			// Accumulate system messages
-			if systemPrompt != "" {
-				systemPrompt += "\n\n" + msg.Content
+			// Prefer structured SystemParts for per-block cache_control.
+			// This enables Anthropic prompt caching: static blocks keep a
+			// stable prefix hash while dynamic parts (time, session) change.
+			if len(msg.SystemParts) > 0 {
+				for _, part := range msg.SystemParts {
+					block := map[string]any{
+						"type": "text",
+						"text": part.Text,
+					}
+					if part.CacheControl != nil && part.CacheControl.Type != "" {
+						block["cache_control"] = map[string]string{
+							"type": part.CacheControl.Type,
+						}
+					}
+					systemBlocks = append(systemBlocks, block)
+				}
 			} else {
-				systemPrompt = msg.Content
+				// Fallback: no structured parts, use plain text block.
+				systemBlocks = append(systemBlocks, map[string]any{
+					"type": "text",
+					"text": msg.Content,
+				})
 			}
 
 		case "user":
@@ -280,9 +297,9 @@ func buildRequestBody(
 
 	result["messages"] = apiMessages
 
-	// Set system prompt if present
-	if systemPrompt != "" {
-		result["system"] = systemPrompt
+	// Set system prompt if present (always as content blocks array for cache_control support)
+	if len(systemBlocks) > 0 {
+		result["system"] = systemBlocks
 	}
 
 	// Add tools if present

--- a/pkg/providers/anthropic_messages/provider_test.go
+++ b/pkg/providers/anthropic_messages/provider_test.go
@@ -86,7 +86,9 @@ func TestBuildRequestBody(t *testing.T) {
 			want: map[string]any{
 				"model":      "test-model",
 				"max_tokens": int64(8192),
-				"system":     "You are a helpful assistant.",
+				"system": []map[string]any{
+					{"type": "text", "text": "You are a helpful assistant."},
+				},
 				"messages": []any{
 					map[string]any{
 						"role":    "user",


### PR DESCRIPTION
## 📝 Description

Fixes #2191

`anthropic_messages` provider ignored `SystemParts` and sent `system` as a flat string, defeating Anthropic prompt caching.

Now uses content blocks array with per-block `cache_control: ephemeral` on static blocks, matching the SDK-based `anthropic` provider behavior.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## 🔗 Related Issue

Fixes #2191

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** `pkg/providers/anthropic_messages/provider.go`
- **Reasoning:** The SDK-based `anthropic` provider already sends system as content blocks with `cache_control`. The raw HTTP `anthropic_messages` provider should behave the same way.

## 🧪 Test Environment
- **Hardware:** Mac
- **OS:** macOS
- **Model/Provider:** Anthropic Claude (anthropic_messages provider)
- **Channels:** WeCom

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.