### PR TITLE
feat(whatsapp): add proxy support for native and bridge modes

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -127,6 +127,7 @@
     "whatsapp": {
       "enabled": false,
       "bridge_url": "ws://localhost:3001",
+      "proxy": "",
       "use_native": false,
       "session_store_path": "",
       "allow_from": [],

--- a/pkg/channels/whatsapp/whatsapp.go
+++ b/pkg/channels/whatsapp/whatsapp.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -55,6 +58,16 @@ func (c *WhatsAppChannel) Start(ctx context.Context) error {
 
 	dialer := websocket.DefaultDialer
 	dialer.HandshakeTimeout = 10 * time.Second
+
+	if c.config.Proxy != "" {
+		proxyURL, parseErr := url.Parse(c.config.Proxy)
+		if parseErr != nil {
+			return fmt.Errorf("invalid proxy URL %q: %w", c.config.Proxy, parseErr)
+		}
+		dialer.Proxy = http.ProxyURL(proxyURL)
+	} else if os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" {
+		dialer.Proxy = http.ProxyFromEnvironment
+	}
 
 	conn, resp, err := dialer.Dial(c.url, nil)
 	if resp != nil {

--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -11,6 +11,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,6 +125,16 @@ func (c *WhatsAppNativeChannel) Start(ctx context.Context) error {
 	}
 
 	client := whatsmeow.NewClient(deviceStore, waLogger)
+
+	if c.config.Proxy != "" {
+		proxyURL, parseErr := url.Parse(c.config.Proxy)
+		if parseErr != nil {
+			return fmt.Errorf("invalid proxy URL %q: %w", c.config.Proxy, parseErr)
+		}
+		client.SetProxy(http.ProxyURL(proxyURL))
+	} else if os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" {
+		client.SetProxy(http.ProxyFromEnvironment)
+	}
 
 	// Create runCtx/runCancel BEFORE registering event handler and starting
 	// goroutines so that Stop() can cancel them at any time, including during

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -336,6 +336,7 @@ type StreamingConfig struct {
 type WhatsAppConfig struct {
 	Enabled            bool                `json:"enabled"              yaml:"-" env:"PICOCLAW_CHANNELS_WHATSAPP_ENABLED"`
 	BridgeURL          string              `json:"bridge_url"           yaml:"-" env:"PICOCLAW_CHANNELS_WHATSAPP_BRIDGE_URL"`
+	Proxy              string              `json:"proxy"                yaml:"-" env:"PICOCLAW_CHANNELS_WHATSAPP_PROXY"`
 	UseNative          bool                `json:"use_native"           yaml:"-" env:"PICOCLAW_CHANNELS_WHATSAPP_USE_NATIVE"`
 	SessionStorePath   string              `json:"session_store_path"   yaml:"-" env:"PICOCLAW_CHANNELS_WHATSAPP_SESSION_STORE_PATH"`
 	AllowFrom          FlexibleStringSlice `json:"allow_from"           yaml:"-" env:"PICOCLAW_CHANNELS_WHATSAPP_ALLOW_FROM"`

--- a/pkg/migrate/sources/openclaw/openclaw_config.go
+++ b/pkg/migrate/sources/openclaw/openclaw_config.go
@@ -642,6 +642,7 @@ type ChannelsConfig struct {
 type WhatsAppConfig struct {
 	Enabled   bool     `json:"enabled"`
 	BridgeURL string   `json:"bridge_url"`
+	Proxy     string   `json:"proxy"`
 	AllowFrom []string `json:"allow_from"`
 }
 


### PR DESCRIPTION
## 📝 Description

This PR adds proxy support to the WhatsApp channel, covering both Native (whatsmeow) and Bridge (websocket) connection modes. It allows the agent to function correctly in environments with restricted network access (e.g., using OpenClash or other proxy tools).

Key improvements:
- WhatsApp Native: Integrated `whatsmeow.SetProxy` with manual config and environment fallback.
- WhatsApp Bridge: Configured `websocket.Dialer` to respect proxy settings.
- Configuration: Added a `proxy` field to the WhatsApp configuration structure.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue
N/A

## 📚 Technical Context
- **Reasoning:** WhatsApp servers are often unreachable in certain network environments. Adding SOCKS5/HTTP proxy support ensures the agent can maintain a stable connection for both in-process and bridged modes.

## 🧪 Test Environment
- **Hardware:** Mac mini M1
- **OS:** macOS / OpenClash
- **Channels:** WhatsApp (Native & Bridge)

