### PR TITLE
fix(agent): reinitialize MCP and discovery tools after reload

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1056,8 +1056,23 @@ func (al *AgentLoop) ReloadProviderAndConfig(
 
 	al.mu.Unlock()
 
+	oldMCPManager := al.mcp.reset()
 	al.hookRuntime.reset(al)
 	configureHookManagerFromConfig(al.hooks, cfg)
+	if err := al.ensureHooksInitialized(ctx); err != nil {
+		logger.WarnCF("agent", "Configured hooks failed to reinitialize after reload",
+			map[string]any{"error": err.Error()})
+	}
+	if oldMCPManager != nil {
+		if err := oldMCPManager.Close(); err != nil {
+			logger.WarnCF("agent", "Failed to close previous MCP manager during reload",
+				map[string]any{"error": err.Error()})
+		}
+	}
+	if err := al.ensureMCPInitialized(ctx); err != nil {
+		logger.WarnCF("agent", "MCP failed to reinitialize after reload",
+			map[string]any{"error": err.Error()})
+	}
 
 	// Close old provider after releasing the lock
 	// This prevents blocking readers while closing

--- a/pkg/agent/loop_mcp.go
+++ b/pkg/agent/loop_mcp.go
@@ -24,6 +24,16 @@ type mcpRuntime struct {
 	initErr  error
 }
 
+func (r *mcpRuntime) reset() *mcp.Manager {
+	r.mu.Lock()
+	manager := r.manager
+	r.manager = nil
+	r.initErr = nil
+	r.initOnce = sync.Once{}
+	r.mu.Unlock()
+	return manager
+}
+
 func (r *mcpRuntime) setManager(manager *mcp.Manager) {
 	r.mu.Lock()
 	r.manager = manager

--- a/pkg/agent/loop_mcp_test.go
+++ b/pkg/agent/loop_mcp_test.go
@@ -7,12 +7,72 @@
 package agent
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sipeed/picoclaw/pkg/mcp"
 )
 
 func boolPtr(b bool) *bool { return &b }
+
+func TestMCPRuntimeResetClearsState(t *testing.T) {
+	var rt mcpRuntime
+	manager := mcp.NewManager()
+	rt.setManager(manager)
+	rt.setInitErr(errors.New("stale init error"))
+	rt.initOnce.Do(func() {})
+
+	got := rt.reset()
+	if got != manager {
+		t.Fatalf("reset() manager = %p, want %p", got, manager)
+	}
+	if rt.hasManager() {
+		t.Fatal("expected manager to be cleared after reset")
+	}
+	if err := rt.getInitErr(); err != nil {
+		t.Fatalf("getInitErr() = %v, want nil", err)
+	}
+
+	reran := false
+	rt.initOnce.Do(func() { reran = true })
+	if !reran {
+		t.Fatal("expected initOnce to be reset")
+	}
+}
+
+func TestReloadProviderAndConfig_ResetsMCPRuntime(t *testing.T) {
+	al, cfg, _, _, cleanup := newTestAgentLoop(t)
+	defer cleanup()
+	defer al.Close()
+
+	manager := mcp.NewManager()
+	al.mcp.setManager(manager)
+	al.mcp.setInitErr(errors.New("stale init error"))
+	al.mcp.initOnce.Do(func() {})
+
+	if !al.mcp.hasManager() {
+		t.Fatal("expected MCP manager to exist before reload")
+	}
+
+	if err := al.ReloadProviderAndConfig(context.Background(), &mockProvider{}, cfg); err != nil {
+		t.Fatalf("ReloadProviderAndConfig() error = %v", err)
+	}
+
+	if al.mcp.hasManager() {
+		t.Fatal("expected MCP manager to be cleared when reloaded config has MCP disabled")
+	}
+	if err := al.mcp.getInitErr(); err != nil {
+		t.Fatalf("getInitErr() = %v, want nil", err)
+	}
+
+	reran := false
+	al.mcp.initOnce.Do(func() { reran = true })
+	if !reran {
+		t.Fatal("expected MCP initOnce to be reset after reload")
+	}
+}
 
 func TestServerIsDeferred(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## 📝 Description

This PR fixes a reload regression where MCP tools and the BM25 discovery tool (`tool_search_tool_*`) could disappear after `/reload`.

The reload flow recreated the agent registry and configuration, but the MCP runtime was still guarded by a previously consumed `sync.Once`. As a result, MCP/discovery initialization was skipped for the new registry, and long-running gateway sessions could lose MCP-discovered tools after a config reload.

This change resets the MCP runtime during reload, closes the previous MCP manager, and reinitializes hooks and MCP tooling after the new config is applied so MCP tools and discovery tools remain available.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A (identified during Raspberry Pi deployment and reload debugging)

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** The `/reload` path rebuilt the agent registry, but MCP/discovery tool registration was tied to a one-time runtime initialization. After reload, the new registry no longer received MCP/discovery tools such as `tool_search_tool_bm25`. Resetting and reinitializing the MCP runtime after config reload restores consistent tool availability.

## 🧪 Test Environment
- **Hardware:** 
- **OS:**
- **Model/Provider:**
- **Channels:**


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
