### PR TITLE
Fix tzdata not installed issue in termux env

### DIFF
--- a/cmd/picoclaw/main.go
+++ b/cmd/picoclaw/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/spf13/cobra"
 


### PR DESCRIPTION
## 📝 Description

In termux env, tzdata is not installed or can be installed by pkg -i command. In the latest version 0.2.5, TZ info is acquired via env param, but since tzdata is not installed in the system, picoclaw fails to work with time correctly. The cron feature is baddly affected by this issue.

## 🗣️ Type of Change
- [√ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ √] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

None.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** none
- **Reasoning:** none

## 🧪 Test Environment
- **Hardware:** <!-- Huawei Nova 7 SE 5G -->
- **OS:** <!-- Termux in HarmonyOS 3.0.0 -->
- **Model/Provider:** <!-- Bailian GLM-5 -->
- **Channels:** <!-- Feishu -->


## 📸 Evidence (Optional)
<details>
No need to provide.
</details>

## ☑️ Checklist
- [ √] My code/docs follow the style of this project.
- [ √] I have performed a self-review of my own changes.
- [ ×] I have updated the documentation accordingly.