### PR TITLE
fix(cron): propagate sessionKey to prevent duplicate tool responses

### DIFF
--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -357,7 +357,7 @@ func (t *CronTool) ExecuteJob(ctx context.Context, job *cron.CronJob) string {
 	}
 
 	if response != "" {
-		t.executor.PublishResponseIfNeeded(ctx, channel, chatID, "", response)
+		t.executor.PublishResponseIfNeeded(ctx, channel, chatID, sessionKey, response)
 	}
 	return "ok"
 }

--- a/pkg/tools/cron_test.go
+++ b/pkg/tools/cron_test.go
@@ -24,6 +24,7 @@ type stubJobExecutor struct {
 	publishedResp   string
 	publishedChan   string
 	publishedChatID string
+	publishedKey    string
 }
 
 func (s *stubJobExecutor) ProcessDirectWithChannel(
@@ -47,6 +48,7 @@ func (s *stubJobExecutor) PublishResponseIfNeeded(
 	s.publishedResp = response
 	s.publishedChan = channel
 	s.publishedChatID = chatID
+	s.publishedKey = sessionKey
 }
 
 func newTestCronToolWithExecutorAndConfig(t *testing.T, executor JobExecutor, cfg *config.Config) *CronTool {
@@ -282,6 +284,9 @@ func TestCronTool_ExecuteJobPublishesAgentResponse(t *testing.T) {
 	}
 	if executor.publishedResp != "generated reply" {
 		t.Fatalf("published response = %q, want generated reply", executor.publishedResp)
+	}
+	if executor.publishedKey != executor.lastKey {
+		t.Fatalf("published sessionKey = %q, want %q", executor.publishedKey, executor.lastKey)
 	}
 	if executor.publishedChan != "telegram" || executor.publishedChatID != "chat-1" {
 		t.Fatalf("published target = %s/%s, want telegram/chat-1", executor.publishedChan, executor.publishedChatID)


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where duplicate messages (typically a "success" confirmation following the actual payload) were being sent during cron job executions. 

The issue was caused by the `sessionKey` being dropped in the final step of the cron flow, which prevented the message suppression filter (introduced in v0.2.7) from identifying that a response had already been delivered for that specific session.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

Fixes [https://github.com/sipeed/picoclaw/issues/2687](https://github.com/sipeed/picoclaw/issues/2687)

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** Since v0.2.7, the filter designed to prevent duplicate messages is no longer global; it relies on the `sessionKey` of the current turn (see `pkg/agent/agent_outbound.go:43` and `pkg/tools/integration/message.go:82`). 

In the cron execution flow, while a valid session was created, it was lost at the final stage: `pkg/tools/cron.go` was calling `PublishResponseIfNeeded` with an empty string for the `sessionKey`. This allowed "shadow" responses (e.g., "Already sent weather report to user") to bypass the filter and reach the user. 

**Changes:**
* Updated `pkg/tools/cron.go` to correctly propagate the `sessionKey` to `PublishResponseIfNeeded`.

## 🧪 Test Environment
- **Hardware:**
- **OS:** 
- **Model/Provider:** N/A
- **Channels:**


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Regression tests passed successfully:
```bash
env GOCACHE=/tmp/picoclaw-gocache GOMODCACHE=/tmp/picoclaw-gomodcache GOTMPDIR=/tmp/picoclaw-gotmp go test ./pkg/tools
```
Result: `PASS`

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly (N/A for this fix).