### PR TITLE
fix(audio): copy Opus frame data in OGG decoder to prevent corruption

### DIFF
--- a/pkg/audio/ogg.go
+++ b/pkg/audio/ogg.go
@@ -40,11 +40,17 @@ func DecodeOggOpus(r io.Reader, onFrame func([]byte) error) error {
 			// If lacing is less than 255, the packet is complete
 			if lacing < 255 {
 				if packet.Len() > 0 {
-					packetBytes := packet.Bytes()
+					raw := packet.Bytes()
 					// Ignore Ogg Opus headers
-					if !bytes.HasPrefix(packetBytes, []byte("OpusHead")) &&
-						!bytes.HasPrefix(packetBytes, []byte("OpusTags")) {
-						if err := onFrame(packetBytes); err != nil {
+					if !bytes.HasPrefix(raw, []byte("OpusHead")) &&
+						!bytes.HasPrefix(raw, []byte("OpusTags")) {
+						// Copy the frame data: packet.Reset() reuses the
+						// underlying array, so the slice would be
+						// overwritten by subsequent packets before the
+						// consumer (e.g. OpusSend channel) reads it.
+						frame := make([]byte, len(raw))
+						copy(frame, raw)
+						if err := onFrame(frame); err != nil {
 							return err
 						}
 					}


### PR DESCRIPTION
## Description

Fix a buffer reuse bug in `DecodeOggOpus` that corrupts every Opus frame before Discord's voice sender can transmit it.

`packet.Bytes()` returns a slice backed by the `bytes.Buffer` internal array. This slice is passed to the `onFrame` callback, which sends it to discordgo's `OpusSend` channel (buffered, cap 16). Immediately after, `packet.Reset()` resets the buffer length but **retains the underlying array**. As subsequent packets are assembled, the previous slice's data is silently overwritten while it is still queued in the channel waiting to be read by the `opusSender` goroutine.

The result is that Discord receives corrupted Opus frames on every send. Depending on how much of each frame is overwritten before transmission, this manifests as garbled or whispery audio in Discord voice channels.

### Root cause

```go
packetBytes := packet.Bytes()   // slice into buffer's backing array
onFrame(packetBytes)            // queued in buffered channel
packet.Reset()                  // resets length, keeps same array
// next packet.Write() overwrites the memory packetBytes points to
```

### Fix

Allocate a copy of the frame data before passing it to the callback:

```go
frame := make([]byte, len(raw))
copy(frame, raw)
onFrame(frame)
```

## Type of Change

- [x] Bug fix

## 🤖 AI Code Generation

🛠️ Mostly AI-generated — AI identified the bug through systematic diagnosis of Discord voice audio quality issues and wrote the fix; contributor validated and tested on hardware.

## Test Environment

- **Hardware:** Raspberry Pi 5 (Linux ARM64)
- **OS:** Debian (aarch64)
- **Channel:** Discord voice
- **TTS Provider:** OpenAI (tts-1, gpt-4o-mini-tts)
- **Picoclaw version:** built from `main` @ `2e149f4`

## Evidence

Before fix: Discord voice TTS consistently produced whispery/garbled audio across all TTS models and encoding approaches (direct opus passthrough, PCM+ffmpeg transcode, WAV+opusenc). The encoding pipeline was verified correct by round-trip decode testing — the issue was isolated to frame delivery.

After fix: Clear, normal-volume TTS playback in Discord voice with direct opus passthrough from OpenAI (zero transcoding, no ffmpeg dependency).

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My code follows the existing style of the project
- [x] I have tested my changes in a real environment
- [x] I have reviewed my own code for correctness and security