### PR TITLE
fix(gateway): add CLI stop/status commands (#2373)

### DIFF
--- a/cmd/picoclaw/internal/gateway/command.go
+++ b/cmd/picoclaw/internal/gateway/command.go
@@ -47,6 +47,10 @@ func NewGatewayCommand() *cobra.Command {
 		false,
 		"Continue starting even when no default model is configured",
 	)
+	cmd.AddCommand(
+		newStatusCommand(),
+		newStopCommand(),
+	)
 
 	return cmd
 }

--- a/cmd/picoclaw/internal/gateway/command_test.go
+++ b/cmd/picoclaw/internal/gateway/command_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,9 +25,20 @@ func TestNewGatewayCommand(t *testing.T) {
 	assert.Nil(t, cmd.PersistentPreRun)
 	assert.Nil(t, cmd.PersistentPostRun)
 
-	assert.False(t, cmd.HasSubCommands())
+	assert.True(t, cmd.HasSubCommands())
 
 	assert.True(t, cmd.HasFlags())
 	assert.NotNil(t, cmd.Flags().Lookup("debug"))
 	assert.NotNil(t, cmd.Flags().Lookup("allow-empty"))
+
+	allowedCommands := []string{
+		"status",
+		"stop",
+	}
+	subcommands := cmd.Commands()
+	assert.Len(t, subcommands, len(allowedCommands))
+	for _, subcmd := range subcommands {
+		assert.True(t, slices.Contains(allowedCommands, subcmd.Name()))
+		assert.NotNil(t, subcmd.RunE)
+	}
 }

--- a/cmd/picoclaw/internal/gateway/control.go
+++ b/cmd/picoclaw/internal/gateway/control.go
@@ -96,9 +96,14 @@ func resolveGatewayTarget(homePath string) (*gatewayTarget, error) {
 		return nil, fmt.Errorf("failed to find gateway process (PID: %d): %w", data.PID, err)
 	}
 
