### PR TITLE
build(release): move Android bundle publishing into GoReleaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Setup pnpm
         run: corepack enable && corepack install
 
-      - name: Build
+      - name: Build core binaries
         run: make build-all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,5 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: web/frontend/pnpm-lock.yaml
-
-      - name: Setup pnpm
-        run: corepack enable && corepack install
-
       - name: Build core binaries
         run: make build-all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,15 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/frontend/pnpm-lock.yaml
+
+      - name: Setup pnpm
+        run: corepack enable && corepack install
+
       - name: Build
         run: make build-all

--- a/.github/workflows/create_dmg.yml
+++ b/.github/workflows/create_dmg.yml
@@ -17,29 +17,35 @@ jobs:
         with:
           ref: main
 
-      # 1. 安装指定版本的 Go (可选，但推荐)
+      # 1. Install Go from go.mod
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      # 2. 安装 pnpm
-      - name: Install pnpm
-        run: brew install pnpm
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/frontend/pnpm-lock.yaml
 
-      # 3. 运行你的 Makefile 编译二进制文件
+      - name: Setup pnpm
+        run: corepack enable && corepack install
+
+      # 3. Build the application bundle
       - name: Build with Make
         run: make build ARCH=${{ matrix.arch }} && make build-macos-app ARCH=${{ matrix.arch }}
 
-      # 4. 签名
+      # 4. Apply ad-hoc signing
       - name: Ad-hoc Sign
         run: codesign --force --deep --sign - "build/PicoClaw Launcher.app"
 
-      # 5. 安装打包工具
+      # 5. Install the DMG packaging tool
       - name: Install create-dmg
         run: brew install create-dmg
 
-      # 6. 执行打包命令
+      # 6. Create the DMG
       - name: Create DMG
         run: |
           mkdir -p dist
@@ -54,7 +60,7 @@ jobs:
             "dist/picoclaw-${{ matrix.arch }}.dmg" \
             "build/PicoClaw Launcher.app"
 
-      # 7. 上传文件到 GitHub Artifacts (供你下载)
+      # 7. Upload the DMG as a GitHub artifact
       - name: Upload DMG
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,6 +77,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Install zip
+        run: sudo apt-get install -y zip
+
       - name: Create local tag for GoReleaser
         run: git tag "${{ steps.version.outputs.version }}"
 
@@ -92,17 +95,13 @@ jobs:
           DOCKERHUB_IMAGE_NAME: ${{ vars.DOCKERHUB_REPOSITORY }}
           GOVERSION: ${{ steps.setup-go.outputs.go-version }}
           GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.version }}
+          INCLUDE_ANDROID_BUNDLE: "true"
           NIGHTLY_BUILD: "true"
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
           MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
-
-      - name: Build release-only artifacts
-        run: |
-          sudo apt-get install -y zip
-          make build-release-artifacts
 
       - name: Update nightly release
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,9 +51,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/frontend/pnpm-lock.yaml
 
       - name: Setup pnpm
-        run: corepack enable && corepack prepare pnpm@latest --activate
+        run: corepack enable && corepack install
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -97,6 +99,11 @@ jobs:
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
 
+      - name: Build release-only artifacts
+        run: |
+          sudo apt-get install -y zip
+          make build-release-artifacts
+
       - name: Update nightly release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -123,7 +130,7 @@ jobs:
 
           # Collect release artifacts from goreleaser dist/
           ASSETS=()
