### PR TITLE
fix(codex): accumulate output items from stream events

### DIFF
--- a/pkg/providers/codex_provider.go
+++ b/pkg/providers/codex_provider.go
@@ -104,12 +104,21 @@ func (p *CodexProvider) Chat(
 	defer stream.Close()
 
 	var resp *responses.Response
+	var accumulatedOutput []responses.ResponseOutputItemUnion
 	for stream.Next() {
 		evt := stream.Current()
+		// Accumulate output items as they arrive — the response.completed
+		// event may not include them in its Response.Output field.
+		if evt.Type == "response.output_item.done" {
+			accumulatedOutput = append(accumulatedOutput, evt.Item)
+		}
 		if evt.Type == "response.completed" || evt.Type == "response.failed" || evt.Type == "response.incomplete" {
 			evtResp := evt.Response
 			if evtResp.ID != "" {
 				evtRespCopy := evtResp
+				if len(evtRespCopy.Output) == 0 && len(accumulatedOutput) > 0 {
+					evtRespCopy.Output = accumulatedOutput
+				}
 				resp = &evtRespCopy
 			}
 		}


### PR DESCRIPTION
## Summary

- The Codex/OpenAI Responses streaming API sends output items via `response.output_item.done` events, but the final `response.completed` event arrives with an empty `Output` array
- This caused all Codex OAuth provider responses to return empty content (0 content chars) despite the model successfully generating a reply (completion tokens > 0)
- Fix accumulates output items as they stream in and merges them into the response when `response.completed` has none

## Reproduction

1. Configure a model with `auth_method: "oauth"` (Codex provider)
2. Send any message
3. Response returns "The model returned an empty response" despite successful API call

## Root cause

In `codex_provider.go`, the streaming loop only captured `evt.Response` from terminal events (`response.completed`), but the OpenAI Responses API does not populate `Response.Output` in that event — output items are delivered separately via `response.output_item.done` events.

## Test plan

- [x] Tested with `gpt-5.4` via OAuth — responses now returned correctly
- [x] Tested with `gpt-5.3-codex` via OAuth — same fix applies
- [x] Verified tool calls and text content both parse correctly
- [x] No regressions on non-Codex providers (change is scoped to `codex_provider.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)