### PR TITLE
build: add Android arm64 cross-compile support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,17 @@ jobs:
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
 
+      - name: Build and upload Android arm64
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sudo apt-get install -y zip
+          make build-all-android
+          gh release upload "${{ inputs.tag }}" \
+            build/picoclaw-android-universal.zip \
+            --clobber
+
       - name: Apply release flags
         shell: bash
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sudo apt-get install -y zip
-          make build-all-android
+          make build-android-bundle
           gh release upload "${{ inputs.tag }}" \
             build/picoclaw-android-universal.zip \
             --clobber

--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,7 @@ build-all: generate
 	GOOS=windows GOARCH=amd64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe ./$(CMD_DIR)
 	GOOS=netbsd GOARCH=amd64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-netbsd-amd64 ./$(CMD_DIR)
 	GOOS=netbsd GOARCH=arm64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-netbsd-arm64 ./$(CMD_DIR)
+	@$(MAKE) build-all-android
 	@echo "All builds complete"
 
 ## install: Install picoclaw to system and copy builtin skills

--- a/Makefile
+++ b/Makefile
@@ -216,15 +216,12 @@ build-android-arm64: generate
 build-launcher-android-arm64:
 	@echo "Building picoclaw-launcher for android/arm64..."
 	@mkdir -p $(BUILD_DIR)
-	@$(MAKE) -C web build \
-		OUTPUT="$(CURDIR)/$(BUILD_DIR)/picoclaw-launcher-android-arm64" \
-		WEB_GO='GOOS=android GOARCH=arm64 CGO_ENABLED=0 go' \
-		GO_BUILD_TAGS='stdjson' \
-		LDFLAGS='$(LDFLAGS)'
+	@$(MAKE) -C web build-android-arm64 \
+		OUTPUT="$(CURDIR)/$(BUILD_DIR)/picoclaw-launcher-android-arm64"
 	@echo "Build complete: $(BUILD_DIR)/picoclaw-launcher-android-arm64"
 
-## build-all-android: Build core and launcher for all Android architectures and package as universal zip
-build-all-android: generate
+## build-android-bundle: Build core and launcher for all Android architectures and package as universal zip
+build-android-bundle: generate
 	@echo "Building core for all Android architectures..."
 	@mkdir -p $(BUILD_DIR)
 	GOOS=android GOARCH=arm64 $(GO) build -tags stdjson -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-android-arm64 ./$(CMD_DIR)
@@ -260,7 +257,7 @@ build-all: generate
 	GOOS=windows GOARCH=amd64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe ./$(CMD_DIR)
 	GOOS=netbsd GOARCH=amd64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-netbsd-amd64 ./$(CMD_DIR)
 	GOOS=netbsd GOARCH=arm64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-netbsd-arm64 ./$(CMD_DIR)
-	@$(MAKE) build-all-android
+	@$(MAKE) build-android-bundle
 	@echo "All builds complete"
 
 ## install: Install picoclaw to system and copy builtin skills

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,40 @@ build-linux-mipsle: generate
 	$(call PATCH_MIPS_FLAGS,$(BUILD_DIR)/$(BINARY_NAME)-linux-mipsle)
 	@echo "Build complete: $(BUILD_DIR)/$(BINARY_NAME)-linux-mipsle"
 
+## build-android-arm64: Build core for Android ARM64
+build-android-arm64: generate
+	@echo "Building for android/arm64..."
+	@mkdir -p $(BUILD_DIR)
+	GOOS=android GOARCH=arm64 $(GO) build -tags stdjson -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-android-arm64 ./$(CMD_DIR)
+	@echo "Build complete: $(BUILD_DIR)/$(BINARY_NAME)-android-arm64"
+
+## build-launcher-android-arm64: Build launcher for Android ARM64
+build-launcher-android-arm64:
+	@echo "Building picoclaw-launcher for android/arm64..."
+	@mkdir -p $(BUILD_DIR)
+	@$(MAKE) -C web build \
+		OUTPUT="$(CURDIR)/$(BUILD_DIR)/picoclaw-launcher-android-arm64" \
+		WEB_GO='GOOS=android GOARCH=arm64 CGO_ENABLED=0 go' \
+		GO_BUILD_TAGS='stdjson' \
+		LDFLAGS='$(LDFLAGS)'
+	@echo "Build complete: $(BUILD_DIR)/picoclaw-launcher-android-arm64"
+
+## build-all-android: Build core and launcher for all Android architectures and package as universal zip
+build-all-android: generate
+	@echo "Building core for all Android architectures..."
+	@mkdir -p $(BUILD_DIR)
+	GOOS=android GOARCH=arm64 $(GO) build -tags stdjson -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-android-arm64 ./$(CMD_DIR)
+	@echo "Building launcher for Android arm64..."
+	@$(MAKE) build-launcher-android-arm64
+	@echo "Staging JNI libs..."
+	@rm -rf $(BUILD_DIR)/android-staging
+	@mkdir -p $(BUILD_DIR)/android-staging/arm64-v8a
+	@cp $(BUILD_DIR)/$(BINARY_NAME)-android-arm64 $(BUILD_DIR)/android-staging/arm64-v8a/libpicoclaw.so
+	@cp $(BUILD_DIR)/picoclaw-launcher-android-arm64 $(BUILD_DIR)/android-staging/arm64-v8a/libpicoclaw-web.so
+	@cd $(BUILD_DIR)/android-staging && zip -r ../picoclaw-android-universal.zip .
+	@rm -rf $(BUILD_DIR)/android-staging
+	@echo "All Android builds complete: $(BUILD_DIR)/picoclaw-android-universal.zip"
+
 ## build-pi-zero: Build for Raspberry Pi Zero 2 W (32-bit and 64-bit)
 build-pi-zero: build-linux-arm build-linux-arm64
 	@echo "Pi Zero 2 W builds: $(BUILD_DIR)/$(BINARY_NAME)-linux-arm (32-bit), $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 (64-bit)"