-          for f in dist/*.tar.gz dist/*.zip dist/*.deb dist/*.rpm dist/checksums.txt; do
+          for f in dist/*.tar.gz dist/*.zip dist/*.deb dist/*.rpm dist/checksums.txt build/picoclaw-android-universal.zip; do
             [ -f "$f" ] && ASSETS+=("$f")
           done
 
@@ -135,4 +142,3 @@ jobs:
             --prerelease \
             --latest=false \
             "${ASSETS[@]}"
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Install zip
+        run: sudo apt-get install -y zip
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -106,22 +109,12 @@ jobs:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           DOCKERHUB_IMAGE_NAME: ${{ vars.DOCKERHUB_REPOSITORY }}
           GOVERSION: ${{ steps.setup-go.outputs.go-version }}
+          INCLUDE_ANDROID_BUNDLE: "true"
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
           MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
-
-      - name: Build and upload release-only artifacts
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          sudo apt-get install -y zip
-          make build-release-artifacts
-          gh release upload "${{ inputs.tag }}" \
-            build/picoclaw-android-universal.zip \
-            --clobber
 
       - name: Apply release flags
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/frontend/pnpm-lock.yaml
 
       - name: Setup pnpm
-        run: corepack enable && corepack prepare pnpm@latest --activate
+        run: corepack enable && corepack install
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -110,13 +112,13 @@ jobs:
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
 
-      - name: Build and upload Android arm64
+      - name: Build and upload release-only artifacts
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sudo apt-get install -y zip
-          make build-android-bundle
+          make build-release-artifacts
           gh release upload "${{ inputs.tag }}" \
             build/picoclaw-android-universal.zip \
             --clobber

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,7 @@ before:
     - go generate ./...
     - sh -c 'cd web/frontend && CI=true pnpm install --frozen-lockfile && pnpm build:backend'
     - sh -c 'GOBIN="$(go env GOPATH)/bin"; mkdir -p "$GOBIN"; go install github.com/tc-hib/go-winres@v0.3.3 && "$GOBIN/go-winres" make --in web/backend/winres/winres.json --out web/backend/rsrc --product-version={{ .Version }} --file-version={{ .Version }}'
+    - sh -c 'if [ "${INCLUDE_ANDROID_BUNDLE:-}" = "true" ]; then make build-android-bundle; fi'
 
 builds:
   - id: picoclaw
@@ -251,6 +252,8 @@ changelog:
 
 release:
   disable: '{{ isEnvSet "NIGHTLY_BUILD" }}'
+  extra_files:
+    - glob: ./build/picoclaw-android-universal.zip
   footer: >-
 
     ---

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,11 +9,9 @@ git:
 
 before:
   hooks:
-    - go mod tidy
     - go generate ./...
-    - sh -c 'cd web/frontend && pnpm install && pnpm build:backend'
-    - go install github.com/tc-hib/go-winres@latest
-    - go-winres make --in web/backend/winres/winres.json --out web/backend/rsrc --product-version={{ .Version }} --file-version={{ .Version }}
+    - sh -c 'cd web/frontend && CI=true pnpm install --frozen-lockfile && pnpm build:backend'
+    - sh -c 'GOBIN="$(go env GOPATH)/bin"; mkdir -p "$GOBIN"; go install github.com/tc-hib/go-winres@v0.3.3 && "$GOBIN/go-winres" make --in web/backend/winres/winres.json --out web/backend/rsrc --product-version={{ .Version }} --file-version={{ .Version }}'
 
 builds:
   - id: picoclaw
@@ -27,7 +25,7 @@ builds:
       - -X github.com/sipeed/picoclaw/pkg/config.Version={{ .Version }}
       - -X github.com/sipeed/picoclaw/pkg/config.GitCommit={{ .ShortCommit }}
       - -X github.com/sipeed/picoclaw/pkg/config.BuildTime={{ .Date }}
-      - -X github.com/sipeed/picoclaw/pkg/config.GoVersion={{ .Env.GOVERSION }}
+      - -X github.com/sipeed/picoclaw/pkg/config.GoVersion={{ with index .Env "GOVERSION" }}{{ . }}{{ else }}unknown{{ end }}
     goos:
       - linux
       - windows
@@ -67,6 +65,10 @@ builds:
       - stdjson
     ldflags:
       - -s -w
+      - -X github.com/sipeed/picoclaw/pkg/config.Version={{ .Version }}
+      - -X github.com/sipeed/picoclaw/pkg/config.GitCommit={{ .ShortCommit }}
+      - -X github.com/sipeed/picoclaw/pkg/config.BuildTime={{ .Date }}
+      - -X github.com/sipeed/picoclaw/pkg/config.GoVersion={{ with index .Env "GOVERSION" }}{{ . }}{{ else }}unknown{{ end }}
     goos:
       - linux
       - windows
@@ -106,6 +108,10 @@ builds:
       - stdjson
     ldflags:
       - -s -w
+      - -X github.com/sipeed/picoclaw/pkg/config.Version={{ .Version }}
+      - -X github.com/sipeed/picoclaw/pkg/config.GitCommit={{ .ShortCommit }}
+      - -X github.com/sipeed/picoclaw/pkg/config.BuildTime={{ .Date }}
+      - -X github.com/sipeed/picoclaw/pkg/config.GoVersion={{ with index .Env "GOVERSION" }}{{ . }}{{ else }}unknown{{ end }}
     goos:
       - linux
       - windows

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build install uninstall clean help test build-core-all build-release-artifacts
+.PHONY: all build install uninstall clean help test build-all
 
 # Build variables
 BINARY_NAME=picoclaw
@@ -242,8 +242,8 @@ build-android-bundle: generate
 build-pi-zero: build-linux-arm build-linux-arm64
 	@echo "Pi Zero 2 W builds: $(BUILD_DIR)/$(BINARY_NAME)-linux-arm (32-bit), $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 (64-bit)"
 
-## build-core-all: Build the picoclaw core binary for all Makefile-managed platforms
-build-core-all: generate
+## build-all: Build the picoclaw core binary for all Makefile-managed platforms
+build-all: generate
 	@echo "Building for multiple platforms..."
 	@mkdir -p $(BUILD_DIR)
 	GOOS=linux GOARCH=amd64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 ./$(CMD_DIR)
@@ -260,13 +260,6 @@ build-core-all: generate
 	GOOS=netbsd GOARCH=amd64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-netbsd-amd64 ./$(CMD_DIR)
 	GOOS=netbsd GOARCH=arm64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-netbsd-arm64 ./$(CMD_DIR)
 	@echo "Core builds complete"
-
-## build-all: Build the picoclaw core binary for all Makefile-managed platforms
-build-all: build-core-all
-
-## build-release-artifacts: Build release-only artifacts that sit outside GoReleaser
-build-release-artifacts: build-android-bundle
-	@echo "Release artifact builds complete"
 
 ## install: Install picoclaw to system and copy builtin skills
 install: build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build install uninstall clean help test
+.PHONY: all build install uninstall clean help test build-core-all build-release-artifacts
 
 # Build variables
 BINARY_NAME=picoclaw
@@ -217,7 +217,9 @@ build-launcher-android-arm64:
 	@echo "Building picoclaw-launcher for android/arm64..."
 	@mkdir -p $(BUILD_DIR)
 	@$(MAKE) -C web build-android-arm64 \
-		OUTPUT="$(CURDIR)/$(BUILD_DIR)/picoclaw-launcher-android-arm64"
+		OUTPUT_ANDROID_ARM64="$(CURDIR)/$(BUILD_DIR)/picoclaw-launcher-android-arm64" \
+		GO='$(GO)' \
+		LDFLAGS='$(LDFLAGS)'
 	@echo "Build complete: $(BUILD_DIR)/picoclaw-launcher-android-arm64"
 
 ## build-android-bundle: Build core and launcher for all Android architectures and package as universal zip
@@ -240,8 +242,8 @@ build-android-bundle: generate
 build-pi-zero: build-linux-arm build-linux-arm64
 	@echo "Pi Zero 2 W builds: $(BUILD_DIR)/$(BINARY_NAME)-linux-arm (32-bit), $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 (64-bit)"
 
-## build-all: Build picoclaw for all platforms
-build-all: generate
+## build-core-all: Build the picoclaw core binary for all Makefile-managed platforms
+build-core-all: generate
 	@echo "Building for multiple platforms..."
 	@mkdir -p $(BUILD_DIR)
 	GOOS=linux GOARCH=amd64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 ./$(CMD_DIR)
@@ -257,8 +259,14 @@ build-all: generate
 	GOOS=windows GOARCH=amd64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe ./$(CMD_DIR)
 	GOOS=netbsd GOARCH=amd64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-netbsd-amd64 ./$(CMD_DIR)
 	GOOS=netbsd GOARCH=arm64 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-netbsd-arm64 ./$(CMD_DIR)
-	@$(MAKE) build-android-bundle
-	@echo "All builds complete"
+	@echo "Core builds complete"
+
+## build-all: Build the picoclaw core binary for all Makefile-managed platforms
+build-all: build-core-all
+
+## build-release-artifacts: Build release-only artifacts that sit outside GoReleaser
+build-release-artifacts: build-android-bundle
+	@echo "Release artifact builds complete"
 
 ## install: Install picoclaw to system and copy builtin skills
 install: build

--- a/README.fr.md
+++ b/README.fr.md
@@ -190,19 +190,12 @@ make build-launcher
 # Compiler les binaires core pour toutes les plateformes gérées par le Makefile
 make build-all
 
-# Compiler les artefacts de release empaquetés séparément des sorties principales de GoReleaser
-make build-release-artifacts
-
 # Compiler pour Raspberry Pi Zero 2 W (32 bits : make build-linux-arm ; 64 bits : make build-linux-arm64)
 make build-pi-zero
 
 # Compiler et installer
 make install
 ```
-
-`make build-all` compile les binaires core de `picoclaw` pour toutes les plateformes gérées par le Makefile.
-
-`make build-release-artifacts` compile les artefacts de release empaquetés séparément des sorties principales de GoReleaser.
 
 **Raspberry Pi Zero 2 W :** Utilisez le binaire correspondant à votre OS : Raspberry Pi OS 32 bits -> `make build-linux-arm` ; 64 bits -> `make build-linux-arm64`. Ou exécutez `make build-pi-zero` pour compiler les deux.
 
@@ -634,5 +627,4 @@ Discord : <https://discord.gg/V4sAZ9XWpN>
 
 WeChat :
 <img src="assets/wechat.png" alt="WeChat group QR code" width="512">
-
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -167,11 +167,19 @@ Vous pouvez aussi télécharger le binaire pour votre plateforme depuis la page 
 
 ### Compiler depuis les sources (pour le développement)
 
+Prérequis :
+
+- Go 1.25+
+- Node.js 22+ avec Corepack activé pour les builds Web UI / launcher
+
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
 
 cd picoclaw
 make deps
+
+# Installer le gestionnaire de paquets frontend déclaré par le dépôt
+(cd web/frontend && corepack install)
 
 # Compiler le binaire principal
 make build
@@ -179,8 +187,11 @@ make build
 # Compiler le Web UI Launcher (requis pour le mode WebUI)
 make build-launcher
 
-# Compiler pour plusieurs plateformes
+# Compiler les binaires core pour toutes les plateformes gérées par le Makefile
 make build-all
+
+# Compiler les artefacts de release empaquetés séparément des sorties principales de GoReleaser
+make build-release-artifacts
 
 # Compiler pour Raspberry Pi Zero 2 W (32 bits : make build-linux-arm ; 64 bits : make build-linux-arm64)
 make build-pi-zero
@@ -188,6 +199,10 @@ make build-pi-zero
 # Compiler et installer
 make install
 ```
+
+`make build-all` compile les binaires core de `picoclaw` pour toutes les plateformes gérées par le Makefile.
+
+`make build-release-artifacts` compile les artefacts de release empaquetés séparément des sorties principales de GoReleaser.
 
 **Raspberry Pi Zero 2 W :** Utilisez le binaire correspondant à votre OS : Raspberry Pi OS 32 bits -> `make build-linux-arm` ; 64 bits -> `make build-linux-arm64`. Ou exécutez `make build-pi-zero` pour compiler les deux.
 
@@ -619,6 +634,5 @@ Discord : <https://discord.gg/V4sAZ9XWpN>
 
 WeChat :
 <img src="assets/wechat.png" alt="WeChat group QR code" width="512">
-
 
 

--- a/README.id.md
+++ b/README.id.md
@@ -187,19 +187,12 @@ make build-launcher
 # Build binary inti untuk semua platform yang dikelola Makefile
 make build-all
 
-# Build artefak rilis yang dikemas terpisah dari output utama GoReleaser
-make build-release-artifacts
-
 # Build untuk Raspberry Pi Zero 2 W (32-bit: make build-linux-arm; 64-bit: make build-linux-arm64)
 make build-pi-zero
 
 # Build dan instal
 make install
 ```
-
-`make build-all` membangun binary inti `picoclaw` untuk semua platform yang dikelola Makefile.
-
-`make build-release-artifacts` membangun artefak rilis yang dikemas terpisah dari output utama GoReleaser.
 
 **Raspberry Pi Zero 2 W:** Gunakan binary yang sesuai dengan OS Anda: Raspberry Pi OS 32-bit -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Atau jalankan `make build-pi-zero` untuk build keduanya.
 

--- a/README.id.md
+++ b/README.id.md
@@ -164,11 +164,19 @@ Atau, unduh binary untuk platform Anda dari halaman [GitHub Releases](https://gi
 
 ### Build dari source (untuk pengembangan)
 
+Prasyarat:
+
+- Go 1.25+
+- Node.js 22+ dengan Corepack aktif untuk build Web UI / launcher
+
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
 
 cd picoclaw
 make deps
+
+# Instal package manager frontend yang dideklarasikan repo
+(cd web/frontend && corepack install)
 
 # Build binary inti
 make build
@@ -176,8 +184,11 @@ make build
 # Build Web UI Launcher (diperlukan untuk mode WebUI)
 make build-launcher
 
-# Build untuk berbagai platform
+# Build binary inti untuk semua platform yang dikelola Makefile
 make build-all
+
+# Build artefak rilis yang dikemas terpisah dari output utama GoReleaser
+make build-release-artifacts
 
 # Build untuk Raspberry Pi Zero 2 W (32-bit: make build-linux-arm; 64-bit: make build-linux-arm64)
 make build-pi-zero
@@ -185,6 +196,10 @@ make build-pi-zero
 # Build dan instal
 make install
 ```
+
+`make build-all` membangun binary inti `picoclaw` untuk semua platform yang dikelola Makefile.
+
+`make build-release-artifacts` membangun artefak rilis yang dikemas terpisah dari output utama GoReleaser.
 
 **Raspberry Pi Zero 2 W:** Gunakan binary yang sesuai dengan OS Anda: Raspberry Pi OS 32-bit -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Atau jalankan `make build-pi-zero` untuk build keduanya.
 

--- a/README.it.md
+++ b/README.it.md
@@ -187,19 +187,12 @@ make build-launcher
 # Compila i binari core per tutte le piattaforme gestite dal Makefile
 make build-all
 
-# Compila gli artefatti di release impacchettati separatamente dagli output principali di GoReleaser
-make build-release-artifacts
-
 # Compila per Raspberry Pi Zero 2 W (32-bit: make build-linux-arm; 64-bit: make build-linux-arm64)
 make build-pi-zero
 
 # Compila e installa
 make install
 ```
-
-`make build-all` compila i binari core di `picoclaw` per tutte le piattaforme gestite dal Makefile.
-
-`make build-release-artifacts` compila gli artefatti di release impacchettati separatamente dagli output principali di GoReleaser.
 
 **Raspberry Pi Zero 2 W:** Usa il binario che corrisponde al tuo OS: Raspberry Pi OS 32-bit -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Oppure esegui `make build-pi-zero` per compilare entrambi.
 

--- a/README.it.md
+++ b/README.it.md
@@ -164,11 +164,19 @@ In alternativa, scarica il binario per la tua piattaforma dalla pagina delle [Gi
 
 ### Compila dai sorgenti (per lo sviluppo)
 
+Prerequisiti:
+
+- Go 1.25+
+- Node.js 22+ con Corepack abilitato per le build Web UI / launcher
+
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
 
 cd picoclaw
 make deps
+
+# Installa il package manager frontend dichiarato dal repository
+(cd web/frontend && corepack install)
 
 # Compila il binario core
 make build
@@ -176,8 +184,11 @@ make build
 # Compila il Web UI Launcher (necessario per la modalità WebUI)
 make build-launcher
 
-# Compila per più piattaforme
+# Compila i binari core per tutte le piattaforme gestite dal Makefile
 make build-all
+
+# Compila gli artefatti di release impacchettati separatamente dagli output principali di GoReleaser
+make build-release-artifacts
 
 # Compila per Raspberry Pi Zero 2 W (32-bit: make build-linux-arm; 64-bit: make build-linux-arm64)
 make build-pi-zero
@@ -185,6 +196,10 @@ make build-pi-zero
 # Compila e installa
 make install
 ```
+
+`make build-all` compila i binari core di `picoclaw` per tutte le piattaforme gestite dal Makefile.
+
+`make build-release-artifacts` compila gli artefatti di release impacchettati separatamente dagli output principali di GoReleaser.
 
 **Raspberry Pi Zero 2 W:** Usa il binario che corrisponde al tuo OS: Raspberry Pi OS 32-bit -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Oppure esegui `make build-pi-zero` per compilare entrambi.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -187,19 +187,12 @@ make build-launcher
 # Makefile が管理するすべてのプラットフォーム向けにコアバイナリをビルド
 make build-all
 
-# メインの GoReleaser 出力とは別にパッケージ化されるリリース専用成果物をビルド
-make build-release-artifacts
-
 # Raspberry Pi Zero 2 W 向けビルド（32-bit: make build-linux-arm; 64-bit: make build-linux-arm64）
 make build-pi-zero
 
 # ビルドとインストール
 make install
 ```
-
-`make build-all` は、Makefile が管理するすべてのプラットフォーム向けにコアの `picoclaw` バイナリをビルドします。
-
-`make build-release-artifacts` は、メインの GoReleaser 出力とは別にパッケージ化されるリリース専用成果物をビルドします。
 
 **Raspberry Pi Zero 2 W:** OS に合ったバイナリを使用してください：32-bit Raspberry Pi OS → `make build-linux-arm`、64-bit → `make build-linux-arm64`。または `make build-pi-zero` で両方をビルド。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -164,11 +164,19 @@ PicoClaw はほぼすべての Linux デバイスにデプロイできます！
 
 ### ソースからビルド（開発用）
 
+前提条件:
+
+- Go 1.25+
+- Web UI / launcher のビルドには Corepack を有効にした Node.js 22+
+
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
 
 cd picoclaw
 make deps
+
+# リポジトリで宣言されたフロントエンド用パッケージマネージャーをインストール
+(cd web/frontend && corepack install)
 
 # コアバイナリをビルド
 make build
@@ -176,8 +184,11 @@ make build
 # Web UI Launcher をビルド（WebUI モードに必要）
 make build-launcher
 
-# 複数プラットフォーム向けビルド
+# Makefile が管理するすべてのプラットフォーム向けにコアバイナリをビルド
 make build-all
+
+# メインの GoReleaser 出力とは別にパッケージ化されるリリース専用成果物をビルド
+make build-release-artifacts
 
 # Raspberry Pi Zero 2 W 向けビルド（32-bit: make build-linux-arm; 64-bit: make build-linux-arm64）
 make build-pi-zero
@@ -185,6 +196,10 @@ make build-pi-zero
 # ビルドとインストール
 make install
 ```
+
+`make build-all` は、Makefile が管理するすべてのプラットフォーム向けにコアの `picoclaw` バイナリをビルドします。
+
+`make build-release-artifacts` は、メインの GoReleaser 出力とは別にパッケージ化されるリリース専用成果物をビルドします。
 
 **Raspberry Pi Zero 2 W:** OS に合ったバイナリを使用してください：32-bit Raspberry Pi OS → `make build-linux-arm`、64-bit → `make build-linux-arm64`。または `make build-pi-zero` で両方をビルド。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -187,19 +187,12 @@ make build-launcher
 # Makefile이 관리하는 모든 플랫폼용 코어 바이너리 빌드
 make build-all
 
-# 메인 GoReleaser 출력과 별도로 패키징되는 릴리스 전용 산출물 빌드
-make build-release-artifacts
-
 # Raspberry Pi Zero 2 W용 빌드 (32비트: make build-linux-arm, 64비트: make build-linux-arm64)
 make build-pi-zero
 
 # 빌드 후 설치
 make install
 ```
-
-`make build-all`은 Makefile이 관리하는 모든 플랫폼용 핵심 `picoclaw` 바이너리를 빌드합니다.
-
-`make build-release-artifacts`는 메인 GoReleaser 출력과 별도로 패키징되는 릴리스 전용 산출물을 빌드합니다.
 
 **Raspberry Pi Zero 2 W:** OS에 맞는 바이너리를 사용하세요. 32비트 Raspberry Pi OS는 `make build-linux-arm`, 64비트는 `make build-linux-arm64`입니다. 또는 `make build-pi-zero`로 둘 다 빌드할 수 있습니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -164,11 +164,19 @@ PicoClaw는 사실상 거의 모든 Linux 장치에 배포할 수 있습니다!
 
 ### 소스에서 빌드(개발용)
 
+필수 사항:
+
+- Go 1.25+
+- Web UI / launcher 빌드를 위한 Corepack 활성화된 Node.js 22+
+
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
 
 cd picoclaw
 make deps
+
+# 저장소에 선언된 프런트엔드 패키지 매니저 설치
+(cd web/frontend && corepack install)
 
 # 코어 바이너리 빌드
 make build
@@ -176,8 +184,11 @@ make build
 # WebUI 런처 빌드 (WebUI 모드에 필요)
 make build-launcher
 
-# 여러 플랫폼용 빌드
+# Makefile이 관리하는 모든 플랫폼용 코어 바이너리 빌드
 make build-all
+
+# 메인 GoReleaser 출력과 별도로 패키징되는 릴리스 전용 산출물 빌드
+make build-release-artifacts
 
 # Raspberry Pi Zero 2 W용 빌드 (32비트: make build-linux-arm, 64비트: make build-linux-arm64)
 make build-pi-zero
@@ -185,6 +196,10 @@ make build-pi-zero
 # 빌드 후 설치
 make install
 ```
+
+`make build-all`은 Makefile이 관리하는 모든 플랫폼용 핵심 `picoclaw` 바이너리를 빌드합니다.
+
+`make build-release-artifacts`는 메인 GoReleaser 출력과 별도로 패키징되는 릴리스 전용 산출물을 빌드합니다.
 
 **Raspberry Pi Zero 2 W:** OS에 맞는 바이너리를 사용하세요. 32비트 Raspberry Pi OS는 `make build-linux-arm`, 64비트는 `make build-linux-arm64`입니다. 또는 `make build-pi-zero`로 둘 다 빌드할 수 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -187,9 +187,6 @@ make build-launcher
 # Build core binaries for all Makefile-managed platforms
 make build-all
 
-# Build release-only artifacts packaged separately from the main GoReleaser outputs
-make build-release-artifacts
-
 # Build for Raspberry Pi Zero 2 W
 # 32-bit: make build-linux-arm
 # 64-bit: make build-linux-arm64
@@ -198,10 +195,6 @@ make build-pi-zero
 # Build and install
 make install
 ```
-
-`make build-all` builds the core `picoclaw` binaries for all Makefile-managed platforms.
-
-`make build-release-artifacts` builds release-only artifacts that are packaged separately from the main GoReleaser outputs.
 
 **Raspberry Pi Zero 2 W:** Use the binary that matches your OS: 32-bit Raspberry Pi OS -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Or run `make build-pi-zero` to build both.
 
@@ -232,7 +225,7 @@ picoclaw-launcher
 <img src="assets/launcher-webui.jpg" alt="WebUI Launcher" width="600">
 </p>
 
-**Getting started:** 
+**Getting started:**
 
 Open the WebUI, then: **1)** Configure a Provider (add your LLM API key) -> **2)** Configure a Channel (e.g., Telegram) -> **3)** Start the Gateway -> **4)** Chat!
 
@@ -310,7 +303,7 @@ picoclaw-launcher-tui
 <img src="assets/launcher-tui.jpg" alt="TUI Launcher" width="600">
 </p>
 
-**Getting started:** 
+**Getting started:**
 
 Use the TUI menus to: **1)** Configure a Provider -> **2)** Configure a Channel -> **3)** Start the Gateway -> **4)** Chat!
 
@@ -385,7 +378,7 @@ This creates `~/.picoclaw/config.json` and the workspace directory.
 ```
 
 > See `config/config.example.json` in the repo for a complete configuration template with all available options.
-> 
+>
 > Please note: config.example.json format is version 0, with sensitive codes in it, and will be auto migrated to version 1+, then, the config.json will only store insensitive data, the sensitive codes will be stored in .security.yml, if you need manually modify the codes, please see `docs/security_configuration.md` for more details.
 
 

--- a/README.md
+++ b/README.md
@@ -164,27 +164,44 @@ Alternatively, download the binary for your platform from the [GitHub Releases](
 
 ### Build from source (for development)
 
+Prerequisites:
+
+- Go 1.25+
+- Node.js 22+ with Corepack enabled for Web UI / launcher builds
+
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
 
 cd picoclaw
 make deps
 
-# Build core binary
+# Install frontend package manager declared by the repo
+(cd web/frontend && corepack install)
+
+# Build the core binary for the current platform
 make build
 
-# Build Web UI Launcher (required for WebUI mode)
+# Build the Web UI Launcher (required for WebUI mode)
 make build-launcher
 
-# Build for multiple platforms
+# Build core binaries for all Makefile-managed platforms
 make build-all
 
-# Build for Raspberry Pi Zero 2 W (32-bit: make build-linux-arm; 64-bit: make build-linux-arm64)
+# Build release-only artifacts packaged separately from the main GoReleaser outputs
+make build-release-artifacts
+
+# Build for Raspberry Pi Zero 2 W
+# 32-bit: make build-linux-arm
+# 64-bit: make build-linux-arm64
 make build-pi-zero
 
 # Build and install
 make install
 ```
+
+`make build-all` builds the core `picoclaw` binaries for all Makefile-managed platforms.
+
+`make build-release-artifacts` builds release-only artifacts that are packaged separately from the main GoReleaser outputs.
 
 **Raspberry Pi Zero 2 W:** Use the binary that matches your OS: 32-bit Raspberry Pi OS -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Or run `make build-pi-zero` to build both.
 

--- a/README.my.md
+++ b/README.my.md
@@ -187,19 +187,12 @@ make build-launcher
 # Bina binari teras untuk semua platform yang diuruskan oleh Makefile
 make build-all
 
-# Bina artifak keluaran yang dibungkus berasingan daripada output utama GoReleaser
-make build-release-artifacts
-
 # Bina untuk Raspberry Pi Zero 2 W (32-bit: make build-linux-arm; 64-bit: make build-linux-arm64)
 make build-pi-zero
 
 # Bina dan pasang
 make install
 ```
-
-`make build-all` membina binari teras `picoclaw` untuk semua platform yang diuruskan oleh Makefile.
-
-`make build-release-artifacts` membina artifak keluaran yang dibungkus berasingan daripada output utama GoReleaser.
 
 **Raspberry Pi Zero 2 W:** Gunakan binari yang sepadan dengan OS anda: Raspberry Pi OS 32-bit -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Atau jalankan `make build-pi-zero` untuk membina kedua-duanya.
 

--- a/README.my.md
+++ b/README.my.md
@@ -165,10 +165,18 @@ Muat turun binari untuk platform anda dari halaman [GitHub Releases](https://git
 
 ### Bina dari sumber (untuk pembangunan)
 
+Prasyarat:
+
+- Go 1.25+
+- Node.js 22+ dengan Corepack diaktifkan untuk binaan Web UI / launcher
+
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
 cd picoclaw
 make deps
+
+# Pasang pengurus pakej frontend yang diisytiharkan oleh repositori
+(cd web/frontend && corepack install)
 
 # Bina binari teras
 make build
@@ -176,8 +184,11 @@ make build
 # Bina Pelancar Web UI (diperlukan untuk mod WebUI)
 make build-launcher
 
-# Bina untuk pelbagai platform
+# Bina binari teras untuk semua platform yang diuruskan oleh Makefile
 make build-all
+
+# Bina artifak keluaran yang dibungkus berasingan daripada output utama GoReleaser
+make build-release-artifacts
 
 # Bina untuk Raspberry Pi Zero 2 W (32-bit: make build-linux-arm; 64-bit: make build-linux-arm64)
 make build-pi-zero
@@ -185,6 +196,10 @@ make build-pi-zero
 # Bina dan pasang
 make install
 ```
+
+`make build-all` membina binari teras `picoclaw` untuk semua platform yang diuruskan oleh Makefile.
+
+`make build-release-artifacts` membina artifak keluaran yang dibungkus berasingan daripada output utama GoReleaser.
 
 **Raspberry Pi Zero 2 W:** Gunakan binari yang sepadan dengan OS anda: Raspberry Pi OS 32-bit -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Atau jalankan `make build-pi-zero` untuk membina kedua-duanya.
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -187,19 +187,12 @@ make build-launcher
 # Compilar os binários core para todas as plataformas gerenciadas pelo Makefile
 make build-all
 
-# Compilar os artefatos de release empacotados separadamente das saídas principais do GoReleaser
-make build-release-artifacts
-
 # Compilar para Raspberry Pi Zero 2 W (32-bit: make build-linux-arm; 64-bit: make build-linux-arm64)
 make build-pi-zero
 
 # Compilar e instalar
 make install
 ```
-
-`make build-all` compila os binários core do `picoclaw` para todas as plataformas gerenciadas pelo Makefile.
-
-`make build-release-artifacts` compila os artefatos de release empacotados separadamente das saídas principais do GoReleaser.
 
 **Raspberry Pi Zero 2 W:** Use o binário que corresponde ao seu SO: Raspberry Pi OS 32-bit -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Ou execute `make build-pi-zero` para compilar ambos.
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -164,11 +164,19 @@ Alternativamente, baixe o binário para sua plataforma na página de [GitHub Rel
 
 ### Compilar a partir do código-fonte (para desenvolvimento)
 
+Pré-requisitos:
+
+- Go 1.25+
+- Node.js 22+ com Corepack habilitado para builds do Web UI / launcher
+
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
 
 cd picoclaw
 make deps
+
+# Instalar o gerenciador de pacotes de frontend declarado pelo repositório
+(cd web/frontend && corepack install)
 
 # Compilar o binário principal
 make build
@@ -176,8 +184,11 @@ make build
 # Compilar o Web UI Launcher (necessário para o modo WebUI)
 make build-launcher
 
-# Compilar para múltiplas plataformas
+# Compilar os binários core para todas as plataformas gerenciadas pelo Makefile
 make build-all
+
+# Compilar os artefatos de release empacotados separadamente das saídas principais do GoReleaser
+make build-release-artifacts
 
 # Compilar para Raspberry Pi Zero 2 W (32-bit: make build-linux-arm; 64-bit: make build-linux-arm64)
 make build-pi-zero
@@ -185,6 +196,10 @@ make build-pi-zero
 # Compilar e instalar
 make install
 ```
+
+`make build-all` compila os binários core do `picoclaw` para todas as plataformas gerenciadas pelo Makefile.
+
+`make build-release-artifacts` compila os artefatos de release empacotados separadamente das saídas principais do GoReleaser.
 
 **Raspberry Pi Zero 2 W:** Use o binário que corresponde ao seu SO: Raspberry Pi OS 32-bit -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Ou execute `make build-pi-zero` para compilar ambos.
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -187,19 +187,12 @@ make build-launcher
 # Build các binary lõi cho mọi nền tảng do Makefile quản lý
 make build-all
 
-# Build các release artifact được đóng gói tách biệt với các đầu ra chính của GoReleaser
-make build-release-artifacts
-
 # Build for Raspberry Pi Zero 2 W (32-bit: make build-linux-arm; 64-bit: make build-linux-arm64)
 make build-pi-zero
 
 # Build and install
 make install
 ```
-
-`make build-all` build các binary lõi `picoclaw` cho mọi nền tảng do Makefile quản lý.
-
-`make build-release-artifacts` build các release artifact được đóng gói tách biệt với các đầu ra chính của GoReleaser.
 
 **Raspberry Pi Zero 2 W:** Sử dụng binary phù hợp với hệ điều hành của bạn: Raspberry Pi OS 32-bit -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Hoặc chạy `make build-pi-zero` để xây dựng cả hai.
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -164,20 +164,31 @@ Ngoài ra, tải binary cho nền tảng của bạn từ trang [GitHub Releases
 
 ### Xây dựng từ mã nguồn (để phát triển)
 
+Yêu cầu:
+
+- Go 1.25+
+- Node.js 22+ với Corepack được bật cho các bản build Web UI / launcher
+
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
 
 cd picoclaw
 make deps
 
-# Build core binary
+# Cài đặt trình quản lý gói frontend được khai báo bởi repo
+(cd web/frontend && corepack install)
+
+# Build binary lõi
 make build
 
-# Build Web UI Launcher (required for WebUI mode)
+# Build Web UI Launcher (cần cho chế độ WebUI)
 make build-launcher
 
-# Build for multiple platforms
+# Build các binary lõi cho mọi nền tảng do Makefile quản lý
 make build-all
+
+# Build các release artifact được đóng gói tách biệt với các đầu ra chính của GoReleaser
+make build-release-artifacts
 
 # Build for Raspberry Pi Zero 2 W (32-bit: make build-linux-arm; 64-bit: make build-linux-arm64)
 make build-pi-zero
@@ -185,6 +196,10 @@ make build-pi-zero
 # Build and install
 make install
 ```
+
+`make build-all` build các binary lõi `picoclaw` cho mọi nền tảng do Makefile quản lý.
+
+`make build-release-artifacts` build các release artifact được đóng gói tách biệt với các đầu ra chính của GoReleaser.
 
 **Raspberry Pi Zero 2 W:** Sử dụng binary phù hợp với hệ điều hành của bạn: Raspberry Pi OS 32-bit -> `make build-linux-arm`; 64-bit -> `make build-linux-arm64`. Hoặc chạy `make build-pi-zero` để xây dựng cả hai.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -187,19 +187,12 @@ make build-launcher
 # 为 Makefile 管理的所有平台构建核心二进制文件
 make build-all
 
-# 构建独立于主 GoReleaser 输出之外的发布附加产物
-make build-release-artifacts
-
 # 为 Raspberry Pi Zero 2 W 构建（32位: make build-linux-arm; 64位: make build-linux-arm64）
 make build-pi-zero
 
 # 构建并安装
 make install
 ```
-
-`make build-all` 会为所有由 Makefile 管理的平台构建核心 `picoclaw` 二进制文件。
-
-`make build-release-artifacts` 会构建独立于主 GoReleaser 输出之外打包的发布附加产物。
 
 **Raspberry Pi Zero 2 W:** 请使用与系统匹配的二进制文件：32 位 Raspberry Pi OS → `make build-linux-arm`；64 位 → `make build-linux-arm64`。或运行 `make build-pi-zero` 同时构建两者。
 
@@ -631,6 +624,5 @@ Discord: <https://discord.gg/V4sAZ9XWpN>
 
 WeChat:
 <img src="assets/wechat.png" alt="WeChat group QR code" width="512">
-
 
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -164,11 +164,19 @@ PicoClaw 几乎可以部署在任何 Linux 设备上！
 
 ### 从源码构建（开发用）
 
+前置要求：
+
+- Go 1.25+
+- Node.js 22+，并启用 Corepack（用于 Web UI / launcher 构建）
+
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
 
 cd picoclaw
 make deps
+
+# 安装仓库声明的前端包管理器
+(cd web/frontend && corepack install)
 
 # 构建核心二进制文件
 make build
@@ -176,8 +184,11 @@ make build
 # 构建 Web UI Launcher（WebUI 模式必需）
 make build-launcher
 
-# 为多平台构建
+# 为 Makefile 管理的所有平台构建核心二进制文件
 make build-all
+
+# 构建独立于主 GoReleaser 输出之外的发布附加产物
+make build-release-artifacts
 
 # 为 Raspberry Pi Zero 2 W 构建（32位: make build-linux-arm; 64位: make build-linux-arm64）
 make build-pi-zero
@@ -185,6 +196,10 @@ make build-pi-zero
 # 构建并安装
 make install
 ```
+
+`make build-all` 会为所有由 Makefile 管理的平台构建核心 `picoclaw` 二进制文件。
+
+`make build-release-artifacts` 会构建独立于主 GoReleaser 输出之外打包的发布附加产物。
 
 **Raspberry Pi Zero 2 W:** 请使用与系统匹配的二进制文件：32 位 Raspberry Pi OS → `make build-linux-arm`；64 位 → `make build-linux-arm64`。或运行 `make build-pi-zero` 同时构建两者。
 
@@ -616,7 +631,6 @@ Discord: <https://discord.gg/V4sAZ9XWpN>
 
 WeChat:
 <img src="assets/wechat.png" alt="WeChat group QR code" width="512">
-
 
 
 

--- a/web/Makefile
+++ b/web/Makefile
@@ -12,6 +12,7 @@ BUILD_DIR=build
 OUTPUT?=$(BUILD_DIR)/picoclaw-launcher
 OUTPUT_ANDROID_ARM64?=$(BUILD_DIR)/picoclaw-launcher-android-arm64
 FRONTEND_DIR=frontend
+FRONTEND_INSTALL_STAMP=$(FRONTEND_DIR)/node_modules/.picoclaw-install-stamp
 BACKEND_DIR=backend
 BACKEND_DIST=$(BACKEND_DIR)/dist
 PICOCLAW_BINARY_NAME=picoclaw
@@ -105,11 +106,14 @@ build-android-bundle: build-frontend
 	@echo "All Android launcher builds complete"
 
 build-frontend:
-	@if [ ! -d $(FRONTEND_DIR)/node_modules ] || \
-		[ $(FRONTEND_DIR)/package.json -nt $(FRONTEND_DIR)/node_modules ] || \
-		[ $(FRONTEND_DIR)/pnpm-lock.yaml -nt $(FRONTEND_DIR)/node_modules ]; then \
+	@expected_stamp="$$(cat $(FRONTEND_DIR)/package.json $(FRONTEND_DIR)/pnpm-lock.yaml | cksum | awk '{print $$1 ":" $$2}')"; \
+	if [ ! -d $(FRONTEND_DIR)/node_modules ] || \
+		[ ! -x $(FRONTEND_DIR)/node_modules/.bin/tsc ] || \
+		[ ! -f $(FRONTEND_INSTALL_STAMP) ] || \
+		[ "$$(cat $(FRONTEND_INSTALL_STAMP) 2>/dev/null)" != "$$expected_stamp" ]; then \
 		echo "Installing frontend dependencies..."; \
-		cd $(FRONTEND_DIR) && pnpm install --frozen-lockfile; \
+		(cd $(FRONTEND_DIR) && CI=true pnpm install --frozen-lockfile) && \
+		printf '%s\n' "$$expected_stamp" > $(FRONTEND_INSTALL_STAMP); \
 	fi
 	@echo "Building frontend..."
 	@cd $(FRONTEND_DIR) && pnpm build:backend

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"
   },


### PR DESCRIPTION
## 📝 Description

This PR streamlines the build and release pipeline around Android packaging and frontend tool bootstrap.

It keeps `make build-all` focused on core binaries, moves Android bundle generation into GoReleaser-driven release flows, standardizes GitHub Actions on Corepack-managed pnpm with lockfile-aware installs, embeds version metadata in launcher binaries, and refreshes the build instructions in the main and translated READMEs.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
  - https://pnpm.io/installation#using-corepack
  - https://goreleaser.com/customization/builds/go/#ldflags
  - https://goreleaser.com/customization/release/
- **Reasoning:**
  - Keep local/core multi-platform builds separate from Android release packaging.
  - Build and publish the Android bundle from the same GoReleaser-driven release path used by tagged releases and nightly builds.
  - Make frontend dependency bootstrap deterministic by pinning pnpm, using `--frozen-lockfile`, and caching against the lockfile.
  - Propagate version metadata to launcher binaries so release artifacts report the same build information as the core binary.

## 🧪 Test Environment
- **Hardware:** Apple Silicon Mac
- **OS:** macOS
- **Model/Provider:** N/A (build/release tooling change)
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- Verified `.goreleaser.yaml` with `goreleaser check`.
- Inspected `make -n build-all` and `make -n build-android-bundle` to confirm target wiring and Android bundle generation flow.
- Did not run GitHub Actions workflows end-to-end from this environment.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
