### PR TITLE
fix(telegram): preserve raw OAuth links in HTML rendering

### DIFF
--- a/pkg/channels/telegram/parser_markdown_to_html.go
+++ b/pkg/channels/telegram/parser_markdown_to_html.go
@@ -2,8 +2,12 @@ package telegram
 
 import (
 	"fmt"
+	"html"
+	"regexp"
 	"strings"
 )
+
+var reRawURL = regexp.MustCompile(`https?://[^\s<]+`)
 
 func markdownToTelegramHTML(text string) string {
 	if text == "" {
@@ -18,6 +22,9 @@ func markdownToTelegramHTML(text string) string {
 
 	links := extractLinks(text)
 	text = links.text
+
+	rawURLs := extractRawURLs(text)
+	text = rawURLs.text
 
 	text = reHeading.ReplaceAllString(text, "$1")
 
@@ -43,8 +50,17 @@ func markdownToTelegramHTML(text string) string {
 
 	for i, lnk := range links.links {
 		label := escapeHTML(lnk[0])
-		url := lnk[1]
+		url := escapeHTMLAttr(lnk[1])
 		text = strings.ReplaceAll(text, fmt.Sprintf("\x00LK%d\x00", i), fmt.Sprintf(`<a href="%s">%s</a>`, url, label))
+	}
+
+	for i, rawURL := range rawURLs.urls {
+		escaped := escapeHTML(rawURL)
+		text = strings.ReplaceAll(
+			text,
+			fmt.Sprintf("\x00RU%d\x00", i),
+			fmt.Sprintf(`<a href="%s">%s</a>`, escapeHTMLAttr(rawURL), escaped),
+		)
 	}
 
 	for i, code := range inlineCodes.codes {
@@ -92,6 +108,11 @@ type codeBlockMatch struct {
 	codes []string
 }
 
+type rawURLMatch struct {
+	text string
+	urls []string
+}
+
 func extractCodeBlocks(text string) codeBlockMatch {
 	matches := reCodeBlock.FindAllStringSubmatch(text, -1)
 
@@ -108,6 +129,24 @@ func extractCodeBlocks(text string) codeBlockMatch {
 	})
 
 	return codeBlockMatch{text: text, codes: codes}
+}
+
+func extractRawURLs(text string) rawURLMatch {
+	matches := reRawURL.FindAllString(text, -1)
+
+	urls := make([]string, 0, len(matches))
+	for _, match := range matches {
+		urls = append(urls, match)
+	}
+
+	i := 0
+	text = reRawURL.ReplaceAllStringFunc(text, func(string) string {
+		placeholder := fmt.Sprintf("\x00RU%d\x00", i)
+		i++
+		return placeholder
+	})
+
+	return rawURLMatch{text: text, urls: urls}
 }
 
 type inlineCodeMatch struct {
@@ -138,4 +177,8 @@ func escapeHTML(text string) string {
 	text = strings.ReplaceAll(text, "<", "&lt;")
 	text = strings.ReplaceAll(text, ">", "&gt;")
 	return text
+}
+
+func escapeHTMLAttr(text string) string {
+	return html.EscapeString(text)
 }

--- a/pkg/channels/telegram/parser_markdown_to_html_test.go
+++ b/pkg/channels/telegram/parser_markdown_to_html_test.go
@@ -33,6 +33,11 @@ func Test_markdownToTelegramHTML(t *testing.T) {
 			expected: `<a href="https://example.com/path">click here</a>`,
 		},
 		{
+			name:     "raw oauth url with underscores survives",
+			input:    "Apri https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=test-client&redirect_uri=http%3A%2F%2Flocalhost%3A8001%2Foauth2callback&code_challenge=abc_def&code_challenge_method=S256",
+			expected: `Apri <a href="https://accounts.google.com/o/oauth2/auth?response_type=code&amp;client_id=test-client&amp;redirect_uri=http%3A%2F%2Flocalhost%3A8001%2Foauth2callback&amp;code_challenge=abc_def&amp;code_challenge_method=S256">https://accounts.google.com/o/oauth2/auth?response_type=code&amp;client_id=test-client&amp;redirect_uri=http%3A%2F%2Flocalhost%3A8001%2Foauth2callback&amp;code_challenge=abc_def&amp;code_challenge_method=S256</a>`,
+		},
+		{
 			name: "link with underscores in URL is not corrupted by italic regex",
 			// Google Flights URLs use URL-safe base64 with underscores in the tfs param.
 			// Previously reItalic ran after reLink, matching _text_ inside href and injecting
@@ -44,6 +49,11 @@ func Test_markdownToTelegramHTML(t *testing.T) {
 			name:     "multiple links all survive",
 			input:    "[first](https://a.com/path_one) and [second](https://b.com/path_two_x)",
 			expected: `<a href="https://a.com/path_one">first</a> and <a href="https://b.com/path_two_x">second</a>`,
+		},
+		{
+			name:     "markdown link query params are escaped in href",
+			input:    "[oauth](https://example.com/cb?response_type=code&client_id=test-client)",
+			expected: `<a href="https://example.com/cb?response_type=code&amp;client_id=test-client">oauth</a>`,
 		},
 		{
 			name:     "link label with HTML special chars is escaped",


### PR DESCRIPTION
## 📝 Description

This PR fixes a Telegram rendering bug that could corrupt raw OAuth links before they were sent to users.

In particular, OAuth query parameters containing underscores such as `response_type`, `client_id`, `redirect_uri`, `code_challenge`, and `code_challenge_method` could be altered by the Telegram HTML formatting pipeline, resulting in broken authorization URLs. This change preserves raw URLs during Telegram HTML conversion and adds regression tests for Google-style OAuth links and query-parameter escaping.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** Telegram Bot API formatting behavior; Google OAuth authorization URL flow
- **Reasoning:** The Telegram channel converts outbound content into HTML before sending it. Raw URLs were not isolated before inline formatting rules were applied, so underscores inside OAuth query parameters could be consumed by italic parsing and produce invalid links. This PR extracts raw URLs before formatting, restores them as safe HTML links, and adds regression coverage for this case.

## 🧪 Test Environment
- **Hardware:** Raspberry Pi
- **OS:** Debian 12 (Bookworm)
- **Model/Provider:** 
- **Channels:** Telegram

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- Before the fix, OAuth parameters such as `response_type` and `client_id` could appear as `responsetype` and `clientid` in Telegram messages.
- After the fix, raw OAuth URLs are preserved and rendered correctly in Telegram.
- Regression tests were added for:
  - raw OAuth URLs with underscores in query parameters
  - markdown links with query parameters escaped safely in HTML

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