-	err = verifyGatewayProcessIdentity(data.PID)
-	if err != nil {
-		return nil, err
+	// Hardening: when possible, ensure the PID file still points to a picoclaw
+	// gateway process before we report or signal it. Currently we only have a
+	// reliable, dependency-free implementation on Linux (/proc).
+	if runtime.GOOS == "linux" {
+		err = verifyGatewayProcessIdentity(data.PID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &gatewayTarget{

--- a/cmd/picoclaw/internal/gateway/control.go
+++ b/cmd/picoclaw/internal/gateway/control.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sipeed/picoclaw/pkg/pid"
 )
 
+type gatewayTarget struct {
+	data    *pid.PidFileData
+	process *os.Process
+}
+
 func newStatusCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
@@ -35,30 +40,36 @@ func newStopCommand() *cobra.Command {
 }
 
 func gatewayStatusCmd(homePath string) error {
-	data := pid.ReadPidFileWithCheck(homePath)
-	if data == nil {
+	target, err := resolveGatewayTarget(homePath)
+	if err != nil {
+		return err
+	}
+	if target == nil {
 		fmt.Println("Gateway status: stopped")
 		return nil
 	}
 
 	fmt.Printf(
 		"Gateway status: running (PID: %d, host: %s, port: %d)\n",
-		data.PID,
-		data.Host,
-		data.Port,
+		target.data.PID,
+		target.data.Host,
+		target.data.Port,
 	)
 	return nil
 }
 
 func gatewayStopCmd(homePath string) error {
-	data := pid.ReadPidFileWithCheck(homePath)
-	if data == nil {
+	target, err := resolveGatewayTarget(homePath)
+	if err != nil {
+		return err
+	}
+	if target == nil {
 		return fmt.Errorf("gateway is not running")
 	}
 
-	process, err := os.FindProcess(data.PID)
-	if err != nil {
-		return fmt.Errorf("failed to find gateway process (PID: %d): %w", data.PID, err)
+	process := target.process
+	if process == nil {
+		return fmt.Errorf("failed to find gateway process (PID: %d)", target.data.PID)
 	}
 
 	if runtime.GOOS == "windows" {
@@ -67,9 +78,31 @@ func gatewayStopCmd(homePath string) error {
 		err = process.Signal(syscall.SIGTERM)
 	}
 	if err != nil {
-		return fmt.Errorf("failed to stop gateway (PID: %d): %w", data.PID, err)
+		return fmt.Errorf("failed to stop gateway (PID: %d): %w", target.data.PID, err)
 	}
 
-	fmt.Printf("Sent stop signal to gateway (PID: %d)\n", data.PID)
+	fmt.Printf("Sent stop signal to gateway (PID: %d)\n", target.data.PID)
 	return nil
+}
+
+func resolveGatewayTarget(homePath string) (*gatewayTarget, error) {
+	data := pid.ReadPidFileWithCheck(homePath)
+	if data == nil {
+		return nil, nil
+	}
+
+	process, err := os.FindProcess(data.PID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find gateway process (PID: %d): %w", data.PID, err)
+	}
+
+	err = verifyGatewayProcessIdentity(data.PID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gatewayTarget{
+		data:    data,
+		process: process,
+	}, nil
 }

--- a/cmd/picoclaw/internal/gateway/control.go
+++ b/cmd/picoclaw/internal/gateway/control.go
@@ -1,0 +1,75 @@
+package gateway
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sipeed/picoclaw/cmd/picoclaw/internal"
+	"github.com/sipeed/picoclaw/pkg/pid"
+)
+
+func newStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show gateway process status",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return gatewayStatusCmd(internal.GetPicoclawHome())
+		},
+	}
+}
+
+func newStopCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop a running gateway process",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return gatewayStopCmd(internal.GetPicoclawHome())
+		},
+	}
+}
+
+func gatewayStatusCmd(homePath string) error {
+	data := pid.ReadPidFileWithCheck(homePath)
+	if data == nil {
+		fmt.Println("Gateway status: stopped")
+		return nil
+	}
+
+	fmt.Printf(
+		"Gateway status: running (PID: %d, host: %s, port: %d)\n",
+		data.PID,
+		data.Host,
+		data.Port,
+	)
+	return nil
+}
+
+func gatewayStopCmd(homePath string) error {
+	data := pid.ReadPidFileWithCheck(homePath)
+	if data == nil {
+		return fmt.Errorf("gateway is not running")
+	}
+
+	process, err := os.FindProcess(data.PID)
+	if err != nil {
+		return fmt.Errorf("failed to find gateway process (PID: %d): %w", data.PID, err)
+	}
+
+	if runtime.GOOS == "windows" {
+		err = process.Kill()
+	} else {
+		err = process.Signal(syscall.SIGTERM)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to stop gateway (PID: %d): %w", data.PID, err)
+	}
+
+	fmt.Printf("Sent stop signal to gateway (PID: %d)\n", data.PID)
+	return nil
+}

--- a/cmd/picoclaw/internal/gateway/control_test.go
+++ b/cmd/picoclaw/internal/gateway/control_test.go
@@ -1,0 +1,112 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureGatewayStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	runErr := fn()
+
+	require.NoError(t, w.Close())
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	_, copyErr := io.Copy(&buf, r)
+	require.NoError(t, copyErr)
+
+	return buf.String(), runErr
+}
+
+func writeGatewayPidFile(t *testing.T, homePath string, processID int) {
+	t.Helper()
+
+	data := map[string]any{
+		"pid":     processID,
+		"token":   "test-token",
+		"version": "test",
+		"host":    "127.0.0.1",
+		"port":    18790,
+	}
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(homePath, ".picoclaw.pid"), raw, 0o600)
+	require.NoError(t, err)
+}
+
+func TestGatewayStatusCmdStopped(t *testing.T) {
+	homePath := t.TempDir()
+
+	output, err := captureGatewayStdout(t, func() error {
+		return gatewayStatusCmd(homePath)
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "Gateway status: stopped")
+}
+
+func TestGatewayStopCmdNotRunning(t *testing.T) {
+	homePath := t.TempDir()
+
+	err := gatewayStopCmd(homePath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gateway is not running")
+}
+
+func TestGatewayStopCmdRunningProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX signal semantics")
+	}
+
+	homePath := t.TempDir()
+	sleepCmd := exec.Command("sleep", "30")
+	require.NoError(t, sleepCmd.Start())
+	t.Cleanup(func() {
+		if sleepCmd.Process != nil {
+			_ = sleepCmd.Process.Kill()
+		}
+		_ = sleepCmd.Wait()
+	})
+
+	writeGatewayPidFile(t, homePath, sleepCmd.Process.Pid)
+
+	output, err := captureGatewayStdout(t, func() error {
+		return gatewayStopCmd(homePath)
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "Sent stop signal to gateway")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sleepCmd.Wait()
+	}()
+
+	select {
+	case waitErr := <-done:
+		if waitErr != nil {
+			assert.True(t, strings.Contains(waitErr.Error(), "signal"))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("gateway process did not exit after stop signal")
+	}
+}

--- a/cmd/picoclaw/internal/gateway/control_test.go
+++ b/cmd/picoclaw/internal/gateway/control_test.go
@@ -73,6 +73,9 @@ func TestGatewayStopCmdNotRunning(t *testing.T) {
 }
 
 func TestGatewayStatusCmdRejectsNonGatewayPID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("process identity verification is linux-only (/proc)")
+	}
 	if runtime.GOOS == "windows" {
 		t.Skip("requires POSIX signal semantics")
 	}
