### PR TITLE
fix(mcp): send empty object instead of null for tool

### DIFF
--- a/pkg/agent/hooks.go
+++ b/pkg/agent/hooks.go
@@ -788,7 +788,7 @@ func cloneLLMResponse(resp *providers.LLMResponse) *providers.LLMResponse {
 
 func cloneStringAnyMap(src map[string]any) map[string]any {
 	if len(src) == 0 {
-		return nil
+		return map[string]any{}
 	}
 
 	cloned := make(map[string]any, len(src))

--- a/pkg/agent/hooks_test.go
+++ b/pkg/agent/hooks_test.go
@@ -1168,6 +1168,56 @@ func TestAgentLoop_HookRespond_SteeringSkipsRemaining(t *testing.T) {
 	}
 }
 
+func TestCloneStringAnyMap_EmptyMapReturnsNonNil(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]any
+		wantNil bool
+		wantLen int
+	}{
+		{
+			name:    "nil input returns empty map",
+			input:   nil,
+			wantNil: false,
+			wantLen: 0,
+		},
+		{
+			name:    "empty map returns empty map",
+			input:   map[string]any{},
+			wantNil: false,
+			wantLen: 0,
+		},
+		{
+			name:    "populated map is cloned",
+			input:   map[string]any{"key": "value"},
+			wantNil: false,
+			wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cloneStringAnyMap(tt.input)
+			if result == nil {
+				t.Fatal("cloneStringAnyMap returned nil — MCP tool calls " +
+					"with no arguments would send null instead of {}")
+			}
+			if len(result) != tt.wantLen {
+				t.Fatalf("expected len %d, got %d", tt.wantLen, len(result))
+			}
+		})
+	}
+
+	t.Run("clone does not share underlying map", func(t *testing.T) {
+		src := map[string]any{"a": 1}
+		cloned := cloneStringAnyMap(src)
+		cloned["b"] = 2
+		if _, ok := src["b"]; ok {
+			t.Fatal("modifying clone should not affect source")
+		}
+	})
+}
+
 func filterEvents(events []Event, kind EventKind) []Event {
 	var result []Event
 	for _, evt := range events {


### PR DESCRIPTION
## 📝 Description

This PR modifies the `cloneStringAnyMap` helper function to ensure it returns an initialized empty map (`map[string]any{}`) instead of `nil` when the source map is empty or nil. This ensures that downstream processes (like MCP tool calls) receive a valid empty JSON object `{}` instead of `null`.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes # (Issue regarding MCP tool calls receiving null arguments)

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:** In Go, a `nil` map marshals to `null` in JSON. Some external APIs and MCP (Model Context Protocol) implementations require an explicit empty object `{}` for arguments. By initializing the map even when empty, we guarantee valid JSON serialization.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Linux/MacOS
- **Model/Provider:** N/A
- **Channels:** 

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

New unit tests added in `pkg/agent/hooks_test.go`:
- `TestCloneStringAnyMap_EmptyMapReturnsNonNil`: Verifies that nil/empty inputs result in a non-nil map.
- `clone does not share underlying map`: Verifies deep copy integrity.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.