### PR TITLE
fix(provider): use native Anthropic SDK for anthropic protocol with API key

### DIFF
--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -266,22 +266,11 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 			}
 			return provider, modelID, nil
 		}
-		// Use API key with HTTP API
-		apiBase := cfg.APIBase
-		if apiBase == "" {
-			apiBase = "https://api.anthropic.com/v1"
-		}
+		// Use API key with native Anthropic SDK (not OpenAI-compatible HTTPProvider)
 		if cfg.APIKey() == "" {
 			return nil, "", fmt.Errorf("api_key is required for anthropic protocol (model: %s)", cfg.Model)
 		}
-		return NewHTTPProviderWithMaxTokensFieldAndRequestTimeout(
-			cfg.APIKey(),
-			apiBase,
-			cfg.Proxy,
-			cfg.MaxTokensField,
-			cfg.RequestTimeout,
-			cfg.ExtraBody,
-		), modelID, nil
+		return NewClaudeProviderWithBaseURL(cfg.APIKey(), cfg.APIBase), modelID, nil
 
 	case "anthropic-messages":
 		// Anthropic Messages API with native format (HTTP-based, no SDK)


### PR DESCRIPTION
## Summary

- When using the `"anthropic"` protocol with an API key (non-OAuth), the factory incorrectly created an `HTTPProvider` (OpenAI-compatible) instead of the native Anthropic SDK provider (`ClaudeProvider`)
- This caused requests to be sent in OpenAI `/v1/chat/completions` format to the Anthropic API endpoint, resulting in failures
- Now uses `NewClaudeProviderWithBaseURL` which sends requests via the native Anthropic Messages API format

## Root Cause

In `CreateProviderFromConfig` (`pkg/providers/factory_provider.go`), the `case "anthropic":` branch with API key auth was calling `NewHTTPProviderWithMaxTokensFieldAndRequestTimeout` — the same OpenAI-compatible HTTP client used for `openai`, `groq`, `deepseek`, etc.

## Fix

Replace the HTTPProvider instantiation with `NewClaudeProviderWithBaseURL`, which wraps the native Anthropic Go SDK provider.

## Test Plan

- [x] `go build ./pkg/providers/...` passes
- [x] `go test ./pkg/providers/...` passes (all packages OK)
- [ ] Manual test: configure `anthropic/claude-sonnet-4.6` with API key and verify native Messages API format is used