### PR TITLE
ci: use pnpm/action-setup and sync README install steps

### DIFF
--- a/.github/workflows/create_dmg.yml
+++ b/.github/workflows/create_dmg.yml
@@ -23,15 +23,18 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: web/frontend/pnpm-lock.yaml
-
-      - name: Setup pnpm
-        run: corepack enable && corepack install
 
       # 3. Build the application bundle
       - name: Build with Make

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,15 +47,18 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: web/frontend/pnpm-lock.yaml
-
-      - name: Setup pnpm
-        run: corepack enable && corepack install
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,15 +65,18 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: web/frontend/pnpm-lock.yaml
-
-      - name: Setup pnpm
-        run: corepack enable && corepack install
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/README.fr.md
+++ b/README.fr.md
@@ -170,7 +170,7 @@ Vous pouvez aussi télécharger le binaire pour votre plateforme depuis la page 
 Prérequis :
 
 - Go 1.25+
-- Node.js 22+ avec Corepack activé pour les builds Web UI / launcher
+- Node.js 22+ et pnpm 10.33.0+ pour les builds Web UI / launcher
 
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
@@ -178,8 +178,8 @@ git clone https://github.com/sipeed/picoclaw.git
 cd picoclaw
 make deps
 
-# Installer le gestionnaire de paquets frontend déclaré par le dépôt
-(cd web/frontend && corepack install)
+# Installer les dépendances frontend
+(cd web/frontend && pnpm install --frozen-lockfile)
 
 # Compiler le binaire principal
 make build
@@ -627,4 +627,3 @@ Discord : <https://discord.gg/V4sAZ9XWpN>
 
 WeChat :
 <img src="assets/wechat.png" alt="WeChat group QR code" width="512">
-

