### PR TITLE
docs(tool): use provider-agnostic JSON escaping guidance

### DIFF
--- a/pkg/agent/hooks_test.go
+++ b/pkg/agent/hooks_test.go
@@ -515,7 +515,6 @@ type respondWithMediaHook struct {
 	media           []string
 	responseHandled bool
 	forLLM          string
-	sendMediaErr    error
 }
 
 func (h *respondWithMediaHook) BeforeTool(

--- a/pkg/providers/common/common_test.go
+++ b/pkg/providers/common/common_test.go
@@ -254,6 +254,22 @@ func TestDecodeToolCallArguments_ObjectJSON(t *testing.T) {
 	}
 }
 
+func TestDecodeToolCallArguments_ObjectJSON_NewlineEscape(t *testing.T) {
+	raw := json.RawMessage(`{"content":"line1\nline2"}`)
+	args := DecodeToolCallArguments(raw, "write_file")
+	if args["content"] != "line1\nline2" {
+		t.Errorf("content = %q, want newline-expanded string", args["content"])
+	}
+}
+
+func TestDecodeToolCallArguments_ObjectJSON_LiteralBackslashN(t *testing.T) {
+	raw := json.RawMessage(`{"content":"line1\\nline2"}`)
+	args := DecodeToolCallArguments(raw, "write_file")
+	if args["content"] != `line1\nline2` {
+		t.Errorf("content = %q, want literal backslash-n", args["content"])
+	}
+}
+
 func TestDecodeToolCallArguments_StringJSON(t *testing.T) {
 	raw := json.RawMessage(`"{\"city\":\"SF\"}"`)
 	args := DecodeToolCallArguments(raw, "test")

--- a/pkg/tools/edit.go
+++ b/pkg/tools/edit.go
@@ -29,7 +29,7 @@ func (t *EditFileTool) Name() string {
 }
 
 func (t *EditFileTool) Description() string {
-	return "Edit a file by replacing old_text with new_text. The old_text must exist exactly in the file. In `function.arguments`, use \\n for newline and \\\\n for literal backslash-n."
+	return "Edit a file by replacing old_text with new_text. The old_text must exist exactly in the file. Standard JSON escaping applies: \\n for newline and \\\\n for literal backslash-n."
 }
 
 func (t *EditFileTool) Parameters() map[string]any {
@@ -42,11 +42,11 @@ func (t *EditFileTool) Parameters() map[string]any {
 			},
 			"old_text": map[string]any{
 				"type":        "string",
-				"description": "The exact text to find and replace. In `function.arguments`, use \\n for newline and \\\\n for literal backslash-n.",
+				"description": "The exact text to find and replace. Standard JSON escaping applies: \\n for newline and \\\\n for literal backslash-n.",
 			},
 			"new_text": map[string]any{
 				"type":        "string",
-				"description": "The text to replace with. In `function.arguments`, use \\n for newline and \\\\n for literal backslash-n.",
+				"description": "The text to replace with. Standard JSON escaping applies: \\n for newline and \\\\n for literal backslash-n.",
 			},
 		},
 		"required": []string{"path", "old_text", "new_text"},
@@ -92,7 +92,7 @@ func (t *AppendFileTool) Name() string {
 }
 
 func (t *AppendFileTool) Description() string {
-	return "Append content to the end of a file. In `function.arguments`, use \\n for newline and \\\\n for literal backslash-n."
+	return "Append content to the end of a file. Standard JSON escaping applies: \\n for newline and \\\\n for literal backslash-n."
 }
 
 func (t *AppendFileTool) Parameters() map[string]any {
@@ -105,7 +105,7 @@ func (t *AppendFileTool) Parameters() map[string]any {
 			},
 			"content": map[string]any{
 				"type":        "string",
-				"description": "The content to append. In `function.arguments`, use \\n for newline and \\\\n for literal backslash-n.",
+				"description": "The content to append. Standard JSON escaping applies: \\n for newline and \\\\n for literal backslash-n.",
 			},
 		},
 		"required": []string{"path", "content"},

--- a/pkg/tools/filesystem.go
+++ b/pkg/tools/filesystem.go
@@ -870,7 +870,7 @@ func (t *WriteFileTool) Name() string {
 }
 
 func (t *WriteFileTool) Description() string {
-	return "Write content to a file. In `function.arguments`, use \\n for a newline and \\\\n for a literal backslash-n sequence. Content is written byte-for-byte after argument decoding. If the file already exists, you must set overwrite=true to replace it."
+	return "Write content to a file. Content is written byte-for-byte after argument decoding. Standard JSON escaping applies: \\n for newline and \\\\n for a literal backslash-n sequence. If the file already exists, you must set overwrite=true to replace it."
 }
 
 func (t *WriteFileTool) Parameters() map[string]any {
@@ -883,7 +883,7 @@ func (t *WriteFileTool) Parameters() map[string]any {
 			},
 			"content": map[string]any{
 				"type":        "string",
-				"description": "Content to write to the file. In `function.arguments`, use \\n for newline and \\\\n for literal backslash-n.",
+				"description": "Content to write to the file. Standard JSON escaping applies: \\n for newline and \\\\n for literal backslash-n.",
 			},
 			"overwrite": map[string]any{
 				"type":        "boolean",


### PR DESCRIPTION
## 📝 Description

- replace shared tool descriptions that assumed `function.arguments` is always a JSON-encoded string
- make `write_file`, `edit_file`, and `append_file` guidance provider-agnostic
- add object-JSON test coverage for newline and literal backslash-n decoding in `DecodeToolCallArguments`

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #2337

## 📚 Technical Context (Skip for Docs)

The previous wording in shared tool metadata said things like `In function.arguments, use ...`, which is accurate for CLI providers that double-decode a JSON string, but misleading for providers that send tool arguments as a JSON object directly.

This PR keeps the escape guidance but rewrites it in provider-agnostic terms:
- `\n` for newline
- `\\n` for a literal backslash-n sequence

It also adds tests for the object-JSON decode path so both argument formats are covered.

## 🧪 Test Environment

Validated locally with Docker using `golang:1.26`:

- `gofmt -w pkg/tools/filesystem.go pkg/tools/edit.go pkg/providers/common/common_test.go`
- `go test ./pkg/providers/common -run 'TestDecodeToolCallArguments_'`
- `go test ./pkg/tools -run '^$'`
- `git diff --check`

Note:
A broader run of `go test ./pkg/tools ./pkg/providers/common` hit an unrelated existing failure in `TestShellTool_TimeoutKillsChildProcess`, which is outside the scope of this PR.

## 📸 Evidence (Optional)

- shared tool descriptions no longer mention `function.arguments`
- object-JSON decoding is now covered for both `\n` and `\\n`

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