@@ -98,6 +101,9 @@ func TestGatewayStatusCmdRejectsNonGatewayPID(t *testing.T) {
 }
 
 func TestGatewayStopCmdRejectsNonGatewayPID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("process identity verification is linux-only (/proc)")
+	}
 	if runtime.GOOS == "windows" {
 		t.Skip("requires POSIX signal semantics")
 	}

--- a/cmd/picoclaw/internal/gateway/control_test.go
+++ b/cmd/picoclaw/internal/gateway/control_test.go
@@ -72,7 +72,7 @@ func TestGatewayStopCmdNotRunning(t *testing.T) {
 	assert.Contains(t, err.Error(), "gateway is not running")
 }
 
-func TestGatewayStopCmdRunningProcess(t *testing.T) {
+func TestGatewayStatusCmdRejectsNonGatewayPID(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("requires POSIX signal semantics")
 	}
@@ -89,6 +89,51 @@ func TestGatewayStopCmdRunningProcess(t *testing.T) {
 
 	writeGatewayPidFile(t, homePath, sleepCmd.Process.Pid)
 
+	_, err := captureGatewayStdout(t, func() error {
+		return gatewayStatusCmd(homePath)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-gateway process")
+}
+
+func TestGatewayStopCmdRejectsNonGatewayPID(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX signal semantics")
+	}
+
+	homePath := t.TempDir()
+	sleepCmd := exec.Command("sleep", "30")
+	require.NoError(t, sleepCmd.Start())
+	t.Cleanup(func() {
+		if sleepCmd.Process != nil {
+			_ = sleepCmd.Process.Kill()
+		}
+		_ = sleepCmd.Wait()
+	})
+
+	writeGatewayPidFile(t, homePath, sleepCmd.Process.Pid)
+
+	err := gatewayStopCmd(homePath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-gateway process")
+}
+
+func TestGatewayStopCmdRunningProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX signal semantics")
+	}
+
+	homePath := t.TempDir()
+	helperCmd := startGatewayHelperProcess(t)
+	t.Cleanup(func() {
+		if helperCmd.Process != nil {
+			_ = helperCmd.Process.Kill()
+		}
+	})
+
+	writeGatewayPidFile(t, homePath, helperCmd.Process.Pid)
+
 	output, err := captureGatewayStdout(t, func() error {
 		return gatewayStopCmd(homePath)
 	})
@@ -98,7 +143,7 @@ func TestGatewayStopCmdRunningProcess(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- sleepCmd.Wait()
+		done <- helperCmd.Wait()
 	}()
 
 	select {
@@ -109,4 +154,40 @@ func TestGatewayStopCmdRunningProcess(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("gateway process did not exit after stop signal")
 	}
+}
+
+func startGatewayHelperProcess(t *testing.T) *exec.Cmd {
+	t.Helper()
+
+	exePath, err := os.Executable()
+	require.NoError(t, err)
+
+	cmd := exec.Command(
+		exePath,
+		"-test.run=TestGatewayCommandHelperProcess",
+		"--",
+		"gateway",
+	)
+	cmd.Env = append(os.Environ(), "GO_WANT_GATEWAY_HELPER_PROCESS=1")
+	require.NoError(t, cmd.Start())
+	return cmd
+}
+
+func TestGatewayCommandHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_GATEWAY_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	for i, arg := range os.Args {
+		if arg != "--" {
+			continue
+		}
+		args := os.Args[i+1:]
+		if len(args) > 0 && args[0] == "gateway" {
+			select {}
+		}
+		break
+	}
+
+	os.Exit(2)
 }

--- a/cmd/picoclaw/internal/gateway/process_identity_linux.go
+++ b/cmd/picoclaw/internal/gateway/process_identity_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package gateway
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+func verifyGatewayProcessIdentity(processID int) error {
+	targetExe, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(processID), "exe"))
+	if err != nil {
+		return fmt.Errorf("failed to inspect gateway process executable (PID: %d): %w", processID, err)
+	}
+
+	currentExe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to inspect current executable: %w", err)
+	}
+
+	if filepath.Base(targetExe) != filepath.Base(currentExe) {
+		return fmt.Errorf("pid file points to a non-gateway process (PID: %d)", processID)
+	}
+
+	rawCmdline, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(processID), "cmdline"))
+	if err != nil {
+		return fmt.Errorf("failed to inspect gateway process command line (PID: %d): %w", processID, err)
+	}
+
+	argv := bytes.Split(rawCmdline, []byte{0})
+	for _, arg := range argv[1:] {
+		if string(arg) == "gateway" || string(arg) == "g" {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("pid file points to a non-gateway process (PID: %d)", processID)
+}

--- a/cmd/picoclaw/internal/gateway/process_identity_other.go
+++ b/cmd/picoclaw/internal/gateway/process_identity_other.go
@@ -2,11 +2,8 @@
 
 package gateway
 
-import "fmt"
-
 func verifyGatewayProcessIdentity(processID int) error {
-	return fmt.Errorf(
-		"gateway process identity verification is not supported on this platform (PID: %d)",
-		processID,
-	)
+	// Best-effort: non-Linux platforms don't have a portable, dependency-free way
+	// to validate /proc-style executable + argv identity. Don't block status/stop.
+	return nil
 }

--- a/cmd/picoclaw/internal/gateway/process_identity_other.go
+++ b/cmd/picoclaw/internal/gateway/process_identity_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package gateway
+
+import "fmt"
+
+func verifyGatewayProcessIdentity(processID int) error {
+	return fmt.Errorf(
+		"gateway process identity verification is not supported on this platform (PID: %d)",
+		processID,
+	)
+}


### PR DESCRIPTION
## Summary
- add `picoclaw gateway status` to report the current PID-file-backed gateway state
- add `picoclaw gateway stop` to send a graceful stop signal to the running gateway process
- keep the existing foreground `picoclaw gateway` behavior unchanged and cover the new helpers with focused tests

## Testing
- `go test -tags goolm ./cmd/picoclaw/internal/gateway -count=1`
- `go test -tags goolm ./pkg/pid -count=1`

## Notes
- reviewer pass obtained on clean `origin/main` base `c3e7396`
- broader `go test ./cmd/picoclaw` still has unrelated existing setup issues outside this lane