--- a/README.id.md
+++ b/README.id.md
@@ -167,7 +167,7 @@ Atau, unduh binary untuk platform Anda dari halaman [GitHub Releases](https://gi
 Prasyarat:
 
 - Go 1.25+
-- Node.js 22+ dengan Corepack aktif untuk build Web UI / launcher
+- Node.js 22+ dan pnpm 10.33.0+ untuk build Web UI / launcher
 
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
@@ -175,8 +175,8 @@ git clone https://github.com/sipeed/picoclaw.git
 cd picoclaw
 make deps
 
-# Instal package manager frontend yang dideklarasikan repo
-(cd web/frontend && corepack install)
+# Instal dependensi frontend
+(cd web/frontend && pnpm install --frozen-lockfile)
 
 # Build binary inti
 make build

--- a/README.it.md
+++ b/README.it.md
@@ -167,7 +167,7 @@ In alternativa, scarica il binario per la tua piattaforma dalla pagina delle [Gi
 Prerequisiti:
 
 - Go 1.25+
-- Node.js 22+ con Corepack abilitato per le build Web UI / launcher
+- Node.js 22+ e pnpm 10.33.0+ per le build Web UI / launcher
 
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
@@ -175,8 +175,8 @@ git clone https://github.com/sipeed/picoclaw.git
 cd picoclaw
 make deps
 
-# Installa il package manager frontend dichiarato dal repository
-(cd web/frontend && corepack install)
+# Installa le dipendenze frontend
+(cd web/frontend && pnpm install --frozen-lockfile)
 
 # Compila il binario core
 make build

--- a/README.ja.md
+++ b/README.ja.md
@@ -167,7 +167,7 @@ PicoClaw はほぼすべての Linux デバイスにデプロイできます！
 前提条件:
 
 - Go 1.25+
-- Web UI / launcher のビルドには Corepack を有効にした Node.js 22+
+- Web UI / launcher のビルドには Node.js 22+ と pnpm 10.33.0+ が必要
 
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
@@ -175,8 +175,8 @@ git clone https://github.com/sipeed/picoclaw.git
 cd picoclaw
 make deps
 
-# リポジトリで宣言されたフロントエンド用パッケージマネージャーをインストール
-(cd web/frontend && corepack install)
+# フロントエンド依存関係をインストール
+(cd web/frontend && pnpm install --frozen-lockfile)
 
 # コアバイナリをビルド
 make build

--- a/README.ko.md
+++ b/README.ko.md
@@ -167,7 +167,7 @@ PicoClaw는 사실상 거의 모든 Linux 장치에 배포할 수 있습니다!
 필수 사항:
 
 - Go 1.25+
-- Web UI / launcher 빌드를 위한 Corepack 활성화된 Node.js 22+
+- Web UI / launcher 빌드에는 Node.js 22+와 pnpm 10.33.0+가 필요합니다
 
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
@@ -175,8 +175,8 @@ git clone https://github.com/sipeed/picoclaw.git
 cd picoclaw
 make deps
 
-# 저장소에 선언된 프런트엔드 패키지 매니저 설치
-(cd web/frontend && corepack install)
+# 프런트엔드 의존성 설치
+(cd web/frontend && pnpm install --frozen-lockfile)
 
 # 코어 바이너리 빌드
 make build

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Alternatively, download the binary for your platform from the [GitHub Releases](
 Prerequisites:
 
 - Go 1.25+
-- Node.js 22+ with Corepack enabled for Web UI / launcher builds
+- Node.js 22+ and pnpm 10.33.0+ for Web UI / launcher builds
 
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
@@ -175,8 +175,8 @@ git clone https://github.com/sipeed/picoclaw.git
 cd picoclaw
 make deps
 
-# Install frontend package manager declared by the repo
-(cd web/frontend && corepack install)
+# Install frontend dependencies
+(cd web/frontend && pnpm install --frozen-lockfile)
 
 # Build the core binary for the current platform
 make build

--- a/README.my.md
+++ b/README.my.md
@@ -168,15 +168,15 @@ Muat turun binari untuk platform anda dari halaman [GitHub Releases](https://git
 Prasyarat:
 
 - Go 1.25+
-- Node.js 22+ dengan Corepack diaktifkan untuk binaan Web UI / launcher
+- Node.js 22+ dan pnpm 10.33.0+ untuk binaan Web UI / launcher
 
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
 cd picoclaw
 make deps
 
-# Pasang pengurus pakej frontend yang diisytiharkan oleh repositori
-(cd web/frontend && corepack install)
+# Pasang dependensi frontend
+(cd web/frontend && pnpm install --frozen-lockfile)
 
 # Bina binari teras
 make build

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -167,7 +167,7 @@ Alternativamente, baixe o binário para sua plataforma na página de [GitHub Rel
 Pré-requisitos:
 
 - Go 1.25+
-- Node.js 22+ com Corepack habilitado para builds do Web UI / launcher
+- Node.js 22+ e pnpm 10.33.0+ para builds do Web UI / launcher
 
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
@@ -175,8 +175,8 @@ git clone https://github.com/sipeed/picoclaw.git
 cd picoclaw
 make deps
 
-# Instalar o gerenciador de pacotes de frontend declarado pelo repositório
-(cd web/frontend && corepack install)
+# Instalar dependências do frontend
+(cd web/frontend && pnpm install --frozen-lockfile)
 
 # Compilar o binário principal
 make build

--- a/README.vi.md
+++ b/README.vi.md
@@ -167,7 +167,7 @@ Ngoài ra, tải binary cho nền tảng của bạn từ trang [GitHub Releases
 Yêu cầu:
 
 - Go 1.25+
-- Node.js 22+ với Corepack được bật cho các bản build Web UI / launcher
+- Node.js 22+ và pnpm 10.33.0+ cho các bản build Web UI / launcher
 
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
@@ -175,8 +175,8 @@ git clone https://github.com/sipeed/picoclaw.git
 cd picoclaw
 make deps
 
-# Cài đặt trình quản lý gói frontend được khai báo bởi repo
-(cd web/frontend && corepack install)
+# Cài đặt dependencies frontend
+(cd web/frontend && pnpm install --frozen-lockfile)
 
 # Build binary lõi
 make build

--- a/README.zh.md
+++ b/README.zh.md
@@ -167,7 +167,7 @@ PicoClaw 几乎可以部署在任何 Linux 设备上！
 前置要求：
 
 - Go 1.25+
-- Node.js 22+，并启用 Corepack（用于 Web UI / launcher 构建）
+- Node.js 22+ 和 pnpm 10.33.0+（用于 Web UI / launcher 构建）
 
 ```bash
 git clone https://github.com/sipeed/picoclaw.git
@@ -175,8 +175,8 @@ git clone https://github.com/sipeed/picoclaw.git
 cd picoclaw
 make deps
 
-# 安装仓库声明的前端包管理器
-(cd web/frontend && corepack install)
+# 安装前端依赖
+(cd web/frontend && pnpm install --frozen-lockfile)
 
 # 构建核心二进制文件
 make build
@@ -624,5 +624,3 @@ Discord: <https://discord.gg/V4sAZ9XWpN>
 
 WeChat:
 <img src="assets/wechat.png" alt="WeChat group QR code" width="512">
-
-


### PR DESCRIPTION
## 📝 Description

This PR replaces `corepack enable && corepack install` with `pnpm/action-setup@v4` in the `create_dmg`, `nightly`, and `release` workflows, and updates the README setup instructions across the translated docs to use `pnpm install --frozen-lockfile`.

This keeps CI and contributor-facing setup documentation aligned with the repository's declared `pnpm@10.33.0` version.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** `web/frontend/package.json` (`packageManager": "pnpm@10.33.0"`)
- **Reasoning:** The workflows should install the same pnpm version the repository declares instead of relying on Corepack defaults, and the README build steps should match by installing frontend dependencies with `pnpm install --frozen-lockfile`.

## 🧪 Test Environment
- **Hardware:** Apple Silicon Mac (documentation/workflow review only)
- **OS:** macOS 26.4
- **Model/Provider:** N/A
- **Channels:** N/A


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- Confirmed `web/frontend/package.json` declares `pnpm@10.33.0`.
- Reviewed the workflow changes in `.github/workflows/create_dmg.yml`, `.github/workflows/nightly.yml`, and `.github/workflows/release.yml`.
- Synced the pnpm installation steps in the updated README files.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
