### PR TITLE
fix(mcp): send empty object instead of nil arguments in CallTool

### DIFF
--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -473,6 +473,12 @@ func (m *Manager) CallTool(
 	}
 	defer m.wg.Done()
 
+	// Some MCP servers (notably @playwright/mcp) reject `arguments: null` with
+	// a Zod validation error ("expected record, received null") when a tool
+	// has no required parameters. Always send an empty object instead of nil.
+	if arguments == nil {
+		arguments = map[string]any{}
+	}
 	params := &mcp.CallToolParams{
 		Name:      toolName,
 		Arguments: arguments,


### PR DESCRIPTION
## Problem

MCP servers built on the official TypeScript SDK validate tool call arguments with Zod. When PicoClaw invokes a tool that has no required parameters, it currently passes a `nil` `map[string]any` to `mcp.CallToolParams.Arguments`, which the Go SDK serializes as JSON `null`. Zod-based servers reject this with:

\`\`\`
expected record, received null
path: params.arguments
\`\`\`

The most prominent affected server is **[@playwright/mcp](https://github.com/microsoft/playwright-mcp)**, which makes every parameter-less browser tool unusable from PicoClaw — `browser_snapshot`, `browser_take_screenshot`, `browser_tabs`, etc. all fail immediately on first call.

## Reproduction

1. Add a Playwright MCP server to \`config.json\`:
   \`\`\`json
   "tools": {
     "mcp": {
       "enabled": true,
       "servers": {
         "playwright": {
           "enabled": true,
           "command": "npx",
           "args": ["-y", "@playwright/mcp@latest", "--headless"]
         }
       }
     }
   }
   \`\`\`
2. Ask the agent: *"Open example.com and tell me the page title"*
3. Agent calls \`browser_navigate\` (works), then \`browser_snapshot\` → fails with the Zod error above.

## Fix

Normalize a nil arguments map to an empty map before constructing \`CallToolParams\`. JSON marshalling then produces \`{}\` instead of \`null\`, which Zod accepts.

Six lines, no behaviour change for tools that already pass non-nil arguments.

## Verified

End-to-end against \`@playwright/mcp@latest\` running headless Chromium inside the launcher Docker image. \`browser_navigate\` + \`browser_snapshot\` now succeed and the agent returns the page title in 6-7 seconds.

Happy to add a unit test in \`pkg/mcp/manager_test.go\` if maintainers want it — just say the word.