### PR TITLE
fix(config): preserve explicit mention_only=false in GroupTriggerConfig

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -307,7 +307,12 @@ func (d *AgentDefaults) GetModelName() string {
 
 // GroupTriggerConfig controls when the bot responds in group chats.
 type GroupTriggerConfig struct {
-	MentionOnly bool     `json:"mention_only,omitempty"`
+	// MentionOnly must always serialize so an explicit `false` survives the
+	// LoadConfig → SaveConfig roundtrip in migration paths (config.go:1042,
+	// 1083, 1122). With `,omitempty`, Go would omit the bool zero value and
+	// defaultChannels() would re-inject the hardcoded `true` default
+	// (defaults.go:483-484), silently reverting the user's choice.
+	MentionOnly bool     `json:"mention_only"`
 	Prefixes    []string `json:"prefixes,omitempty"`
 }
 

--- a/pkg/config/group_trigger_mention_only_test.go
+++ b/pkg/config/group_trigger_mention_only_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGroupTriggerConfig_MentionOnly_False_Roundtrips documents the regression
+// where an explicit `mention_only: false` is silently lost on a JSON roundtrip
+// because the struct tag `json:"mention_only,omitempty"` causes Go to omit the
+// field whenever its value equals the bool zero value (false).
+//
+// Chain of damage in production:
+//   1. User edits config.json and sets "mention_only": false.
+//   2. Gateway loads config → LoadConfig triggers defer SaveConfig on any
+//      migration path (config.go:1042/1083/1122).
+//   3. SaveConfig re-marshals the struct. `,omitempty` drops the false field.
+//   4. The next load merges with defaultChannels() (defaults.go:483-484),
+//      which hardcodes `{"mention_only": true}` for the "line" channel.
+//   5. User's explicit false silently becomes true.
+//
+// The fix is to remove `,omitempty` from the tag so false always serializes,
+// matching the pattern already used by DiscordConfig.MentionOnly (no omitempty).
+func TestGroupTriggerConfig_MentionOnly_False_Roundtrips(t *testing.T) {
+	original := GroupTriggerConfig{MentionOnly: false}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	// The bug: with `,omitempty`, the false field is omitted entirely, so the
+	// JSON becomes "{}" and the user's explicit choice is indistinguishable
+	// from "never set". A caller that fills in defaults for missing fields
+	// will then replace false with true.
+	assert.Contains(t, string(data), `"mention_only":false`,
+		"explicit false must serialize — otherwise defaults logic overwrites it; see defaults.go:483-484")
+
+	var decoded GroupTriggerConfig
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.False(t, decoded.MentionOnly, "mention_only should survive roundtrip as false")
+}


### PR DESCRIPTION
## Summary

`GroupTriggerConfig.MentionOnly` is tagged `` json:\"mention_only,omitempty\" ``. Because Go's `bool` zero value is `false`, `,omitempty` silently omits the field whenever a user sets it to `false`. The next `LoadConfig` fills the missing field from `defaultChannels()`, which hardcodes `\"mention_only\": true` for LINE and Matrix, then `defer SaveConfig(...)` writes the override back to disk. Users who explicitly opt *out* of mention-only mode see their setting silently revert to `true` after any upgrade or version migration.

## Reproduction

Before this patch, marshaling `GroupTriggerConfig{MentionOnly: false}` produces `{}`:

```go
data, _ := json.Marshal(GroupTriggerConfig{MentionOnly: false})
// data == []byte(\"{}\")
```

The new test `TestGroupTriggerConfig_MentionOnly_False_Roundtrips` fails on `main` and passes after the fix.

## Failure chain in production

1. User edits `~/.picoclaw/config.json` and sets `\"mention_only\": false` for a LINE or Matrix channel.
2. Gateway starts → `LoadConfig` (`pkg/config/config.go:970`) parses the file. Any of the migration branches (`:1042`, `:1083`, `:1122`) runs `defer SaveConfig(path, cfg)`.
3. `SaveConfig` re-marshals the struct. `,omitempty` drops the `false` field.
4. On the subsequent load, `defaultChannels()` (`pkg/config/defaults.go:483-484`) supplies `{\"mention_only\": true}` as the default for the \"line\" (and \"matrix\") channel.
5. User's explicit `false` has silently become `true`.

## Fix

Remove `,omitempty` from the `MentionOnly` tag so `false` always serializes, matching the pattern `DiscordConfig.MentionOnly` already uses (`config.go:369`, plain `` json:\"mention_only\" ``). An inline comment explains why the tag must stay plain, with file:line citations to the migration and default paths.

```diff
 type GroupTriggerConfig struct {
-	MentionOnly bool     ` + "`" + `json:\"mention_only,omitempty\"` + "`" + `
+	// MentionOnly must always serialize so an explicit ` + "`" + `false` + "`" + ` survives the
+	// LoadConfig → SaveConfig roundtrip in migration paths (config.go:1042,
+	// 1083, 1122). With ` + "`" + `,omitempty` + "`" + `, Go would omit the bool zero value and
+	// defaultChannels() would re-inject the hardcoded ` + "`" + `true` + "`" + ` default
+	// (defaults.go:483-484), silently reverting the user's choice.
+	MentionOnly bool     ` + "`" + `json:\"mention_only\"` + "`" + `
 	Prefixes    []string ` + "`" + `json:\"prefixes,omitempty\"` + "`" + `
 }
```

## Affected channels

Any channel whose config embeds `GroupTriggerConfig`, namely LINE, Matrix, Telegram, Feishu, Discord (wrapper), QQ, OneBot, DingTalk, Weixin. Only Discord set this tag correctly already (its own `DiscordConfig.MentionOnly`).

## Test coverage

- **New**: `TestGroupTriggerConfig_MentionOnly_False_Roundtrips` — asserts that explicit `false` serializes and survives roundtrip. Fails on `main`, passes with this patch.
- **Existing**: all `pkg/config/` tests still pass (including `config_channel_test.go` cases that marshal `MentionOnly: true`).

```
$ go test ./pkg/config/
ok      github.com/sipeed/picoclaw/pkg/config   1.437s
```

## Relationship to #2541 / #2329

`#2541` (WhatsApp) and `#2329` address a different root cause — the WhatsApp channel struct was missing a `GroupTrigger` field entirely. This PR addresses a bug in the shared `GroupTriggerConfig` struct itself, which affects every channel that correctly embeds it. The two fixes are complementary.

## Test plan

- [x] `go test ./pkg/config/` passes locally
- [x] Verified that the new test fails without the one-line change (reproducing the bug)
- [x] Confirmed no existing test regressed
- [x] CI