### PR TITLE
CLI: Improve the embedding process of workspace files

### DIFF
--- a/cmd/picoclaw/internal/onboard/command.go
+++ b/cmd/picoclaw/internal/onboard/command.go
@@ -6,6 +6,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Prepare an embedded file system
+// 1. Remove any vestigial `workspace` folder that might be present
+// 2. Duplicate `workspace` folder into the module
+// 3. Embed the module's `workspace` folder into the executable
+//
+//go:generate rm -rf ./workspace
 //go:generate cp -r ../../../../workspace .
 //go:embed workspace
 var embeddedFiles embed.FS


### PR DESCRIPTION
CLI: Improve the embedding process of workspace files used for the onboard process

## 📝 Description

The embedded file system in the `picoclaw` binary should contain **only** the contents from the **latest** `workspace` folder.

The fix improves the embedding process to ensure that vestigial files from older versions of the `workspace` folder are excluded from the embedded file system.

## 🗣️ Type of Change
- [☑️] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [☑️] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 📚 Technical Context
The embedded file system in the `picoclaw` binary should contain **only** the contents from the **latest** `workspace` folder.

The current embedding process does not directly source its contents from the `workspace` folder. The build process populates the embedded file system in [two steps](https://github.com/sipeed/picoclaw/blob/2e149f44dd9da4a05e3001beef37ddcacf659939/cmd/picoclaw/internal/onboard/command.go#L9-L11):
- Step 1: copies the contents from the `workspace` folder into an intermediate folder (`cmd/picoclaw/internal/onboard/workspace`). (Note that the intermediate folder is not under version control per [.gitignore](https://github.com/sipeed/picoclaw/blob/2e149f44dd9da4a05e3001beef37ddcacf659939/.gitignore#L13))
- Step 2: embeds/copies the contents from the intermediate folder into the executable.

However, the intermediate folder is never cleaned **between builds**. Consequently, the intermediate folder can accumulate files from older versions of the `workspace` folder. (One example is the recent removal of the `IDENTITY.md` file from the workspace in [Commit f7f27e](https://github.com/sipeed/picoclaw/commit/f7f27e237a88d7f7a1107926540b8216a507332e) which remained in the intermediate folder under the existing build process.)

The fix adds a precursor step, which is effectively a "Step 0", to clean/delete the intermediate folder before "Step 1".

## 🧪 Test Environment
The presence of the problem was detected on machine that has been building PicoClaw over many weeks.

The problem was detected by the [TestCopyEmbeddedToTargetUsesStructuredAgentFiles test](https://github.com/sipeed/picoclaw/blob/7db2e7d579528c200f8249e92bc7b5dcb6b864bd/cmd/picoclaw/internal/onboard/helpers_test.go#L31-L36) after [Commit f7f27e](https://github.com/sipeed/picoclaw/commit/f7f27e237a88d7f7a1107926540b8216a507332e) which removed the `IDENTITY.md` file from the `workspace` folder **although** the file remained in the intermediate folder.

Subsequently, when the unit test copied the interim folder's `IDENTITY.md` file into the temp folder, the unit test failed.

## ☑️ Checklist
- [☑️] My code/docs follow the style of this project.
- [☑️] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.