### PR TITLE
fix(launcher): fall back to token auth on unsupported platforms

### DIFF
--- a/web/backend/api/auth.go
+++ b/web/backend/api/auth.go
@@ -81,8 +81,13 @@ type launcherAuthHandlers struct {
 	loginLimit    *loginRateLimiter
 }
 
+func (h *launcherAuthHandlers) usesLegacyTokenAuth() bool {
+	return h.store == nil && h.storeErr == nil && h.token != ""
+}
+
 // isStoreInitialized safely queries the store.
-// Returns (false, nil) when no store is configured (storeErr also nil).
+// Returns (true, nil) when legacy token auth is active without a password store.
+// Returns (false, nil) when no store/token fallback is configured.
 // Returns (false, err) on store errors — callers must treat this as a 5xx, not as
 // "uninitialized", to keep auth fail-closed.
 // Exception: handleLogin swallows storeErr and falls back to token auth so
@@ -94,6 +99,9 @@ func (h *launcherAuthHandlers) isStoreInitialized(ctx context.Context) (bool, er
 				"password store unavailable (%w); "+
 					"to recover, stop the application, delete the database file and restart ",
 				h.storeErr)
+		}
+		if h.usesLegacyTokenAuth() {
+			return true, nil
 		}
 		return false, nil
 	}
