### PR TITLE
fix(logger): ensure valid zerolog event by syncing instance level

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -286,19 +286,20 @@ func getCallerSkip() (int, string) {
 
 //nolint:zerologlint
 func getEvent(logger zerolog.Logger, level LogLevel) *zerolog.Event {
+	l := logger.Level(zerolog.DebugLevel)
 	switch level {
 	case zerolog.DebugLevel:
-		return logger.Debug()
+		return l.Debug()
 	case zerolog.InfoLevel:
-		return logger.Info()
+		return l.Info()
 	case zerolog.WarnLevel:
-		return logger.Warn()
+		return l.Warn()
 	case zerolog.ErrorLevel:
-		return logger.Error()
+		return l.Error()
 	case zerolog.FatalLevel:
-		return logger.Fatal()
+		return l.Fatal()
 	default:
-		return logger.Info()
+		return l.Info()
 	}
 }
 


### PR DESCRIPTION
## 📝 Description
Fixed a bug in `pkg/logger/logger.go` where `getEvent` returns a `nil` pointer when `zerolog.GlobalLevel` is higher than the package's `currentLevel`. This caused logs to fail silently.

**Solution:** Explicitly set the level on the logger instance before fetching the event: `logger.Level(level).Info()`.

## 🗣️ Type of Change
- [x] 🐞 Bug fix

## 🤖 AI Code Generation
- [x] 👨‍💻 Mostly Human-written (Manual debugging via `fmt.Printf`)

## 📚 Technical Context
- **Reasoning:** `zerolog` returns `nil` if the instance level is higher than the call level. Syncing the level ensures a valid `*zerolog.Event` is always returned.

## 🧪 Test Environment
- **Hardware:** Mac mini M1
- **OS:** macOS

## ☑️ Checklist
- [x] My code follows the style of this project.
- [x] I have performed a self-review of my own changes.