### PR TITLE
fix(agent): resolve thinking level from model refs

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -157,7 +157,7 @@ func NewAgentInstance(
 	}
 
 	var thinkingLevelStr string
-	if mc, err := cfg.GetModelConfig(model); err == nil {
+	if mc := lookupModelConfigByRef(cfg, model); mc != nil {
 		thinkingLevelStr = mc.ThinkingLevel
 	}
 	thinkingLevel := parseThinkingLevel(thinkingLevelStr)

--- a/pkg/agent/instance_test.go
+++ b/pkg/agent/instance_test.go
@@ -217,6 +217,61 @@ func TestNewAgentInstance_PreservesDistinctLimiterIdentityForSharedResolvedModel
 	}
 }
 
+func TestNewAgentInstance_ResolvesThinkingLevelFromModelReference(t *testing.T) {
+	tests := []struct {
+		name         string
+		primary      string
+		wantThinking ThinkingLevel
+	}{
+		{
+			name:         "full protocol reference",
+			primary:      "anthropic/claude-sonnet-4.6",
+			wantThinking: ThinkingHigh,
+		},
+		{
+			name:         "bare model id",
+			primary:      "claude-sonnet-4.6",
+			wantThinking: ThinkingHigh,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			cfg := &config.Config{
+				Agents: config.AgentsConfig{
+					Defaults: config.AgentDefaults{
+						Workspace: tmpDir,
+						ModelName: "main-model",
+					},
+					List: []config.AgentConfig{
+						{
+							ID: "main",
+							Model: &config.AgentModelConfig{
+								Primary: tt.primary,
+							},
+						},
+					},
+				},
+				ModelList: []*config.ModelConfig{
+					{
+						ModelName:     "main-model",
+						Model:         "anthropic/claude-sonnet-4.6",
+						ThinkingLevel: "high",
+						APIBase:       "https://example.invalid",
+					},
+				},
+			}
+
+			agent := NewAgentInstance(&cfg.Agents.List[0], &cfg.Agents.Defaults, cfg, &mockProvider{})
+			if agent.ThinkingLevel != tt.wantThinking {
+				t.Fatalf("ThinkingLevel = %q, want %q", agent.ThinkingLevel, tt.wantThinking)
+			}
+		})
+	}
+}
+
 func TestNewAgentInstance_AllowsMediaTempDirForReadListAndExec(t *testing.T) {
 	workspace := t.TempDir()
 	mediaDir := media.TempDir()


### PR DESCRIPTION
## 📝 Description

Fixes the `thinking_level` lookup bug behind `#2286`: when an agent's primary model is configured via a model reference instead of a `model_name` alias, PicoClaw initializes the agent with `ThinkingOff` even though the referenced `model_list` entry has `thinking_level` configured.

Problem summary:
- `NewAgentInstance()` resolves the agent model reference from config.
- It then tries to read `thinking_level` using `cfg.GetModelConfig(model)`.
- `GetModelConfig()` only matches `model_name`, so a primary value like `anthropic/claude-sonnet-4.6` or `claude-sonnet-4.6` misses the correct `model_list` entry.
- The agent therefore starts with `ThinkingOff` instead of the configured level.

Root cause:
- This path used a lookup helper that only accepts `model_name` aliases.
- But agent model references are already allowed to be aliases, full `protocol/model` strings, or bare model IDs.
- The thinking-level lookup was narrower than the rest of the model-resolution path.

What changed:
- Reuse `lookupModelConfigByRef()` when initializing `ThinkingLevel` in `NewAgentInstance()`.
- Add a regression test that covers both a full protocol reference and a bare model ID pointing at the same `model_list` entry.

Why this fix:
- It is the smallest targeted fix for `#2286`.
- It aligns `thinking_level` initialization with the existing model candidate resolution logic.
- I considered broadening `GetModelConfig()` to accept model references globally, but that would widen semantics and risk beyond this bug.

Risk / compatibility:
- Low risk. This only affects how `ThinkingLevel` is initialized when the configured primary model is given as a model reference instead of a `model_name` alias.
- Alias-based configs keep the same behavior.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #2286

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/2286
- **Reasoning:** The bug is local to `thinking_level` initialization. The rest of PicoClaw's model resolution already understands aliases, full protocol references, and bare model IDs through `lookupModelConfigByRef()`, so reusing that narrower helper is safer than redefining `GetModelConfig()` semantics globally.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows (local development environment)
- **Model/Provider:** N/A (unit tests with mock provider)
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Passed:
- `go test ./pkg/agent -run TestNewAgentInstance_ResolvesThinkingLevelFromModelReference -count=1`
- `go test ./pkg/agent -run TestNewAgentInstance_|TestParseThinkingLevel -count=1`

Baseline reproduction:
- The new regression test fails on clean `upstream/main` before this fix.
- In that baseline run, `ThinkingLevel` is `off` for both `anthropic/claude-sonnet-4.6` and `claude-sonnet-4.6`, even though the referenced `model_list` entry sets `thinking_level = high`.

Additional notes:
- `go test ./pkg/agent -count=1` still fails due to pre-existing `TestGlobalSkillFileContentChange`; I confirmed the same failure on clean `upstream/main`, so it is unrelated to this PR.
- `codex review --base origin/main` could not run in this environment because the local Codex config rejected `approvals_reviewer = never`.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.