--- a/pkg/gateway/channel_matrix.go
+++ b/pkg/gateway/channel_matrix.go
@@ -1,4 +1,4 @@
-//go:build !mipsle && !netbsd && !(freebsd && arm)
+//go:build !mipsle && !netbsd && !(freebsd && arm) && !android
 
 package gateway
 

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,5 +1,5 @@
 .PHONY: dev dev-frontend dev-backend build build-frontend build-dev-picoclaw test lint clean \
-	build-android-arm64 build-all-android
+	build-android-arm64 build-android-bundle
 
 # Go variables
 GO?=CGO_ENABLED=0 go
@@ -99,7 +99,7 @@ build-android-arm64: build-frontend
 	GOOS=android GOARCH=arm64 $(GO) build -tags stdjson -ldflags "$(LDFLAGS)" -o "$(OUTPUT_ANDROID_ARM64)" ./$(BACKEND_DIR)/
 
 # Build launcher for all Android architectures
-build-all-android: build-frontend
+build-android-bundle: build-frontend
 	@mkdir -p $(BUILD_DIR)
 	GOOS=android GOARCH=arm64 $(GO) build -tags stdjson -ldflags "$(LDFLAGS)" -o "$(BUILD_DIR)/picoclaw-launcher-android-arm64" ./$(BACKEND_DIR)/
 	@echo "All Android launcher builds complete"

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,4 +1,5 @@
-.PHONY: dev dev-frontend dev-backend build build-frontend build-dev-picoclaw test lint clean
+.PHONY: dev dev-frontend dev-backend build build-frontend build-dev-picoclaw test lint clean \
+	build-android-arm64 build-all-android
 
 # Go variables
 GO?=CGO_ENABLED=0 go
@@ -9,6 +10,7 @@ GOFLAGS?=-v -tags $(GO_BUILD_TAGS)
 # Build variables
 BUILD_DIR=build
 OUTPUT?=$(BUILD_DIR)/picoclaw-launcher
+OUTPUT_ANDROID_ARM64?=$(BUILD_DIR)/picoclaw-launcher-android-arm64
 FRONTEND_DIR=frontend
 BACKEND_DIR=backend
 BACKEND_DIST=$(BACKEND_DIR)/dist
@@ -90,6 +92,17 @@ dev-backend:
 build: build-frontend
 	@mkdir -p "$$(dirname "$(OUTPUT)")"
 	${WEB_GO} build $(GOFLAGS) -ldflags "$(LAUNCHER_LDFLAGS)" -o "$(OUTPUT)" ./$(BACKEND_DIR)/
+
+# Build launcher for Android ARM64 (frontend must already be built)
+build-android-arm64: build-frontend
+	@mkdir -p $(BUILD_DIR)
+	GOOS=android GOARCH=arm64 $(GO) build -tags stdjson -ldflags "$(LDFLAGS)" -o "$(OUTPUT_ANDROID_ARM64)" ./$(BACKEND_DIR)/
+
+# Build launcher for all Android architectures
+build-all-android: build-frontend
+	@mkdir -p $(BUILD_DIR)
+	GOOS=android GOARCH=arm64 $(GO) build -tags stdjson -ldflags "$(LDFLAGS)" -o "$(BUILD_DIR)/picoclaw-launcher-android-arm64" ./$(BACKEND_DIR)/
+	@echo "All Android launcher builds complete"
 
 build-frontend:
 	@if [ ! -d $(FRONTEND_DIR)/node_modules ] || \

--- a/web/backend/systray.go
+++ b/web/backend/systray.go
@@ -1,4 +1,4 @@
-//go:build (!darwin && !freebsd && !android) || cgo
+//go:build !android && ((!darwin && !freebsd) || cgo)
 
 package main
 

--- a/web/backend/systray.go
+++ b/web/backend/systray.go
@@ -1,4 +1,4 @@
-//go:build (!darwin && !freebsd) || cgo
+//go:build (!darwin && !freebsd && !android) || cgo
 
 package main
 

--- a/web/backend/systray_stub_nocgo.go
+++ b/web/backend/systray_stub_nocgo.go
@@ -1,4 +1,4 @@
-//go:build (darwin || freebsd) && !cgo
+//go:build (darwin || freebsd || android) && !cgo
 
 package main
 


### PR DESCRIPTION
- Add build-android-arm64, build-launcher-android-arm64, build-all-android targets to Makefile and web/Makefile
- Use -tags stdjson (no goolm) for Android; CGO_ENABLED=0 throughout
- Output staged as build/android-staging/arm64-v8a/libpicoclaw{,-web}.so for JNI consumption; zip packaging handled by CI
- Exclude Matrix channel from android builds (channel_matrix.go) to avoid modernc.org/sqlite CGO dependency
- Exclude systray from android builds; use headless stub instead (systray.go / systray_stub_nocgo.go)
- related to: 
  - https://github.com/sipeed/picoclaw/issues/2335 
  - https://github.com/sipeed/picoclaw_fui/issues/47
  - https://github.com/sipeed/picoclaw/issues/292
- tested at Android16 fui app

## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** <!-- e.g. Raspberry Pi 5, Orange Pi, PC--> Phone
- **OS:** <!-- e.g. Debian 12, Ubuntu 22.04 --> Android 16
- **Model/Provider:** <!-- e.g. OpenAI GPT-4o, Kimi k2, DeepSeek-V3 --> GLM
- **Channels:** <!-- e.g. Discord, Telegram, Feishu, ... -->


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.