### PR TITLE
feat(web): add markdown syntax highlighting for chat and skills

### DIFF
--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -26,6 +26,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.20",
+    "highlight.js": "^11.11.1",
     "i18next": "^26.0.3",
     "i18next-browser-languagedetector": "^8.2.1",
     "jotai": "^2.19.1",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -35,6 +35,7 @@
     "react-i18next": "^17.0.2",
     "react-markdown": "^10.1.0",
     "react-textarea-autosize": "^8.5.9",
+    "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",

--- a/web/frontend/pnpm-lock.yaml
+++ b/web/frontend/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       dayjs:
         specifier: ^1.11.20
         version: 1.11.20
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       i18next:
         specifier: ^26.0.3
         version: 26.0.3(typescript@5.9.3)

--- a/web/frontend/pnpm-lock.yaml
+++ b/web/frontend/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       react-textarea-autosize:
         specifier: ^8.5.9
         version: 8.5.9(@types/react@19.2.14)(react@19.2.5)
+      rehype-highlight:
+        specifier: ^7.0.2
+        version: 7.0.2
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
@@ -2433,6 +2436,9 @@ packages:
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
 
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
@@ -2448,6 +2454,9 @@ packages:
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
 
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
@@ -2462,6 +2471,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   hono@4.12.12:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
@@ -2806,6 +2819,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -3371,6 +3387,9 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  rehype-highlight@7.0.2:
+    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
+
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
 
@@ -3685,6 +3704,9 @@ packages:
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -6253,6 +6275,10 @@ snapshots:
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
 
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-parse-selector@4.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -6309,6 +6335,13 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -6328,6 +6361,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  highlight.js@11.11.1: {}
 
   hono@4.12.12: {}
 
@@ -6573,6 +6608,12 @@ snapshots:
       is-unicode-supported: 1.3.0
 
   longest-streak@3.1.0: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.1
 
   lru-cache@5.1.1:
     dependencies:
@@ -7350,6 +7391,14 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  rehype-highlight@7.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-text: 4.0.2
+      lowlight: 3.3.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   rehype-raw@7.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -7743,6 +7792,11 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
 
   unist-util-is@6.0.1:
     dependencies:

--- a/web/frontend/src/app-providers.tsx
+++ b/web/frontend/src/app-providers.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react"
+
+import { useHighlightTheme } from "./hooks/use-highlight-theme"
+
+interface AppProvidersProps {
+  children: ReactNode
+}
+
+export function AppProviders({ children }: AppProvidersProps) {
+  useHighlightTheme()
+
+  return <>{children}</>
+}

