### PR TITLE
fix(openai_compat): request stream usage

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -257,6 +257,9 @@ func (p *Provider) ChatStream(
 
 	requestBody := p.buildRequestBody(messages, tools, model, options)
 	requestBody["stream"] = true
+	if supportsStreamingUsage(p.apiBase) {
+		requestBody["stream_options"] = map[string]any{"include_usage": true}
+	}
 
 	jsonData, err := json.Marshal(requestBody)
 	if err != nil {
@@ -479,15 +482,22 @@ func isNativeSearchHost(apiBase string) bool {
 	return host == "api.openai.com" || strings.HasSuffix(host, ".openai.azure.com")
 }
 
-// supportsPromptCacheKey reports whether the given API base is known to
-// support the prompt_cache_key request field. Currently only OpenAI's own
-// API and Azure OpenAI support this. All other OpenAI-compatible providers
-// (Mistral, Gemini, DeepSeek, Groq, etc.) reject unknown fields with 422 errors.
-func supportsPromptCacheKey(apiBase string) bool {
+// isOpenAINativeBaseURL reports whether the given API base is the OpenAI or
+// Azure OpenAI native endpoint family. We reuse it for request fields that are
+// known to work only on those native hosts.
+func isOpenAINativeBaseURL(apiBase string) bool {
 	u, err := url.Parse(apiBase)
 	if err != nil {
 		return false
 	}
 	host := u.Hostname()
 	return host == "api.openai.com" || strings.HasSuffix(host, ".openai.azure.com")
+}
+
+func supportsPromptCacheKey(apiBase string) bool {
+	return isOpenAINativeBaseURL(apiBase)
+}
+
+func supportsStreamingUsage(apiBase string) bool {
+	return isOpenAINativeBaseURL(apiBase)
 }

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -258,7 +258,12 @@ func (p *Provider) ChatStream(
 	requestBody := p.buildRequestBody(messages, tools, model, options)
 	requestBody["stream"] = true
 	if supportsStreamingUsage(p.apiBase) {
-		requestBody["stream_options"] = map[string]any{"include_usage": true}
+		streamOptions := map[string]any{}
+		if existing, ok := requestBody["stream_options"].(map[string]any); ok {
+			streamOptions = maps.Clone(existing)
+		}
+		streamOptions["include_usage"] = true
+		requestBody["stream_options"] = streamOptions
 	}
 
 	jsonData, err := json.Marshal(requestBody)
@@ -474,12 +479,7 @@ func (p *Provider) SupportsNativeSearch() bool {
 }
 
 func isNativeSearchHost(apiBase string) bool {
-	u, err := url.Parse(apiBase)
-	if err != nil {
-		return false
-	}
-	host := u.Hostname()
-	return host == "api.openai.com" || strings.HasSuffix(host, ".openai.azure.com")
+	return isOpenAINativeBaseURL(apiBase)
 }
 
 // isOpenAINativeBaseURL reports whether the given API base is the OpenAI or

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -991,7 +991,7 @@ func chatWithCacheKey(t *testing.T, apiBase string) map[string]any {
 	return requestBody
 }
 
-func chatStreamWithRequestBody(t *testing.T, apiBase string) map[string]any {
+func chatStreamWithRequestBody(t *testing.T, apiBase string, opts ...Option) map[string]any {
 	t.Helper()
 	var requestBody map[string]any
 
@@ -1016,7 +1016,7 @@ func chatStreamWithRequestBody(t *testing.T, apiBase string) map[string]any {
 	}))
 	defer server.Close()
 
-	p := NewProvider("key", server.URL, "")
+	p := NewProvider("key", server.URL, "", opts...)
 	p.apiBase = apiBase
 	p.httpClient = &http.Client{
 		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
@@ -1051,6 +1051,26 @@ func TestProviderChatStream_IncludesUsageForOpenAI(t *testing.T) {
 	streamOptions, ok := body["stream_options"].(map[string]any)
 	if !ok {
 		t.Fatalf("stream_options = %T, want map[string]any", body["stream_options"])
+	}
+	if got := streamOptions["include_usage"]; got != true {
+		t.Fatalf("stream_options.include_usage = %v, want true", got)
+	}
+}
+
+func TestProviderChatStream_PreservesExistingStreamOptions(t *testing.T) {
+	body := chatStreamWithRequestBody(
+		t,
+		"https://api.openai.com/v1",
+		WithExtraBody(map[string]any{
+			"stream_options": map[string]any{"custom_flag": true},
+		}),
+	)
+	streamOptions, ok := body["stream_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("stream_options = %T, want map[string]any", body["stream_options"])
+	}
+	if got := streamOptions["custom_flag"]; got != true {
+		t.Fatalf("stream_options.custom_flag = %v, want true", got)
 	}
 	if got := streamOptions["include_usage"]; got != true {
 		t.Fatalf("stream_options.include_usage = %v, want true", got)

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -991,10 +991,91 @@ func chatWithCacheKey(t *testing.T, apiBase string) map[string]any {
 	return requestBody
 }
 
+func chatStreamWithRequestBody(t *testing.T, apiBase string) map[string]any {
+	t.Helper()
+	var requestBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(
+			w,
+			"data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\n",
+		)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	p.apiBase = apiBase
+	p.httpClient = &http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL, _ = url.Parse(server.URL + r.URL.Path)
+			return http.DefaultTransport.RoundTrip(r)
+		}),
+	}
+
+	_, err := p.ChatStream(
+		t.Context(),
+		[]Message{{Role: "user", Content: "hi"}},
+		nil,
+		"test-model",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ChatStream() error = %v", err)
+	}
+	return requestBody
+}
+
 func TestProviderChat_PromptCacheKeySentToOpenAI(t *testing.T) {
 	body := chatWithCacheKey(t, "https://api.openai.com/v1")
 	if body["prompt_cache_key"] != "agent-main" {
 		t.Fatalf("prompt_cache_key = %v, want %q", body["prompt_cache_key"], "agent-main")
+	}
+}
+
+func TestProviderChatStream_IncludesUsageForOpenAI(t *testing.T) {
+	body := chatStreamWithRequestBody(t, "https://api.openai.com/v1")
+	streamOptions, ok := body["stream_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("stream_options = %T, want map[string]any", body["stream_options"])
+	}
+	if got := streamOptions["include_usage"]; got != true {
+		t.Fatalf("stream_options.include_usage = %v, want true", got)
+	}
+}
+
+func TestProviderChatStream_OmitsUsageForNonOpenAI(t *testing.T) {
+	tests := []struct {
+		name    string
+		apiBase string
+	}{
+		{"mistral", "https://api.mistral.ai/v1"},
+		{"gemini", "https://generativelanguage.googleapis.com/v1beta"},
+		{"deepseek", "https://api.deepseek.com/v1"},
+		{"groq", "https://api.groq.com/openai/v1"},
+		{"minimax", "https://api.minimaxi.com/v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := chatStreamWithRequestBody(t, tt.apiBase)
+			if _, exists := body["stream_options"]; exists {
+				t.Fatalf("stream_options should NOT be sent to %s, but was included in request", tt.name)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

Add streaming usage support to the OpenAI-compatible provider for OpenAI and Azure OpenAI endpoints. The provider now opts into `stream_options.include_usage` only for native OpenAI-hosted bases, matching the existing prompt-cache-key gating pattern and leaving third-party OpenAI-compatible providers unchanged.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** The provider already parses streamed usage chunks, but it did not request them. This change adds a small native-host gate for `stream_options.include_usage` so OpenAI/Azure requests can receive usage data while non-native OpenAI-compatible endpoints stay untouched.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows
- **Model/Provider:** OpenAI-compatible provider tests (httptest)
- **Channels:** N/A


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Validation passed:

- `go test ./pkg/providers/openai_compat/...`

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.