### PR TITLE
fix(antigravity): bump client version to 1.25.0 for gemini-3.1 model access

### DIFF
--- a/pkg/providers/antigravity_provider.go
+++ b/pkg/providers/antigravity_provider.go
@@ -21,7 +21,7 @@ const (
 	antigravityDefaultModel = "gemini-3-flash"
 	antigravityUserAgent    = "antigravity"
 	antigravityXGoogClient  = "google-cloud-sdk vscode_cloudshelleditor/0.1"
-	antigravityVersion      = "1.15.8"
+	antigravityVersion      = "1.25.0"
 )
 
 // AntigravityProvider implements LLMProvider using Google's Cloud Code Assist (Antigravity) API.


### PR DESCRIPTION
## Summary

- Bumps `antigravityVersion` from `1.15.8` to `1.25.0` in the Antigravity provider
- Without this, Google's Cloud Code Assist API rejects newer models (`gemini-3.1-pro-low`, `gemini-3.1-flash-lite`, etc.) — the model itself responds with "Gemini 3.1 Pro is not available on this version. Please upgrade to the latest version."
- The API checks the `User-Agent` header (`antigravity/<version>`) and gates model access behind minimum client versions

## Root cause

`pkg/providers/antigravity_provider.go:24` — the version string `1.15.8` is too old for gemini-3.1 models. Bumping to `1.25.0` (matching current Antigravity IDE releases) resolves the issue.

## Test plan

- [x] Verified `gemini-3.1-pro-low` returns "not available" with version `1.15.8`
- [x] Verified `gemini-3.1-pro-low` works correctly with version `1.25.0` (tested via direct API call and patched binary)
- [x] `gemini-3-flash` and other existing models continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)