### PR TITLE
fix(web): hydrate cached Pico token for websocket proxy

### DIFF
--- a/web/backend/api/gateway.go
+++ b/web/backend/api/gateway.go
@@ -59,6 +59,16 @@ func refreshPicoTokensLocked(configPath string) {
 	gateway.picoToken = cfg.Channels.Pico.Token.String()
 }
 
+// ensurePicoTokenCachedLocked lazily fills the in-memory pico token cache when
+// the launcher has already discovered a running gateway via pidData, but has
+// not yet refreshed the token into memory.
+func ensurePicoTokenCachedLocked(configPath string) {
+	if gateway.picoToken != "" {
+		return
+	}
+	refreshPicoTokensLocked(configPath)
+}
+
 const (
 	protocolKey = "Sec-Websocket-Protocol"
 	tokenPrefix = "token."

--- a/web/backend/api/pico.go
+++ b/web/backend/api/pico.go
@@ -56,6 +56,7 @@ func (h *Handler) createWsProxy(origProtocol string, token string) *httputil.Rev
 func (h *Handler) handleWebSocketProxy() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		gateway.mu.Lock()
+		ensurePicoTokenCachedLocked(h.configPath)
 		gatewayAvailable := gateway.pidData != nil
 		gateway.mu.Unlock()
 

--- a/web/backend/api/pico_test.go
+++ b/web/backend/api/pico_test.go
@@ -377,6 +377,55 @@ func TestHandleWebSocketProxyReloadsGatewayTargetFromConfig(t *testing.T) {
 	}
 }
 
+func TestHandleWebSocketProxyLoadsCachedPicoTokenWhenMissing(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	h := NewHandler(configPath)
+	handler := h.handleWebSocketProxy()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/pico/ws" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/pico/ws")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "proxied")
+	}))
+	defer server.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Gateway.Host = "127.0.0.1"
+	cfg.Gateway.Port = mustGatewayTestPort(t, server.URL)
+	cfg.Channels.Pico.Enabled = true
+	cfg.Channels.Pico.SetToken("cached-token")
+	if err := config.SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	origPidData := gateway.pidData
+	origPicoToken := gateway.picoToken
+	t.Cleanup(func() {
+		gateway.pidData = origPidData
+		gateway.picoToken = origPicoToken
+	})
+
+	gateway.pidData = &ppid.PidFileData{}
+	gateway.picoToken = ""
+
+	req := httptest.NewRequest(http.MethodGet, "/pico/ws?session_id=test-session", nil)
+	req.Header.Set(protocolKey, tokenPrefix+"cached-token")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "proxied" {
+		t.Fatalf("body = %q, want %q", body, "proxied")
+	}
+	if gateway.picoToken != "cached-token" {
+		t.Fatalf("gateway.picoToken = %q, want %q", gateway.picoToken, "cached-token")
+	}
+}
+
 func mustGatewayTestPort(t *testing.T, rawURL string) int {
 	t.Helper()
 


### PR DESCRIPTION
## 📝 Description

This fixes the Pico websocket proxy flow when the launcher attaches to an already running gateway through cached `pidData`. In that case the in-memory `gateway.picoToken` can still be empty, so valid websocket requests are rejected before the token cache is hydrated from config.

The change lazily reloads the Pico token from config before validating websocket proxy requests, and adds a regression test for the existing-gateway plus empty-token-cache path.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** When the launcher discovers an existing gateway via `pidData`, websocket proxy handling only checked the in-memory Pico token cache. If that cache had not been hydrated yet, the request failed even though the config already contained the correct Pico token. This change hydrates the cache before validation and adds regression coverage for that state.

## 🧪 Test Environment
- **Hardware:** Mac15,6
- **OS:** macOS 26.4
- **Model/Provider:** N/A
- **Channels:** Pico websocket proxy (web backend)


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```text
go test ./web/backend/api
make check
```

Both commands passed locally.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
