### PR TITLE
refactor(pico): unify message kind handling of tool_calls and thought

### DIFF
--- a/pkg/channels/pico/client_test.go
+++ b/pkg/channels/pico/client_test.go
@@ -333,18 +333,33 @@ func TestIsThoughtPayload(t *testing.T) {
 		want    bool
 	}{
 		{
-			name:    "explicit thought bool",
+			name:    "explicit thought kind",
+			payload: map[string]any{PayloadKeyKind: MessageKindThought},
+			want:    true,
+		},
+		{
+			name:    "thought kind ignores case and whitespace",
+			payload: map[string]any{PayloadKeyKind: "  ThOuGhT  "},
+			want:    true,
+		},
+		{
+			name:    "legacy thought bool remains supported for inbound compatibility",
 			payload: map[string]any{PayloadKeyThought: true},
 			want:    true,
 		},
 		{
-			name:    "thought false",
+			name:    "legacy thought false",
 			payload: map[string]any{PayloadKeyThought: false},
 			want:    false,
 		},
 		{
-			name:    "thought string ignored",
-			payload: map[string]any{PayloadKeyThought: "true"},
+			name:    "tool calls kind",
+			payload: map[string]any{PayloadKeyKind: MessageKindToolCalls},
+			want:    false,
+		},
+		{
+			name:    "non-string kind ignored",
+			payload: map[string]any{PayloadKeyKind: true},
 			want:    false,
 		},
 		{
@@ -380,13 +395,41 @@ func TestPicoClientChannel_HandleServerMessage_IgnoresThought(t *testing.T) {
 		Type: TypeMessageCreate,
 		Payload: map[string]any{
 			PayloadKeyContent: "internal reasoning",
-			PayloadKeyThought: true,
+			PayloadKeyKind:    MessageKindThought,
 		},
 	})
 
 	select {
 	case msg := <-mb.InboundChan():
 		t.Fatalf("expected no inbound publish for thought payload, got %+v", msg)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestPicoClientChannel_HandleServerMessage_IgnoresLegacyThoughtBool(t *testing.T) {
+	mb := bus.NewMessageBus()
+	bc := &config.Channel{Type: config.ChannelPicoClient, Enabled: true}
+	ch, err := NewPicoClientChannel(bc, &config.PicoClientSettings{
+		URL: "ws://localhost:8080/ws",
+	}, mb)
+	if err != nil {
+		t.Fatalf("NewPicoClientChannel() error = %v", err)
+	}
+
+	ch.ctx = context.Background()
+	pc := &picoConn{sessionID: "sess-thought-legacy"}
+
+	ch.handleServerMessage(pc, PicoMessage{
+		Type: TypeMessageCreate,
+		Payload: map[string]any{
+			PayloadKeyContent: "legacy internal reasoning",
+			PayloadKeyThought: true,
+		},
+	})
+
+	select {
+	case msg := <-mb.InboundChan():
+		t.Fatalf("expected no inbound publish for legacy thought payload, got %+v", msg)
 	case <-time.After(150 * time.Millisecond):
 	}
 }

--- a/pkg/channels/pico/pico.go
+++ b/pkg/channels/pico/pico.go
@@ -323,10 +323,12 @@ func (c *PicoChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]stri
 
 	payload := map[string]any{
 		PayloadKeyContent: content,
-		PayloadKeyThought: isThought,
 		"message_id":      msgID,
 	}
-	if isToolCalls {
+	switch {
+	case isThought:
+		payload[PayloadKeyKind] = MessageKindThought
+	case isToolCalls:
 		payload[PayloadKeyKind] = MessageKindToolCalls
 		if toolCalls, ok := picoToolCallsPayload(msg); ok {
 			payload[PayloadKeyToolCalls] = toolCalls
@@ -457,7 +459,6 @@ func (c *PicoChannel) SendPlaceholder(ctx context.Context, chatID string) (strin
 	msgID := uuid.New().String()
 	outMsg := newMessage(TypeMessageCreate, map[string]any{
 		PayloadKeyContent: text,
-		PayloadKeyThought: false,
 		"message_id":      msgID,
 	})
 

--- a/pkg/channels/pico/pico.go
+++ b/pkg/channels/pico/pico.go
@@ -328,6 +328,12 @@ func (c *PicoChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]stri
 	switch {
 	case isThought:
 		payload[PayloadKeyKind] = MessageKindThought
+
+		// This field is kept solely for compatibility with legacy pico clients that
+		// do not yet support the newer "kind" field.
+		// DO NOT use it for any purpose other than legacy client compatibility.
+		payload[PayloadKeyThought] = true
+
 	case isToolCalls:
 		payload[PayloadKeyKind] = MessageKindToolCalls
 		if toolCalls, ok := picoToolCallsPayload(msg); ok {

--- a/pkg/channels/pico/pico_test.go
+++ b/pkg/channels/pico/pico_test.go
@@ -131,8 +131,8 @@ func TestSend_ThoughtMessageDoesNotFinalizeTrackedToolFeedback(t *testing.T) {
 		if got := payload[PayloadKeyContent]; got != "thinking trace" {
 			t.Fatalf("thought content = %#v, want %q", got, "thinking trace")
 		}
-		if got := payload[PayloadKeyThought]; got != true {
-			t.Fatalf("thought flag = %#v, want true", got)
+		if got := payload[PayloadKeyKind]; got != MessageKindThought {
+			t.Fatalf("thought kind = %#v, want %q", got, MessageKindThought)
 		}
 		if got := payload["message_id"]; got == "msg-progress" || got == nil || got == "" {
 			t.Fatalf("thought message_id = %#v, want new non-progress id", got)
@@ -190,6 +190,47 @@ func TestSend_ThoughtMessageDoesNotFinalizeTrackedToolFeedback(t *testing.T) {
 
 	if _, ok := ch.currentToolFeedbackMessage("pico:sess-1"); ok {
 		t.Fatal("expected tracked tool feedback to be cleared after final reply")
+	}
+}
+
+func TestSendPlaceholder_EmitsNormalMessageWithoutKind(t *testing.T) {
+	ch := newTestPicoChannel(t)
+	ch.bc.Placeholder.Enabled = true
+
+	if err := ch.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer ch.Stop(context.Background())
+
+	clientConn, received, cleanup := newTestPicoWebSocket(t)
+	defer cleanup()
+	ch.addConnForTest(&picoConn{id: "conn-1", conn: clientConn, sessionID: "sess-1"})
+
+	msgID, err := ch.SendPlaceholder(context.Background(), "pico:sess-1")
+	if err != nil {
+		t.Fatalf("SendPlaceholder() error = %v", err)
+	}
+	if msgID == "" {
+		t.Fatal("expected placeholder message id")
+	}
+
+	select {
+	case msg := <-received:
+		if msg.Type != TypeMessageCreate {
+			t.Fatalf("placeholder message type = %q, want %q", msg.Type, TypeMessageCreate)
+		}
+		payload := msg.Payload
+		if got := payload["message_id"]; got != msgID {
+			t.Fatalf("placeholder message_id = %#v, want %q", got, msgID)
+		}
+		if got := payload[PayloadKeyContent]; got != "Thinking..." {
+			t.Fatalf("placeholder content = %#v, want %q", got, "Thinking...")
+		}
+		if got, ok := payload[PayloadKeyKind]; ok {
+			t.Fatalf("placeholder kind = %#v, want absent", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected placeholder message to be delivered")
 	}
 }
 

--- a/pkg/channels/pico/protocol.go
+++ b/pkg/channels/pico/protocol.go
@@ -1,6 +1,9 @@
 package pico
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // Protocol message types.
 const (
@@ -47,6 +50,13 @@ func newMessage(msgType string, payload map[string]any) PicoMessage {
 }
 
 func isThoughtPayload(payload map[string]any) bool {
+	kind, _ := payload[PayloadKeyKind].(string)
+	if strings.EqualFold(strings.TrimSpace(kind), MessageKindThought) {
+		return true
+	}
+
+	// Keep pico_client inbound-compatible with legacy servers that still send
+	// the pre-kind boolean thought marker.
 	thought, _ := payload[PayloadKeyThought].(bool)
 	return thought
 }

--- a/web/frontend/src/features/chat/assistant-message-state.ts
+++ b/web/frontend/src/features/chat/assistant-message-state.ts
@@ -19,14 +19,25 @@ export interface AssistantMessageUpdateState {
   toolCalls?: AssistantToolCalls
 }
 
+function normalizeAssistantMessageKind(
+  payload: Record<string, unknown>,
+): string | undefined {
+  if (typeof payload.kind !== "string") {
+    return undefined
+  }
+  const kind = payload.kind.trim().toLowerCase()
+  return kind || undefined
+}
+
 function parseAssistantMessageKind(
   payload: Record<string, unknown>,
   toolCalls?: AssistantToolCalls,
 ): AssistantMessageKind {
-  if (payload.thought === true) {
+  const kind = normalizeAssistantMessageKind(payload)
+  if (kind === "thought") {
     return "thought"
   }
-  if (payload.kind === "tool_calls" || toolCalls) {
+  if (kind === "tool_calls" || toolCalls) {
     return "tool_calls"
   }
   return "normal"
@@ -36,8 +47,7 @@ function hasExplicitAssistantKindPayload(
   payload: Record<string, unknown>,
 ): boolean {
   return (
-    typeof payload.thought === "boolean" ||
-    payload.kind === "tool_calls" ||
+    normalizeAssistantMessageKind(payload) !== undefined ||
     payload.tool_calls !== undefined
   )
 }


### PR DESCRIPTION
## 📝 Description

Unify message kind handling for `tool_calls` and `thought`.

This change makes `thought` use the same protocol shape as `tool_calls`, i.e. `payload.kind = "thought"`, instead of the legacy `payload.thought = true`.

This frontend-side breaking change is intentional. In Pico's current architecture, the web UI is served from backend-embedded assets rather than deployed independently, so frontend/backend version skew is not a primary compatibility target in practice. Keeping legacy frontend parsing for `payload.thought === true` would preserve extra protocol branching and maintenance cost for a case that is uncommon in real usage.

Backend-side compatibility is still preserved for Go client/server interaction, since those are separate binaries and may not always be upgraded in strict lockstep.

## 🗣️ Type of Change
- [x] ⚡ Code refactoring (with internal pico protocol breaking changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🧪 Test Environment
- **Hardware:** Local x64 Server
- **OS:** Ubuntu Server 24
- **Model/Provider:** DeepSeek V4 Flash
- **Channels:** Web

## 📸 Evidence
<details>
<summary>Click to view Logs/Screenshots</summary>

Thought:
<img width="1092" height="262" alt="image" src="https://github.com/user-attachments/assets/9b7a9ac2-08d4-4909-ba33-d7666889f401" />

Tool calls:
<img width="1111" height="276" alt="image" src="https://github.com/user-attachments/assets/6fc61ce5-fc5e-4285-adeb-fd618c565fbc" />

Web:
<img width="1044" height="658" alt="image" src="https://github.com/user-attachments/assets/e511e2db-bc2e-40ee-bde2-8a76d12451bc" />

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.