### PR TITLE
fix(cron): make each job execution use an independent session

### DIFF
--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -342,7 +342,7 @@ func (t *CronTool) ExecuteJob(ctx context.Context, job *cron.CronJob) string {
 		return "ok"
 	}
 
-	sessionKey := fmt.Sprintf("cron-%s", job.ID)
+	sessionKey := fmt.Sprintf("cron-%s-%d", job.ID, time.Now().UnixMilli())
 
 	// Call agent with the job message
 	response, err := t.executor.ProcessDirectWithChannel(

--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
 	"github.com/sipeed/picoclaw/pkg/constants"

--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
 	"github.com/sipeed/picoclaw/pkg/constants"
@@ -342,7 +343,7 @@ func (t *CronTool) ExecuteJob(ctx context.Context, job *cron.CronJob) string {
 		return "ok"
 	}
 
-	sessionKey := fmt.Sprintf("cron-%s-%d", job.ID, time.Now().UnixMilli())
+	sessionKey := fmt.Sprintf("agent:cron-%s-%s", job.ID, uuid.New().String())
 
 	// Call agent with the job message
 	response, err := t.executor.ProcessDirectWithChannel(

--- a/pkg/tools/cron_test.go
+++ b/pkg/tools/cron_test.go
@@ -271,8 +271,8 @@ func TestCronTool_ExecuteJobPublishesAgentResponse(t *testing.T) {
 		t.Fatalf("ExecuteJob() = %q, want ok", got)
 	}
 
-	if executor.lastKey != "cron-job-1" {
-		t.Fatalf("sessionKey = %q, want cron-job-1", executor.lastKey)
+	if !strings.HasPrefix(executor.lastKey, "agent:cron-job-1-") {
+		t.Fatalf("sessionKey = %q, want agent:cron-job-1-{uuid}", executor.lastKey)
 	}
 	if executor.lastChan != "telegram" || executor.lastChatID != "chat-1" {
 		t.Fatalf("executor target = %s/%s, want telegram/chat-1", executor.lastChan, executor.lastChatID)


### PR DESCRIPTION
## 📝 Description

Previously all executions of the same cron job reused the session key "cron-{jobID}", causing conversation history to accumulate across runs. Now each run gets a unique key "cron-{jobID}-{timestamp}", preventing cross-execution interference.

## 🗣️ Type of Change
- [ x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:** The cron job session key was previously "cron-{jobID}", causing each execution to accumulate in the same conversation history. Now it uses "cron-{jobID}-{timestamp}" to ensure each run gets an independent session.

## ☑️ Checklist
- [x ] My code/docs follow the style of this project.
- [x ] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.