### PR TITLE
fix(provider): handle split SSE stream chunk parsing

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -316,6 +316,7 @@ func parseStreamResponse(
 
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024) // 1MB initial, 10MB max
+	var pendingData string
 	for scanner.Scan() {
 		// Check for context cancellation between chunks
 		if err := ctx.Err(); err != nil {
@@ -330,6 +331,13 @@ func parseStreamResponse(
 		data := strings.TrimPrefix(line, "data: ")
 		if data == "[DONE]" {
 			break
+		}
+
+		// Some SSE implementations can split a JSON payload across multiple data lines.
+		// Keep incomplete fragments and retry parse when the next fragment arrives.
+		payload := data
+		if pendingData != "" {
+			payload = pendingData + payload
 		}
 
 		var chunk struct {
@@ -350,9 +358,17 @@ func parseStreamResponse(
 			Usage *UsageInfo `json:"usage"`
 		}
 
-		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
-			continue // skip malformed chunks
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			// Keep buffer only for likely truncated JSON.
+			// For other malformed payloads, drop it to avoid poisoning later valid chunks.
+			if strings.Contains(err.Error(), "unexpected end of JSON input") {
+				pendingData = payload
+			} else {
+				pendingData = ""
+			}
+			continue
 		}
+		pendingData = ""
 
 		if chunk.Usage != nil {
 			usage = chunk.Usage

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -2,6 +2,7 @@ package openai_compat
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +16,41 @@ import (
 	"github.com/sipeed/picoclaw/pkg/providers/common"
 	"github.com/sipeed/picoclaw/pkg/providers/protocoltypes"
 )
+
+func TestParseStreamResponse_ReassemblesSplitJSONAcrossDataLines(t *testing.T) {
+	stream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"hel`,
+		`data: lo"},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+
+	out, err := parseStreamResponse(context.Background(), strings.NewReader(stream), nil)
+	if err != nil {
+		t.Fatalf("parseStreamResponse() error = %v", err)
+	}
+	if out.Content != "hello" {
+		t.Fatalf("Content = %q, want %q", out.Content, "hello")
+	}
+}
+
+func TestParseStreamResponse_DropsMalformedChunkAndRecovers(t *testing.T) {
+	stream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"bad"}}]} garbage`,
+		`data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+
+	out, err := parseStreamResponse(context.Background(), strings.NewReader(stream), nil)
+	if err != nil {
+		t.Fatalf("parseStreamResponse() error = %v", err)
+	}
+	// The malformed chunk should be skipped, and the next valid chunk should still parse.
+	if out.Content != "ok" {
+		t.Fatalf("Content = %q, want %q", out.Content, "ok")
+	}
+}
 
 func TestProviderChat_UsesMaxCompletionTokensForGLM(t *testing.T) {
 	var requestBody map[string]any


### PR DESCRIPTION
Preserve partial stream payloads only when JSON is incomplete so chunk boundaries no longer drop content, while malformed payloads are discarded to avoid poisoning subsequent valid chunks. Add regression tests for split-payload reassembly and malformed-chunk recovery.

Made-with: Cursor

## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC-->
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 -->
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 -->
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [ ] My code/docs follow the style of this project.
- [ ] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.