@@ -129,7 +137,7 @@ func (h *launcherAuthHandlers) handleLogin(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	if initialized {
+	if initialized && h.store != nil {
 		// Bcrypt path: verify against the stored hash.
 		var err error
 		ok, err = h.store.VerifyPassword(r.Context(), in)
@@ -217,6 +225,14 @@ func (h *launcherAuthHandlers) handleStatus(w http.ResponseWriter, r *http.Reque
 //   - If a password is already set, the caller must hold a valid session cookie.
 func (h *launcherAuthHandlers) handleSetup(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+
+	if h.usesLegacyTokenAuth() {
+		w.WriteHeader(http.StatusNotImplemented)
+		_, _ = w.Write(
+			[]byte(`{"error":"password setup is unavailable on this platform; use the dashboard token instead"}`),
+		)
+		return
+	}
 
 	if h.store == nil {
 		w.WriteHeader(http.StatusNotImplemented)

--- a/web/backend/api/auth_test.go
+++ b/web/backend/api/auth_test.go
@@ -75,6 +75,67 @@ func TestLauncherAuthLoginAndStatus(t *testing.T) {
 	})
 }
 
+func TestLauncherAuthLegacyTokenFallbackReportsInitialized(t *testing.T) {
+	key := make([]byte, 32)
+	const tok = "legacy-fallback-token"
+	sess := middleware.SessionCookieValue(key, tok)
+	mux := http.NewServeMux()
+	RegisterLauncherAuthRoutes(mux, LauncherAuthRouteOpts{
+		DashboardToken: tok,
+		SessionCookie:  sess,
+	})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/auth/status", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Authenticated bool `json:"authenticated"`
+		Initialized   bool `json:"initialized"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if !body.Initialized {
+		t.Fatalf("initialized = false, want true in legacy token fallback mode")
+	}
+	if body.Authenticated {
+		t.Fatalf("unexpected authenticated=true: %+v", body)
+	}
+
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"password":"`+tok+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("login code = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestLauncherAuthSetupRejectedInLegacyTokenFallback(t *testing.T) {
+	key := make([]byte, 32)
+	sess := middleware.SessionCookieValue(key, "legacy-token")
+	mux := http.NewServeMux()
+	RegisterLauncherAuthRoutes(mux, LauncherAuthRouteOpts{
+		DashboardToken: "legacy-token",
+		SessionCookie:  sess,
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/auth/setup",
+		strings.NewReader(`{"password":"12345678","confirm":"12345678"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("setup code = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestLauncherAuthLogoutRequiresPostAndJSON(t *testing.T) {
 	key := make([]byte, 32)
 	sess := middleware.SessionCookieValue(key, "tok")

--- a/web/backend/dashboardauth/platform.go
+++ b/web/backend/dashboardauth/platform.go
@@ -1,0 +1,7 @@
+package dashboardauth
+
+import "errors"
+
+// ErrUnsupportedPlatform reports that the SQLite-backed password store is not
+// available for the current target platform.
+var ErrUnsupportedPlatform = errors.New("dashboard password store is unavailable on this platform")

--- a/web/backend/dashboardauth/store.go
+++ b/web/backend/dashboardauth/store.go
@@ -1,3 +1,5 @@
+//go:build !mipsle && !netbsd && !(freebsd && arm)
+
 // Package dashboardauth provides a bcrypt-backed SQLite store for the
 // launcher dashboard password. The database contains a single row (id=1)
 // with the bcrypt hash; no plaintext is ever persisted.

--- a/web/backend/dashboardauth/store_unsupported.go
+++ b/web/backend/dashboardauth/store_unsupported.go
@@ -1,0 +1,60 @@
+//go:build mipsle || netbsd || (freebsd && arm)
+
+package dashboardauth
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+)
+
+// Store is unavailable on platforms where modernc sqlite/libc does not build.
+type Store struct {
+	path string
+}
+
+// New reports that the password store is unavailable on this platform.
+func New(dir string) (*Store, error) {
+	path := filepath.Join(dir, DBFilename)
+	s, err := Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", path, err)
+	}
+	return s, nil
+}
+
+// Open reports that the password store is unavailable on this platform.
+func Open(path string) (*Store, error) {
+	return nil, unsupportedPlatformError()
+}
+
+// Close is a no-op for unsupported platforms.
+func (s *Store) Close() error { return nil }
+
+// DBPath returns the configured path, if any.
+func (s *Store) DBPath() string {
+	if s == nil {
+		return ""
+	}
+	return s.path
+}
+
+// IsInitialized reports that the store is unavailable on this platform.
+func (s *Store) IsInitialized(context.Context) (bool, error) {
+	return false, unsupportedPlatformError()
+}
+
+// SetPassword reports that the store is unavailable on this platform.
+func (s *Store) SetPassword(context.Context, string) error {
+	return unsupportedPlatformError()
+}
+
+// VerifyPassword reports that the store is unavailable on this platform.
+func (s *Store) VerifyPassword(context.Context, string) (bool, error) {
+	return false, unsupportedPlatformError()
+}
+
+func unsupportedPlatformError() error {
+	return fmt.Errorf("%w (%s/%s)", ErrUnsupportedPlatform, runtime.GOOS, runtime.GOARCH)
+}

--- a/web/backend/main.go
+++ b/web/backend/main.go
@@ -229,11 +229,21 @@ func main() {
 
 	// Open the bcrypt password store (creates the DB file on first run).
 	authStore, authStoreErr := dashboardauth.New(picoHome)
-	if authStoreErr != nil {
-		logger.ErrorC("web", fmt.Sprintf("Warning: could not open auth store: %v", authStoreErr))
-		authStore = nil
-	} else {
+	var passwordStore api.PasswordStore
+	if authStoreErr == nil {
+		passwordStore = authStore
 		defer authStore.Close()
+	} else if errors.Is(authStoreErr, dashboardauth.ErrUnsupportedPlatform) {
+		logger.InfoC(
+			"web",
+			fmt.Sprintf(
+				"Dashboard password store unavailable on this platform; falling back to token login: %v",
+				authStoreErr,
+			),
+		)
+		authStoreErr = nil
+	} else {
+		logger.ErrorC("web", fmt.Sprintf("Warning: could not open auth store: %v", authStoreErr))
 	}
 
 	// Determine listen address
@@ -250,7 +260,7 @@ func main() {
 	api.RegisterLauncherAuthRoutes(mux, api.LauncherAuthRouteOpts{
 		DashboardToken: dashboardToken,
 		SessionCookie:  dashboardSessionCookie,
-		PasswordStore:  authStore,
+		PasswordStore:  passwordStore,
 		StoreError:     authStoreErr,
 	})
 


### PR DESCRIPTION
## 📝 Description

This change keeps launcher authentication usable on platforms where the SQLite-backed dashboard password store is unavailable.
It treats legacy dashboard token auth as initialized, rejects password setup on unsupported platforms, and adds tests covering the fallback behavior.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** `dashboardauth.New` currently fails on platforms where the modernc SQLite stack is unsupported. This PR keeps launcher auth available by treating token-based auth as initialized in that case, returning a clear 501 for password setup, and leaving the existing password-store flow unchanged on supported platforms.

## 🧪 Test Environment
- **Hardware:** Apple Silicon Mac
- **OS:** macOS 26.4
- **Model/Provider:** N/A (launcher web backend unit tests)
- **Channels:** N/A (launcher web backend unit tests)


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```text
make check
go test ./web/backend/...
```

Both completed successfully.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
