### PR TITLE
fix: isolate thought bubble collapse state

### DIFF
--- a/web/frontend/src/components/chat/assistant-message.tsx
+++ b/web/frontend/src/components/chat/assistant-message.tsx
@@ -6,7 +6,6 @@ import {
   IconDownload,
   IconFileText,
 } from "@tabler/icons-react"
-import { useAtom } from "jotai"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import ReactMarkdown from "react-markdown"
@@ -18,7 +17,7 @@ import remarkGfm from "remark-gfm"
 import { Button } from "@/components/ui/button"
 import { formatMessageTime } from "@/hooks/use-pico-chat"
 import { cn } from "@/lib/utils"
-import { type ChatAttachment, showThoughtsAtom } from "@/store/chat"
+import { type ChatAttachment } from "@/store/chat"
 
 interface AssistantMessageProps {
   content: string
@@ -42,7 +41,7 @@ export function AssistantMessage({
   const fileAttachments = attachments.filter(
     (attachment) => attachment.type !== "image",
   )
-  const [isExpanded, setIsExpanded] = useAtom(showThoughtsAtom)
+  const [isExpanded, setIsExpanded] = useState(true)
   const formattedTimestamp =
     timestamp !== "" ? formatMessageTime(timestamp) : ""
 

--- a/web/frontend/src/store/chat.ts
+++ b/web/frontend/src/store/chat.ts
@@ -57,8 +57,6 @@ const DEFAULT_CHAT_STATE: ChatStoreState = {
 
 export const chatAtom = atom<ChatStoreState>(DEFAULT_CHAT_STATE)
 
-export const showThoughtsAtom = atom<boolean>(true)
-
 const store = getDefaultStore()
 
 export function getChatState() {


### PR DESCRIPTION
## 📝 Description

Fix the thought bubble collapse state so each reasoning bubble manages its own expanded/collapsed state instead of sharing one global frontend atom.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** The previous implementation stored thought bubble visibility in a shared `showThoughtsAtom`, so collapsing one reasoning bubble also collapsed every other reasoning bubble, including bubbles shown after switching sessions. This change moves the expanded state into each `AssistantMessage` instance with local React state.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Ubuntu 24.04
- **Model/Provider:** N/A (frontend UI behavior)
- **Channels:** Web frontend chat UI


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Unable to run `pnpm lint` and `pnpm build` locally because `web/frontend/node_modules` is missing in this workspace, so `eslint` and `tsc` are not available.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
