### PR TITLE
fix(agent): preserve multiple armed /use skills

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -3405,10 +3405,16 @@ func (al *AgentLoop) applyExplicitSkillCommand(
 		if opts == nil || strings.TrimSpace(opts.SessionKey) == "" {
 			return true, true, commandsUnavailableSkillMessage()
 		}
-		al.setPendingSkills(opts.SessionKey, []string{skillName})
+		armedSkills := al.setPendingSkills(opts.SessionKey, []string{skillName})
+		if len(armedSkills) == 1 {
+			return true, true, fmt.Sprintf(
+				"Skill %q is armed for your next message. Send your next prompt normally, or use /use clear to cancel.",
+				skillName,
+			)
+		}
 		return true, true, fmt.Sprintf(
-			"Skill %q is armed for your next message. Send your next prompt normally, or use /use clear to cancel.",
-			skillName,
+			"Skills %s are armed for your next message. Send your next prompt normally, or use /use clear to cancel.",
+			quoteSkillNames(armedSkills),
 		)
 	}
 
@@ -3540,24 +3546,27 @@ func buildUseCommandHelp(agent *AgentInstance) string {
 	)
 }
 
-func (al *AgentLoop) setPendingSkills(sessionKey string, skillNames []string) {
+func (al *AgentLoop) setPendingSkills(sessionKey string, skillNames []string) []string {
 	sessionKey = strings.TrimSpace(sessionKey)
 	if sessionKey == "" || len(skillNames) == 0 {
-		return
+		return nil
 	}
 
-	filtered := make([]string, 0, len(skillNames))
-	for _, name := range skillNames {
-		name = strings.TrimSpace(name)
-		if name != "" {
-			filtered = append(filtered, name)
+	merged := make([]string, 0, len(skillNames))
+	if existingValue, ok := al.pendingSkills.Load(sessionKey); ok {
+		if existingSkills, ok := existingValue.([]string); ok {
+			merged = append(merged, existingSkills...)
 		}
 	}
+	merged = append(merged, skillNames...)
+
+	filtered := uniqueSkillNames(merged)
 	if len(filtered) == 0 {
-		return
+		return nil
 	}
 
 	al.pendingSkills.Store(sessionKey, filtered)
+	return append([]string(nil), filtered...)
 }
 
 func (al *AgentLoop) takePendingSkills(sessionKey string) []string {
@@ -3585,6 +3594,31 @@ func (al *AgentLoop) clearPendingSkills(sessionKey string) {
 		return
 	}
 	al.pendingSkills.Delete(sessionKey)
+}
+
+func uniqueSkillNames(skillNames []string) []string {
+	filtered := make([]string, 0, len(skillNames))
+	seen := make(map[string]struct{}, len(skillNames))
+	for _, name := range skillNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		filtered = append(filtered, name)
+	}
+	return filtered
+}
+
+func quoteSkillNames(skillNames []string) string {
+	quoted := make([]string, 0, len(skillNames))
+	for _, name := range skillNames {
+		quoted = append(quoted, fmt.Sprintf("%q", name))
+	}
+	return strings.Join(quoted, ", ")
 }
 
 func mapCommandError(result commands.ExecuteResult) string {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -365,6 +365,60 @@ func TestApplyExplicitSkillCommand_ArmsSkillForNextMessage(t *testing.T) {
 	}
 }
 
+func TestApplyExplicitSkillCommand_AppendsPendingSkillsForNextMessage(t *testing.T) {
+	al, cfg, _, _, cleanup := newTestAgentLoop(t)
+	defer cleanup()
+
+	for _, skillName := range []string{"shell", "finance-news"} {
+		skillDir := filepath.Join(cfg.Agents.Defaults.Workspace, "skills", skillName)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s) error = %v", skillName, err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(skillDir, "SKILL.md"),
+			[]byte("# "+skillName+"\n\nSkill test fixture.\n"),
+			0o644,
+		); err != nil {
+			t.Fatalf("WriteFile(%s/SKILL.md) error = %v", skillName, err)
+		}
+	}
+
+	agent := al.GetRegistry().GetDefaultAgent()
+	if agent == nil {
+		t.Fatal("expected default agent")
+	}
+
+	opts := &processOptions{SessionKey: "agent:main:test"}
+	_, handled, reply := al.applyExplicitSkillCommand("/use shell", agent, opts)
+	if !handled {
+		t.Fatal("expected /use shell to be handled")
+	}
+	if !strings.Contains(reply, `Skill "shell" is armed for your next message`) {
+		t.Fatalf("unexpected first reply: %q", reply)
+	}
+
+	_, handled, reply = al.applyExplicitSkillCommand("/use finance-news", agent, opts)
+	if !handled {
+		t.Fatal("expected /use finance-news to be handled")
+	}
+	if !strings.Contains(reply, `Skills "shell", "finance-news" are armed for your next message`) {
+		t.Fatalf("unexpected second reply: %q", reply)
+	}
+
+	_, handled, reply = al.applyExplicitSkillCommand("/use shell", agent, opts)
+	if !handled {
+		t.Fatal("expected duplicate /use shell to be handled")
+	}
+	if !strings.Contains(reply, `Skills "shell", "finance-news" are armed for your next message`) {
+		t.Fatalf("unexpected duplicate reply: %q", reply)
+	}
+
+	pending := al.takePendingSkills(opts.SessionKey)
+	if !slices.Equal(pending, []string{"shell", "finance-news"}) {
+		t.Fatalf("pending skills = %#v, want [shell finance-news]", pending)
+	}
+}
+
 func TestApplyExplicitSkillCommand_InlineMessageMutatesOptions(t *testing.T) {
 	al, cfg, _, _, cleanup := newTestAgentLoop(t)
 	defer cleanup()


### PR DESCRIPTION
## 📝 Description

Fixes the `/use <skill>` pending-skill behavior so multiple armed skills are preserved instead of being overwritten by the most recent `/use` command.

This change:
- appends newly armed pending skills for the next message instead of replacing the previous list
- deduplicates repeated `/use` selections while preserving the original order
- updates the confirmation message to show all armed skills when more than one skill is pending
- adds regression coverage for repeated `/use` arming

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Closes #2478

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/2478
- **Reasoning:** `pendingSkills` is stored as `[]string`, but repeated `/use <skill>` calls for the same session previously replaced the stored slice with the latest single skill. The fix changes pending-skill storage to merge and deduplicate skills so the next message can apply all armed skills as intended.

## 🧪 Test Environment
- **Hardware:** Local development machine
- **OS:** macOS (tested via Docker with Go 1.25.9)
- **Model/Provider:** N/A
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```bash
docker run --rm -v /Users/lahuman/picoclaw:/workspace -w /workspace golang:1.25.9 /bin/sh -lc '/usr/local/go/bin/go test ./pkg/agent -count=1'
ok  	github.com/sipeed/picoclaw/pkg/agent	15.134s
```

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.