### PR TITLE
fix(exec): fail closed on ambiguous script preflight

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -113,6 +113,7 @@ var (
 	}
 
 	scriptPreflightEnvVarPattern = regexp.MustCompile(`\$[A-Z_][A-Z0-9_]{1,}`)
+	scriptPreflightNodePattern   = regexp.MustCompile(`(?m)^[ \t]*(?:NODE\s+["'][^"']+["']|(?:bash|sh)\s+-c\b|export\s+[A-Za-z_][A-Za-z0-9_]*=)`)
 	envAssignmentPattern         = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
 	interpreterPipePattern       = regexp.MustCompile(
 		`(?i)(?:^|[|;&]\s*)(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b`,
@@ -1156,13 +1157,19 @@ func (t *ExecTool) validateScriptFileForShellBleed(command, cwd string) string {
 			continue
 		}
 
-		if !shouldScanScriptForShellBleed(absPath) {
+		kind := scriptPreflightKind(absPath)
+		if kind == "" {
 			continue
 		}
 
-		if first := scriptPreflightEnvVarPattern.Find(content); len(first) > 0 {
+		if first := firstScriptPreflightMatch(kind, content); first != "" {
+			reason := "exec preflight: detected likely shell variable injection"
+			if kind == "node" {
+				reason = "exec preflight: detected likely shell syntax"
+			}
 			return fmt.Sprintf(
-				"Command blocked by safety guard (exec preflight: detected likely shell variable injection (%s))",
+				"Command blocked by safety guard (%s (%s))",
+				reason,
 				first,
 			)
 		}
@@ -1191,7 +1198,7 @@ func extractScriptTargetFromCommand(command string) []string {
 		}
 		return []string{target}
 	case isNodeInterpreter(interpreter):
-		target := findFirstPositionalScriptArg(argv[1:], []string{".js"})
+		target := findFirstPositionalScriptArg(argv[1:], []string{".js", ".mjs", ".cjs"})
 		if target == "" {
 			return nil
 		}
@@ -1287,6 +1294,24 @@ func stripEnvPrefix(argv []string) []string {
 			idx++
 			continue
 		}
+		if lower == "-i" || lower == "--ignore-environment" {
+			idx++
+			continue
+		}
+		if lower == "-u" || strings.HasPrefix(lower, "-u") {
+			idx++
+			if lower == "-u" && idx < len(argv) {
+				idx++
+			}
+			continue
+		}
+		if lower == "--unset" || strings.HasPrefix(lower, "--unset=") {
+			idx++
+			if lower == "--unset" && idx < len(argv) {
+				idx++
+			}
+			continue
+		}
 		if envAssignmentPattern.MatchString(token) && !strings.HasPrefix(token, "-") {
 			idx++
 			continue
@@ -1360,9 +1385,29 @@ func hasScriptSuffix(token string, suffixes []string) bool {
 	return false
 }
 
-func shouldScanScriptForShellBleed(path string) bool {
-	ext := strings.ToLower(filepath.Ext(path))
-	return ext == ".py" || ext == ".pyw"
+func scriptPreflightKind(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".py", ".pyw":
+		return "python"
+	case ".js", ".mjs", ".cjs":
+		return "node"
+	default:
+		return ""
+	}
+}
+
+func firstScriptPreflightMatch(kind string, content []byte) string {
+	switch kind {
+	case "python":
+		if first := scriptPreflightEnvVarPattern.Find(content); len(first) > 0 {
+			return string(first)
+		}
+	case "node":
+		if first := scriptPreflightNodePattern.Find(content); len(first) > 0 {
+			return string(first)
+		}
+	}
+	return ""
 }
 
 func shouldFailClosedInterpreterPreflight(command string) bool {

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -113,9 +113,11 @@ var (
 	}
 
 	scriptPreflightEnvVarPattern = regexp.MustCompile(`\$[A-Z_][A-Z0-9_]{1,}`)
-	scriptPreflightNodePattern   = regexp.MustCompile(`(?m)^[ \t]*(?:NODE\s+["'][^"']+["']|(?:bash|sh)\s+-c\b|export\s+[A-Za-z_][A-Za-z0-9_]*=)`)
-	envAssignmentPattern         = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
-	interpreterPipePattern       = regexp.MustCompile(
+	scriptPreflightNodePattern   = regexp.MustCompile(
+		`(?m)^[ \t]*(?:NODE\s+["'][^"']+["']|(?:bash|sh)\s+-c\b|export\s+[A-Za-z_][A-Za-z0-9_]*=)`,
+	)
+	envAssignmentPattern   = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
+	interpreterPipePattern = regexp.MustCompile(
 		`(?i)(?:^|[|;&]\s*)(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b`,
 	)
 	interpreterShellWrapperPattern = regexp.MustCompile(

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -113,6 +113,7 @@ var (
 	}
 
 	scriptPreflightEnvVarPattern = regexp.MustCompile(`\$[A-Z_][A-Z0-9_]{1,}`)
+	envAssignmentPattern         = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
 	interpreterPipePattern       = regexp.MustCompile(
 		`(?i)(?:^|[|;&]\s*)(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b`,
 	)
@@ -1155,6 +1156,10 @@ func (t *ExecTool) validateScriptFileForShellBleed(command, cwd string) string {
 			continue
 		}
 
+		if !shouldScanScriptForShellBleed(absPath) {
+			continue
+		}
+
 		if first := scriptPreflightEnvVarPattern.Find(content); len(first) > 0 {
 			return fmt.Sprintf(
 				"Command blocked by safety guard (exec preflight: detected likely shell variable injection (%s))",
@@ -1180,13 +1185,13 @@ func extractScriptTargetFromCommand(command string) []string {
 	interpreter := strings.ToLower(filepath.Base(argv[0]))
 	switch {
 	case isPythonInterpreter(interpreter):
-		target := findLastPositionalScriptArg(argv[1:], []string{".py"})
+		target := findFirstPositionalScriptArg(argv[1:], []string{".py"})
 		if target == "" {
 			return nil
 		}
 		return []string{target}
 	case isNodeInterpreter(interpreter):
-		target := findLastPositionalScriptArg(argv[1:], []string{".js"})
+		target := findFirstPositionalScriptArg(argv[1:], []string{".js"})
 		if target == "" {
 			return nil
 		}
@@ -1282,7 +1287,7 @@ func stripEnvPrefix(argv []string) []string {
 			idx++
 			continue
 		}
-		if strings.Contains(token, "=") && !strings.HasPrefix(token, "-") && !strings.ContainsAny(token, "/\\") {
+		if envAssignmentPattern.MatchString(token) && !strings.HasPrefix(token, "-") {
 			idx++
 			continue
 		}
@@ -1302,7 +1307,7 @@ func isNodeInterpreter(token string) bool {
 	return token == "node" || token == "nodejs"
 }
 
-func findLastPositionalScriptArg(tokens []string, suffixes []string) string {
+func findFirstPositionalScriptArg(tokens []string, suffixes []string) string {
 	if len(tokens) == 0 {
 		return ""
 	}
@@ -1355,6 +1360,11 @@ func hasScriptSuffix(token string, suffixes []string) bool {
 	return false
 }
 
+func shouldScanScriptForShellBleed(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".py" || ext == ".pyw"
+}
+
 func shouldFailClosedInterpreterPreflight(command string) bool {
 	trimmed := strings.TrimSpace(command)
 	if trimmed == "" {
@@ -1367,8 +1377,12 @@ func shouldFailClosedInterpreterPreflight(command string) bool {
 	if interpreterShellWrapperPattern.MatchString(trimmed) {
 		return true
 	}
-	if interpreterPipePattern.MatchString(trimmed) && strings.ContainsAny(trimmed, "|;&") {
-		return true
+	if matches := interpreterPipePattern.FindAllStringIndex(trimmed, -1); len(matches) > 0 {
+		for _, match := range matches {
+			if match[0] > 0 {
+				return true
+			}
+		}
 	}
 
 	return false

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -112,10 +112,16 @@ var (
 		"/dev/stderr":  true,
 	}
 
-	scriptPreflightEnvVarPattern      = regexp.MustCompile(`\$[A-Z_][A-Z0-9_]{1,}`)
-	interpreterPipePattern            = regexp.MustCompile(`(?i)(?:^|[|;&]\s*)(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b`)
-	interpreterShellWrapperPattern    = regexp.MustCompile(`(?i)(?:^|\s)(?:env\s+)?(?:bash|sh|zsh|dash)\b[^\n]*\s-c\s+["']?\s*(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b`)
-	interpreterProcessSubstPattern    = regexp.MustCompile(`(?i)(?:^|\s)(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b[^\n]*<\(`)
+	scriptPreflightEnvVarPattern = regexp.MustCompile(`\$[A-Z_][A-Z0-9_]{1,}`)
+	interpreterPipePattern       = regexp.MustCompile(
+		`(?i)(?:^|[|;&]\s*)(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b`,
+	)
+	interpreterShellWrapperPattern = regexp.MustCompile(
+		`(?i)(?:^|\s)(?:env\s+)?(?:bash|sh|zsh|dash)\b[^\n]*\s-c\s+["']?\s*(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b`,
+	)
+	interpreterProcessSubstPattern = regexp.MustCompile(
+		`(?i)(?:^|\s)(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b[^\n]*<\(`,
+	)
 )
 
 func NewExecTool(workingDir string, restrict bool, allowPaths ...[]*regexp.Regexp) (*ExecTool, error) {
@@ -1150,7 +1156,10 @@ func (t *ExecTool) validateScriptFileForShellBleed(command, cwd string) string {
 		}
 
 		if first := scriptPreflightEnvVarPattern.Find(content); len(first) > 0 {
-			return fmt.Sprintf("Command blocked by safety guard (exec preflight: detected likely shell variable injection (%s))", first)
+			return fmt.Sprintf(
+				"Command blocked by safety guard (exec preflight: detected likely shell variable injection (%s))",
+				first,
+			)
 		}
 	}
 
@@ -1309,14 +1318,23 @@ func findLastPositionalScriptArg(tokens []string, suffixes []string) string {
 		if token == "-c" || token == "-m" || token == "-e" || token == "-p" || token == "--eval" || token == "--print" {
 			return ""
 		}
-		if token == "-W" || token == "-X" || token == "-Q" || token == "--check-hash-based-pycs" || token == "-r" || token == "--require" || token == "--import" {
+		if token == "-W" || token == "-X" || token == "-Q" || token == "--check-hash-based-pycs" || token == "-r" ||
+			token == "--require" ||
+			token == "--import" {
 			i++
 			continue
 		}
-		if strings.HasPrefix(token, "-W") || strings.HasPrefix(token, "-X") || strings.HasPrefix(token, "-Q") || strings.HasPrefix(token, "-r") || strings.HasPrefix(token, "-e") || strings.HasPrefix(token, "-p") || strings.HasPrefix(token, "-c") {
+		if strings.HasPrefix(token, "-W") || strings.HasPrefix(token, "-X") || strings.HasPrefix(token, "-Q") ||
+			strings.HasPrefix(token, "-r") ||
+			strings.HasPrefix(token, "-e") ||
+			strings.HasPrefix(token, "-p") ||
+			strings.HasPrefix(token, "-c") {
 			continue
 		}
-		if strings.HasPrefix(token, "--require=") || strings.HasPrefix(token, "--import=") || strings.HasPrefix(token, "--check-hash-based-pycs=") || strings.HasPrefix(token, "--eval=") || strings.HasPrefix(token, "--print=") {
+		if strings.HasPrefix(token, "--require=") || strings.HasPrefix(token, "--import=") ||
+			strings.HasPrefix(token, "--check-hash-based-pycs=") ||
+			strings.HasPrefix(token, "--eval=") ||
+			strings.HasPrefix(token, "--print=") {
 			continue
 		}
 		if hasScriptSuffix(token, suffixes) {

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -111,6 +111,11 @@ var (
 		"/dev/stdout":  true,
 		"/dev/stderr":  true,
 	}
+
+	scriptPreflightEnvVarPattern      = regexp.MustCompile(`\$[A-Z_][A-Z0-9_]{1,}`)
+	interpreterPipePattern            = regexp.MustCompile(`(?i)(?:^|[|;&]\s*)(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b`)
+	interpreterShellWrapperPattern    = regexp.MustCompile(`(?i)(?:^|\s)(?:env\s+)?(?:bash|sh|zsh|dash)\b[^\n]*\s-c\s+["']?\s*(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b`)
+	interpreterProcessSubstPattern    = regexp.MustCompile(`(?i)(?:^|\s)(?:env\s+)?(?:python(?:\d+(?:\.\d+)?)?|node(?:js)?)\b[^\n]*<\(`)
 )
 
 func NewExecTool(workingDir string, restrict bool, allowPaths ...[]*regexp.Regexp) (*ExecTool, error) {
@@ -319,6 +324,10 @@ func (t *ExecTool) executeRun(ctx context.Context, args map[string]any) *ToolRes
 
 	if guardError := t.guardCommand(command, cwd); guardError != "" {
 		return ErrorResult(guardError)
+	}
+
+	if preflightError := t.validateScriptFileForShellBleed(command, cwd); preflightError != "" {
+		return ErrorResult(preflightError)
 	}
 
 	// Re-resolve symlinks immediately before execution to shrink the TOCTOU window
@@ -1113,6 +1122,238 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 	}
 
 	return ""
+}
+
+func (t *ExecTool) validateScriptFileForShellBleed(command, cwd string) string {
+	if shouldFailClosedInterpreterPreflight(command) {
+		return "Command blocked by safety guard (exec preflight: complex interpreter invocation detected; refusing to run without script preflight validation. Use a direct `python <file>.py` or `node <file>.js` command.)"
+	}
+
+	targets := extractScriptTargetFromCommand(command)
+	if len(targets) == 0 {
+		return ""
+	}
+
+	for _, relOrAbsPath := range targets {
+		if relOrAbsPath == "" {
+			continue
+		}
+
+		absPath := relOrAbsPath
+		if !filepath.IsAbs(absPath) {
+			absPath = filepath.Join(cwd, relOrAbsPath)
+		}
+
+		content, err := os.ReadFile(absPath)
+		if err != nil || len(content) > 512*1024 {
+			continue
+		}
+
+		if first := scriptPreflightEnvVarPattern.Find(content); len(first) > 0 {
+			return fmt.Sprintf("Command blocked by safety guard (exec preflight: detected likely shell variable injection (%s))", first)
+		}
+	}
+
+	return ""
+}
+
+func extractScriptTargetFromCommand(command string) []string {
+	argv := splitShellArgs(command)
+	if len(argv) == 0 {
+		return nil
+	}
+
+	argv = stripEnvPrefix(argv)
+	if len(argv) == 0 {
+		return nil
+	}
+
+	interpreter := strings.ToLower(filepath.Base(argv[0]))
+	switch {
+	case isPythonInterpreter(interpreter):
+		target := findLastPositionalScriptArg(argv[1:], []string{".py"})
+		if target == "" {
+			return nil
+		}
+		return []string{target}
+	case isNodeInterpreter(interpreter):
+		target := findLastPositionalScriptArg(argv[1:], []string{".js"})
+		if target == "" {
+			return nil
+		}
+		return []string{target}
+	default:
+		return nil
+	}
+}
+
+func splitShellArgs(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	tokens := make([]string, 0, 8)
+	var buf strings.Builder
+	inSingle := false
+	inDouble := false
+	escaped := false
+
+	pushToken := func() {
+		if buf.Len() == 0 {
+			return
+		}
+		tokens = append(tokens, buf.String())
+		buf.Reset()
+	}
+
+	for i := 0; i < len(raw); i++ {
+		ch := raw[i]
+		if escaped {
+			buf.WriteByte(ch)
+			escaped = false
+			continue
+		}
+		if inSingle {
+			if ch == '\'' {
+				inSingle = false
+				continue
+			}
+			buf.WriteByte(ch)
+			continue
+		}
+		if inDouble {
+			switch ch {
+			case '\\':
+				if i+1 < len(raw) {
+					i++
+					buf.WriteByte(raw[i])
+				}
+			case '"':
+				inDouble = false
+			default:
+				buf.WriteByte(ch)
+			}
+			continue
+		}
+		switch ch {
+		case '\\':
+			if i+1 < len(raw) {
+				next := raw[i+1]
+				if next == ' ' || next == '\\' || next == '"' || next == '\'' || next == '$' || next == '`' {
+					escaped = true
+					continue
+				}
+			}
+			buf.WriteByte(ch)
+		case '\'':
+			inSingle = true
+		case '"':
+			inDouble = true
+		case ' ', '\t', '\n', '\r':
+			pushToken()
+		default:
+			buf.WriteByte(ch)
+		}
+	}
+
+	if escaped || inSingle || inDouble {
+		return nil
+	}
+	pushToken()
+	return tokens
+}
+
+func stripEnvPrefix(argv []string) []string {
+	idx := 0
+	for idx < len(argv) {
+		token := argv[idx]
+		lower := strings.ToLower(token)
+		if lower == "env" {
+			idx++
+			continue
+		}
+		if strings.Contains(token, "=") && !strings.HasPrefix(token, "-") && !strings.ContainsAny(token, "/\\") {
+			idx++
+			continue
+		}
+		break
+	}
+	if idx >= len(argv) {
+		return nil
+	}
+	return argv[idx:]
+}
+
+func isPythonInterpreter(token string) bool {
+	return token == "python" || token == "python2" || token == "python3" || strings.HasPrefix(token, "python")
+}
+
+func isNodeInterpreter(token string) bool {
+	return token == "node" || token == "nodejs"
+}
+
+func findLastPositionalScriptArg(tokens []string, suffixes []string) string {
+	if len(tokens) == 0 {
+		return ""
+	}
+
+	for i := 0; i < len(tokens); i++ {
+		token := tokens[i]
+		if token == "--" {
+			if i+1 < len(tokens) && hasScriptSuffix(tokens[i+1], suffixes) {
+				return tokens[i+1]
+			}
+			continue
+		}
+		if token == "-c" || token == "-m" || token == "-e" || token == "-p" || token == "--eval" || token == "--print" {
+			return ""
+		}
+		if token == "-W" || token == "-X" || token == "-Q" || token == "--check-hash-based-pycs" || token == "-r" || token == "--require" || token == "--import" {
+			i++
+			continue
+		}
+		if strings.HasPrefix(token, "-W") || strings.HasPrefix(token, "-X") || strings.HasPrefix(token, "-Q") || strings.HasPrefix(token, "-r") || strings.HasPrefix(token, "-e") || strings.HasPrefix(token, "-p") || strings.HasPrefix(token, "-c") {
+			continue
+		}
+		if strings.HasPrefix(token, "--require=") || strings.HasPrefix(token, "--import=") || strings.HasPrefix(token, "--check-hash-based-pycs=") || strings.HasPrefix(token, "--eval=") || strings.HasPrefix(token, "--print=") {
+			continue
+		}
+		if hasScriptSuffix(token, suffixes) {
+			return token
+		}
+	}
+
+	return ""
+}
+
+func hasScriptSuffix(token string, suffixes []string) bool {
+	lower := strings.ToLower(token)
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldFailClosedInterpreterPreflight(command string) bool {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return false
+	}
+
+	if interpreterProcessSubstPattern.MatchString(trimmed) {
+		return true
+	}
+	if interpreterShellWrapperPattern.MatchString(trimmed) {
+		return true
+	}
+	if interpreterPipePattern.MatchString(trimmed) && strings.ContainsAny(trimmed, "|;&") {
+		return true
+	}
+
+	return false
 }
 
 func (t *ExecTool) SetTimeout(timeout time.Duration) {

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -686,10 +686,17 @@ func TestShellTool_ScriptPreflight(t *testing.T) {
 		want     string
 	}{
 		{
-			name:     "quoted script path validates content",
-			command:  `node "bad.js"`,
-			fileName: "bad.js",
+			name:     "quoted python script path validates content",
+			command:  `python "bad.py"`,
+			fileName: "bad.py",
 			content:  "const value = $DM_JSON;",
+			want:     "exec preflight: detected likely shell variable injection ($DM_JSON)",
+		},
+		{
+			name:     "env-prefixed interpreter validates content",
+			command:  `env PYTHONPATH=/tmp python bad.py`,
+			fileName: "bad.py",
+			content:  "payload = $DM_JSON",
 			want:     "exec preflight: detected likely shell variable injection ($DM_JSON)",
 		},
 		{
@@ -735,6 +742,24 @@ func TestShellTool_ScriptPreflight(t *testing.T) {
 			require.Contains(t, result.ForLLM, tt.want)
 		})
 	}
+}
+
+func TestShellTool_ScriptPreflight_AllowsDirectChainedInterpreter(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "good.py"), []byte("print('ok')"), 0o644); err != nil {
+		t.Fatalf("failed to write test script: %v", err)
+	}
+
+	tool, err := NewExecTool(tmpDir, false)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"action":  "run",
+		"command": "python good.py && echo ok",
+	})
+	require.NotContains(t, result.ForLLM, "exec preflight:")
 }
 
 // TestShellTool_URLBypassPrevented verifies that a command cannot bypass the workspace

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -700,6 +700,27 @@ func TestShellTool_ScriptPreflight(t *testing.T) {
 			want:     "exec preflight: detected likely shell variable injection ($DM_JSON)",
 		},
 		{
+			name:     "quoted node js script path validates shell bleed",
+			command:  `node "bad.js"`,
+			fileName: "bad.js",
+			content:  `NODE "$TMPDIR/hot.json"`,
+			want:     "exec preflight: detected likely shell syntax (NODE \"$TMPDIR/hot.json\")",
+		},
+		{
+			name:     "quoted node mjs script path validates shell bleed",
+			command:  `node "bad.mjs"`,
+			fileName: "bad.mjs",
+			content:  `NODE "$TMPDIR/hot.json"`,
+			want:     "exec preflight: detected likely shell syntax (NODE \"$TMPDIR/hot.json\")",
+		},
+		{
+			name:     "quoted node cjs script path validates shell bleed",
+			command:  `node "bad.cjs"`,
+			fileName: "bad.cjs",
+			content:  `NODE "$TMPDIR/hot.json"`,
+			want:     "exec preflight: detected likely shell syntax (NODE \"$TMPDIR/hot.json\")",
+		},
+		{
 			name:     "piped interpreter fails closed",
 			command:  "cat bad.py | python",
 			fileName: "bad.py",
@@ -758,6 +779,24 @@ func TestShellTool_ScriptPreflight_AllowsDirectChainedInterpreter(t *testing.T) 
 	result := tool.Execute(context.Background(), map[string]any{
 		"action":  "run",
 		"command": "python good.py && echo ok",
+	})
+	require.NotContains(t, result.ForLLM, "exec preflight:")
+}
+
+func TestShellTool_ScriptPreflight_AllowsDirectChainedNodeInterpreter(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "good.js"), []byte("console.log('ok')"), 0o644); err != nil {
+		t.Fatalf("failed to write test script: %v", err)
+	}
+
+	tool, err := NewExecTool(tmpDir, false)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"action":  "run",
+		"command": "node good.js && echo ok",
 	})
 	require.NotContains(t, result.ForLLM, "exec preflight:")
 }

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -677,6 +677,66 @@ func TestShellTool_FileURISandboxing(t *testing.T) {
 	}
 }
 
+func TestShellTool_ScriptPreflight(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		fileName string
+		content  string
+		want     string
+	}{
+		{
+			name:     "quoted script path validates content",
+			command:  `node "bad.js"`,
+			fileName: "bad.js",
+			content:  "const value = $DM_JSON;",
+			want:     "exec preflight: detected likely shell variable injection ($DM_JSON)",
+		},
+		{
+			name:     "piped interpreter fails closed",
+			command:  "cat bad.py | python",
+			fileName: "bad.py",
+			content:  "payload = $DM_JSON",
+			want:     "exec preflight: complex interpreter invocation detected",
+		},
+		{
+			name:     "shell wrapped interpreter fails closed",
+			command:  `bash -c "python bad.py"`,
+			fileName: "bad.py",
+			content:  "payload = $DM_JSON",
+			want:     "exec preflight: complex interpreter invocation detected",
+		},
+		{
+			name:     "process substitution fails closed",
+			command:  "python <(cat bad.py)",
+			fileName: "bad.py",
+			content:  "payload = $DM_JSON",
+			want:     "exec preflight: complex interpreter invocation detected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(tmpDir, tt.fileName), []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("failed to write test script: %v", err)
+			}
+
+			tool, err := NewExecTool(tmpDir, false)
+			if err != nil {
+				t.Fatalf("unable to configure exec tool: %s", err)
+			}
+
+			result := tool.Execute(context.Background(), map[string]any{
+				"action":  "run",
+				"command": tt.command,
+			})
+			require.True(t, result.IsError, "expected script preflight to block %q", tt.command)
+			require.Contains(t, result.ForLLM, tt.want)
+		})
+	}
+}
+
 // TestShellTool_URLBypassPrevented verifies that a command cannot bypass the workspace
 // sandbox by smuggling a real path after a URL that contains the same //path substring.
 // e.g. "echo https://etc/passwd && cat //etc/passwd" must still be blocked.


### PR DESCRIPTION
## 📝 Description

Add exec script preflight hardening so interpreter commands that are too ambiguous to inspect fail closed instead of silently skipping validation. The change adds quoted-path handling, a fail-closed guard for piped/shell-wrapped/process-substitution forms, and regression coverage for the new preflight behavior.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** PicoClaw already has a generic exec tool and broad command deny/allow checks, but it lacked script-content preflight for interpreter commands. This change adds a narrow security guardrail in the existing exec path without changing the overall sandbox model.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows
- **Model/Provider:** N/A
- **Channels:** N/A


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Targeted validation passed:

- `go test ./pkg/tools -run TestShellTool_ScriptPreflight`

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.