### PR TITLE
fix(agent): honor thinking_level for direct model refs (#2286)

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -157,7 +157,7 @@ func NewAgentInstance(
 	}
 
 	var thinkingLevelStr string
-	if mc, err := cfg.GetModelConfig(model); err == nil {
+	if mc := lookupModelConfigByRef(cfg, model); mc != nil {
 		thinkingLevelStr = mc.ThinkingLevel
 	}
 	thinkingLevel := parseThinkingLevel(thinkingLevelStr)

--- a/pkg/agent/instance_test.go
+++ b/pkg/agent/instance_test.go
@@ -165,6 +165,55 @@ func TestNewAgentInstance_ResolveCandidatesFromModelListAlias(t *testing.T) {
 	}
 }
 
+func TestNewAgentInstance_ResolvesThinkingLevelByModelRef(t *testing.T) {
+	tests := []struct {
+		name          string
+		defaultModel  string
+		modelListName string
+		modelListID   string
+	}{
+		{
+			name:          "full model ref",
+			defaultModel:  "deepseek/deepseek-reasoner",
+			modelListName: "reasoner-alias",
+			modelListID:   "deepseek/deepseek-reasoner",
+		},
+		{
+			name:          "model id without protocol",
+			defaultModel:  "deepseek-reasoner",
+			modelListName: "reasoner-alias",
+			modelListID:   "deepseek/deepseek-reasoner",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace := t.TempDir()
+
+			cfg := &config.Config{
+				Agents: config.AgentsConfig{
+					Defaults: config.AgentDefaults{
+						Workspace: workspace,
+						ModelName: tt.defaultModel,
+					},
+				},
+				ModelList: []*config.ModelConfig{
+					{
+						ModelName:     tt.modelListName,
+						Model:         tt.modelListID,
+						ThinkingLevel: "high",
+					},
+				},
+			}
+
+			agent := NewAgentInstance(nil, &cfg.Agents.Defaults, cfg, &mockProvider{})
+			if agent.ThinkingLevel != ThinkingHigh {
+				t.Fatalf("ThinkingLevel = %q, want %q", agent.ThinkingLevel, ThinkingHigh)
+			}
+		})
+	}
+}
+
 func TestNewAgentInstance_PreservesDistinctLimiterIdentityForSharedResolvedModel(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- make `NewAgentInstance` resolve `thinking_level` through the existing model-ref lookup path instead of only `GetModelConfig(model_name)`
- preserve current precedence: exact `model_name` match first, then fall back to matching full `model` ref or bare model id
- add a regression test covering both full refs and protocol-less ids when `model_name` differs from `model`

## Testing
- go test ./pkg/agent -run TestNewAgentInstance_ResolvesThinkingLevelByModelRef -count=1

## Notes
- `go test ./pkg/agent -count=1` still hits a pre-existing unrelated failure in `TestGlobalSkillFileContentChange`

Closes #2286