--- a/web/frontend/src/components/agent/skills/detail-sheet.tsx
+++ b/web/frontend/src/components/agent/skills/detail-sheet.tsx
@@ -172,7 +172,7 @@ export function DetailSheet({
               </div>
 
               {detailView === "preview" ? (
-                <div className="prose prose-zinc dark:prose-invert prose-sm sm:prose-base prose-pre:rounded-xl prose-pre:border prose-pre:border-border/40 prose-pre:bg-zinc-950/90 prose-pre:shadow-sm prose-headings:tracking-tight prose-a:text-primary prose-a:no-underline hover:prose-a:underline max-w-none">
+                <div className="prose prose-zinc dark:prose-invert prose-sm sm:prose-base prose-pre:rounded-xl prose-pre:border prose-pre:border-border/40 prose-pre:bg-zinc-100 prose-pre:p-0 prose-pre:shadow-sm dark:prose-pre:bg-zinc-950/90 prose-headings:tracking-tight prose-a:text-primary prose-a:no-underline hover:prose-a:underline max-w-none">
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm]}
                     rehypePlugins={[rehypeRaw, rehypeSanitize, rehypeHighlight]}

--- a/web/frontend/src/components/agent/skills/detail-sheet.tsx
+++ b/web/frontend/src/components/agent/skills/detail-sheet.tsx
@@ -7,6 +7,7 @@ import {
 import type { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 import ReactMarkdown from "react-markdown"
+import rehypeHighlight from "rehype-highlight"
 import rehypeRaw from "rehype-raw"
 import rehypeSanitize from "rehype-sanitize"
 import remarkGfm from "remark-gfm"
@@ -174,7 +175,7 @@ export function DetailSheet({
                 <div className="prose prose-zinc dark:prose-invert prose-sm sm:prose-base prose-pre:rounded-xl prose-pre:border prose-pre:border-border/40 prose-pre:bg-zinc-950/90 prose-pre:shadow-sm prose-headings:tracking-tight prose-a:text-primary prose-a:no-underline hover:prose-a:underline max-w-none">
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm]}
-                    rehypePlugins={[rehypeRaw, rehypeSanitize]}
+                    rehypePlugins={[rehypeRaw, rehypeSanitize, rehypeHighlight]}
                   >
                     {selectedSkillDetail.content}
                   </ReactMarkdown>

--- a/web/frontend/src/components/chat/assistant-message.tsx
+++ b/web/frontend/src/components/chat/assistant-message.tsx
@@ -2,6 +2,7 @@ import { IconBrain, IconCheck, IconCopy } from "@tabler/icons-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import ReactMarkdown from "react-markdown"
+import rehypeHighlight from "rehype-highlight"
 import rehypeRaw from "rehype-raw"
 import rehypeSanitize from "rehype-sanitize"
 import remarkGfm from "remark-gfm"
@@ -71,7 +72,7 @@ export function AssistantMessage({
         >
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeRaw, rehypeSanitize]}
+            rehypePlugins={[rehypeRaw, rehypeSanitize, rehypeHighlight]}
           >
             {content}
           </ReactMarkdown>

--- a/web/frontend/src/components/chat/assistant-message.tsx
+++ b/web/frontend/src/components/chat/assistant-message.tsx
@@ -64,7 +64,7 @@ export function AssistantMessage({
       >
         <div
           className={cn(
-            "prose dark:prose-invert prose-pre:my-2 prose-pre:overflow-x-auto prose-pre:rounded-lg prose-pre:border prose-pre:bg-zinc-950 prose-pre:p-3 max-w-none [overflow-wrap:anywhere] break-words",
+            "prose dark:prose-invert prose-pre:my-2 prose-pre:overflow-x-auto prose-pre:rounded-lg prose-pre:border prose-pre:bg-zinc-100 prose-pre:p-0 dark:prose-pre:bg-zinc-950 max-w-none [overflow-wrap:anywhere] break-words",
             isThought
               ? "prose-p:my-1.5 p-3 text-[13px] leading-relaxed opacity-90"
               : "prose-p:my-2 p-4 text-[15px] leading-relaxed",

--- a/web/frontend/src/hooks/use-highlight-theme.ts
+++ b/web/frontend/src/hooks/use-highlight-theme.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react"
+
+import githubDarkCss from "highlight.js/styles/github-dark.css?inline"
+import githubLightCss from "highlight.js/styles/github.css?inline"
+
+const THEME_STYLE_ID = "hljs-theme-style"
+
+function getOrCreateThemeStyleElement() {
+  let styleElement = document.getElementById(THEME_STYLE_ID)
+  if (!styleElement) {
+    styleElement = document.createElement("style")
+    styleElement.id = THEME_STYLE_ID
+    document.head.appendChild(styleElement)
+  }
+  return styleElement
+}
+
+export function useHighlightTheme() {
+  useEffect(() => {
+    const root = document.documentElement
+    const styleElement = getOrCreateThemeStyleElement()
+
+    const applyTheme = () => {
+      const nextThemeCss = root.classList.contains("dark")
+        ? githubDarkCss
+        : githubLightCss
+      styleElement.textContent = nextThemeCss
+    }
+
+    applyTheme()
+
+    const observer = new MutationObserver(() => {
+      applyTheme()
+    })
+
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ["class"],
+    })
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
+}

--- a/web/frontend/src/hooks/use-highlight-theme.ts
+++ b/web/frontend/src/hooks/use-highlight-theme.ts
@@ -4,14 +4,39 @@ import githubDarkCss from "highlight.js/styles/github-dark.css?inline"
 import githubLightCss from "highlight.js/styles/github.css?inline"
 
 const THEME_STYLE_ID = "hljs-theme-style"
+const THEME_STYLE_OWNER_ATTR = "data-picoclaw-highlight-theme"
+const THEME_STYLE_OWNER_VALUE = "true"
+const MANAGED_THEME_STYLE_SELECTOR = `style[${THEME_STYLE_OWNER_ATTR}="${THEME_STYLE_OWNER_VALUE}"]`
+const ID_THEME_STYLE_SELECTOR = `style#${THEME_STYLE_ID}`
 
-function getOrCreateThemeStyleElement() {
-  let styleElement = document.getElementById(THEME_STYLE_ID)
-  if (!styleElement) {
-    styleElement = document.createElement("style")
-    styleElement.id = THEME_STYLE_ID
-    document.head.appendChild(styleElement)
+function getOrCreateThemeStyleElement(): HTMLStyleElement {
+  const managedStyleElement = document.head.querySelector<HTMLStyleElement>(
+    MANAGED_THEME_STYLE_SELECTOR,
+  )
+  if (managedStyleElement) {
+    return managedStyleElement
   }
+
+  const existingStyleElement =
+    document.querySelector<HTMLStyleElement>(ID_THEME_STYLE_SELECTOR)
+  if (existingStyleElement) {
+    existingStyleElement.setAttribute(
+      THEME_STYLE_OWNER_ATTR,
+      THEME_STYLE_OWNER_VALUE,
+    )
+    return existingStyleElement
+  }
+
+  const conflictingElement = document.getElementById(THEME_STYLE_ID)
+  const styleElement = document.createElement("style")
+  if (!conflictingElement) {
+    styleElement.id = THEME_STYLE_ID
+  }
+
+  // Leave conflicting non-style nodes untouched and track the injected style explicitly.
+  styleElement.setAttribute(THEME_STYLE_OWNER_ATTR, THEME_STYLE_OWNER_VALUE)
+  document.head.appendChild(styleElement)
+
   return styleElement
 }
 

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -157,6 +157,69 @@
   height: calc(100svh - 3.5rem);
 }
 
+/* Markdown code highlighting (rehype-highlight / highlight.js classes) */
+.prose pre code.hljs,
+.prose pre code[class*="language-"] {
+  display: block;
+  overflow-x: auto;
+  background: transparent;
+  padding: 0;
+  color: #e4e4e7;
+}
+
+.prose pre code .hljs-comment,
+.prose pre code .hljs-quote {
+  color: #71717a;
+}
+
+.prose pre code .hljs-keyword,
+.prose pre code .hljs-selector-tag,
+.prose pre code .hljs-subst {
+  color: #f472b6;
+}
+
+.prose pre code .hljs-string,
+.prose pre code .hljs-doctag,
+.prose pre code .hljs-regexp,
+.prose pre code .hljs-addition,
+.prose pre code .hljs-attribute,
+.prose pre code .hljs-template-tag,
+.prose pre code .hljs-template-variable {
+  color: #34d399;
+}
+
+.prose pre code .hljs-number,
+.prose pre code .hljs-literal,
+.prose pre code .hljs-bullet,
+.prose pre code .hljs-meta,
+.prose pre code .hljs-built_in,
+.prose pre code .hljs-builtin-name,
+.prose pre code .hljs-symbol,
+.prose pre code .hljs-variable,
+.prose pre code .hljs-link,
+.prose pre code .hljs-type,
+.prose pre code .hljs-selector-class,
+.prose pre code .hljs-selector-attr,
+.prose pre code .hljs-selector-pseudo {
+  color: #22d3ee;
+}
+
+.prose pre code .hljs-title,
+.prose pre code .hljs-section,
+.prose pre code .hljs-name,
+.prose pre code .hljs-selector-id,
+.prose pre code .hljs-deletion {
+  color: #60a5fa;
+}
+
+.prose pre code .hljs-emphasis {
+  font-style: italic;
+}
+
+.prose pre code .hljs-strong {
+  font-weight: 700;
+}
+
 /* Typing indicator animations */
 @keyframes shimmer {
   0% {

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -157,69 +157,6 @@
   height: calc(100svh - 3.5rem);
 }
 
-/* Markdown code highlighting (rehype-highlight / highlight.js classes) */
-.prose pre code.hljs,
-.prose pre code[class*="language-"] {
-  display: block;
-  overflow-x: auto;
-  background: transparent;
-  padding: 0;
-  color: #e4e4e7;
-}
-
-.prose pre code .hljs-comment,
-.prose pre code .hljs-quote {
-  color: #71717a;
-}
-
-.prose pre code .hljs-keyword,
-.prose pre code .hljs-selector-tag,
-.prose pre code .hljs-subst {
-  color: #f472b6;
-}
-
-.prose pre code .hljs-string,
-.prose pre code .hljs-doctag,
-.prose pre code .hljs-regexp,
-.prose pre code .hljs-addition,
-.prose pre code .hljs-attribute,
-.prose pre code .hljs-template-tag,
-.prose pre code .hljs-template-variable {
-  color: #34d399;
-}
-
-.prose pre code .hljs-number,
-.prose pre code .hljs-literal,
-.prose pre code .hljs-bullet,
-.prose pre code .hljs-meta,
-.prose pre code .hljs-built_in,
-.prose pre code .hljs-builtin-name,
-.prose pre code .hljs-symbol,
-.prose pre code .hljs-variable,
-.prose pre code .hljs-link,
-.prose pre code .hljs-type,
-.prose pre code .hljs-selector-class,
-.prose pre code .hljs-selector-attr,
-.prose pre code .hljs-selector-pseudo {
-  color: #22d3ee;
-}
-
-.prose pre code .hljs-title,
-.prose pre code .hljs-section,
-.prose pre code .hljs-name,
-.prose pre code .hljs-selector-id,
-.prose pre code .hljs-deletion {
-  color: #60a5fa;
-}
-
-.prose pre code .hljs-emphasis {
-  font-style: italic;
-}
-
-.prose pre code .hljs-strong {
-  font-weight: 700;
-}
-
 /* Typing indicator animations */
 @keyframes shimmer {
   0% {

--- a/web/frontend/src/main.tsx
+++ b/web/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { RouterProvider, createRouter } from "@tanstack/react-router"
 import { StrictMode } from "react"
 import ReactDOM from "react-dom/client"
 
+import { useHighlightTheme } from "./hooks/use-highlight-theme"
 import "./i18n"
 import "./index.css"
 import { routeTree } from "./routeTree.gen"
@@ -22,14 +23,22 @@ declare module "@tanstack/react-router" {
   }
 }
 
+function AppProviders() {
+  useHighlightTheme()
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  )
+}
+
 const rootElement = document.getElementById("root")!
 if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement)
   root.render(
     <StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
-      </QueryClientProvider>
+      <AppProviders />
     </StrictMode>,
   )
 }

--- a/web/frontend/src/main.tsx
+++ b/web/frontend/src/main.tsx
@@ -3,7 +3,7 @@ import { RouterProvider, createRouter } from "@tanstack/react-router"
 import { StrictMode } from "react"
 import ReactDOM from "react-dom/client"
 
-import { useHighlightTheme } from "./hooks/use-highlight-theme"
+import { AppProviders } from "./app-providers"
 import "./i18n"
 import "./index.css"
 import { routeTree } from "./routeTree.gen"
@@ -23,22 +23,16 @@ declare module "@tanstack/react-router" {
   }
 }
 
-function AppProviders() {
-  useHighlightTheme()
-
-  return (
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
-  )
-}
-
 const rootElement = document.getElementById("root")!
 if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement)
   root.render(
     <StrictMode>
-      <AppProviders />
+      <AppProviders>
+        <QueryClientProvider client={queryClient}>
+          <RouterProvider router={router} />
+        </QueryClientProvider>
+      </AppProviders>
     </StrictMode>,
   )
 }


### PR DESCRIPTION
## 📝 Description

- Adds syntax highlighting for Markdown code blocks in Web Chat assistant messages.
- Adds syntax highlighting for Markdown code blocks in Skills detail preview.
- Integrates `rehype-highlight` into both ReactMarkdown rendering pipelines with sanitize-before-highlight ordering.

From the official documentation, we can learn that:
1. It is safe to run the plugin after rehype-sanitize, provided you trust the plugin.
2. In the official rehype-sanitize example, syntax highlighting follows the order of sanitize -> highlight.

Therefore, I believe it is safe to treat highlight as safe/semi-trusted content and place it after sanitize.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 📚 Technical Context
- **Reference URL:**
  - https://github.com/rehypejs/rehype-highlight
  - https://github.com/highlightjs/highlight.js
- **Reasoning:**
  - The project already uses ReactMarkdown, so enabling `rehype-highlight` at the markdown pipeline level provides low-friction syntax highlighting for both chat and skills views.
  - Using official highlight.js themes avoids incomplete handcrafted token maps and reduces style drift.
  - Dynamic light/dark switching is aligned with the existing `html.dark` theme class behavior.

## 🧪 Test Environment
- **Hardware:** Local x64 Server
- **OS:** Ubuntu Server 24
- **Model/Provider:** -
- **Channels:** Web

## 📸 Evidence
<details>
<summary>Click to view Logs/Screenshots</summary>

<img width="1142" height="1403" alt="image" src="https://github.com/user-attachments/assets/9b106ed8-20fc-4eb3-929b-bf0885db42e0" />

<img width="801" height="603" alt="image" src="https://github.com/user-attachments/assets/e570f464-c0a6-4156-ad25-98c7542dc658" />

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.