### PR TITLE
fix(test): skip isolation env test on unsupported OSes

### DIFF
--- a/pkg/isolation/runtime_test.go
+++ b/pkg/isolation/runtime_test.go
@@ -212,6 +212,9 @@ func TestExistingExposePaths_SkipsMissingPaths(t *testing.T) {
 }
 
 func TestPrepareCommand_AppliesUserEnv(t *testing.T) {
+	if !isSupportedOn(runtime.GOOS) {
+		t.Skipf("isolation not supported on %s", runtime.GOOS)
+	}
 	t.Setenv(config.EnvHome, filepath.Join(t.TempDir(), "home"))
 	if runtime.GOOS == "linux" {
 		binDir := filepath.Join(t.TempDir(), "bin")


### PR DESCRIPTION
## 📝 Description

This PR updates `TestPrepareCommand_AppliesUserEnv` to skip on operating systems where isolation is not supported.

This avoids false-negative test results on unsupported platforms while preserving existing behavior and assertions on supported systems.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** `prepareCommand` test coverage should only run where isolation runtime support exists; skipping on unsupported OSes keeps CI and local runs stable without weakening supported-platform validation.

## 🧪 Test Environment
- **Hardware:** Apple Silicon (arm64)
- **OS:** macOS 26.4 (darwin/arm64)
- **Model/Provider:** N/A (unit test change)
- **Channels:** N/A (unit test change)


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```bash
go test ./pkg/isolation/... -run TestPrepareCommand_AppliesUserEnv -v
=== RUN   TestPrepareCommand_AppliesUserEnv
    runtime_test.go:216: isolation not supported on darwin
--- SKIP: TestPrepareCommand_AppliesUserEnv (0.00s)
PASS
ok  github.com/sipeed/picoclaw/pkg/isolation 0.802s
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
