### PR TITLE
fix: block find / from bypassing workspace sandbox (fixes #2688)

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -95,10 +95,12 @@ var (
 		regexp.MustCompile(`\bssh\b.*@`),
 		regexp.MustCompile(`\beval\b`),
 		regexp.MustCompile(`\bsource\s+.*\.sh\b`),
+		regexp.MustCompile(`\bfind\s+/\b`),       // find / - traverse entire filesystem
+		regexp.MustCompile(`\bls\s+/\b`),         // ls / - list root directory
 	}
 
 	// absolutePathPattern matches absolute file paths in commands (Unix and Windows).
-	absolutePathPattern = regexp.MustCompile(`[A-Za-z]:\\[^\\\"']+|/[^\s\"']+`)
+	absolutePathPattern = regexp.MustCompile(`[A-Za-z]:\\[^\\\"']+|/(?:[^\s\"']*)?`)
 
 	// safePaths are kernel pseudo-devices that are always safe to reference in
 	// commands, regardless of workspace restriction. They contain no user data
@@ -111,6 +113,7 @@ var (
 		"/dev/stdin":   true,
 		"/dev/stdout":  true,
 		"/dev/stderr":  true,
+		"/":            true,  // root is a path boundary, not a regular file
 	}
 )
 

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -95,8 +95,8 @@ var (
 		regexp.MustCompile(`\bssh\b.*@`),
 		regexp.MustCompile(`\beval\b`),
 		regexp.MustCompile(`\bsource\s+.*\.sh\b`),
-		regexp.MustCompile(`\bfind\s+/\b`),       // find / - traverse entire filesystem
-		regexp.MustCompile(`\bls\s+/\b`),         // ls / - list root directory
+		regexp.MustCompile(`\bfind\s+/(\s|$)`),   // find / - traverse entire filesystem
+		regexp.MustCompile(`\bls\s+/(\s|$)`),     // ls / - list root directory
 	}
 
 	// absolutePathPattern matches absolute file paths in commands (Unix and Windows).

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -1613,3 +1613,56 @@ func TestEncodeKeyTokenWithPtyKeyMode(t *testing.T) {
 		})
 	}
 }
+
+func TestShellTool_FindRootBlocked(t *testing.T) {
+	tmpDir := t.TempDir()
+	tool, err := NewExecTool(tmpDir, true)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+
+	blocked := []string{
+		"find / -name 'private*' -type f 2>/dev/null",
+		"find /etc -name 'passwd'",
+		"find / -type f -name '*.key'",
+		"ls /",
+		"ls /etc",
+	}
+
+	for _, cmd := range blocked {
+		result := tool.Execute(context.Background(), map[string]any{
+			"action":  "run",
+			"command": cmd,
+		})
+		if !result.IsError {
+			t.Errorf("expected command to be blocked: %s", cmd)
+		}
+		if !strings.Contains(result.ForLLM, "blocked") {
+			t.Errorf("expected 'blocked' message for: %s\ngot: %s", cmd, result.ForLLM)
+		}
+	}
+}
+
+func TestShellTool_FindInWorkspaceAllowed(t *testing.T) {
+	tmpDir := t.TempDir()
+	tool, err := NewExecTool(tmpDir, true)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+
+	allowed := []string{
+		"find . -name '*.go'",
+		"find -name '*.txt'",
+		"echo hello",
+	}
+
+	for _, cmd := range allowed {
+		result := tool.Execute(context.Background(), map[string]any{
+			"action":  "run",
+			"command": cmd,
+		})
+		if result.IsError && strings.Contains(result.ForLLM, "blocked") {
+			t.Errorf("command should not be blocked: %s\n  error: %s", cmd, result.ForLLM)
+		}
+	}
+}


### PR DESCRIPTION
## Description

The `guardCommand()` safety guard in `pkg/tools/shell.go` uses the regex `absolutePathPattern = /[^\s"']+/` to find absolute paths in commands. This regex requires at least one character after the leading `/` (the `+` quantifier), so a bare `/` (filesystem root) is never matched.

Commands like `find / -name foo` pass through with zero path matches, bypassing the workspace restriction entirely.

## Fix

1. **Change regex** to `/(?:[^\s"']*)?` making the path portion optional
2. **Skip bare "/"** from workspace path check (it's root, not a file)
3. **Add deny patterns** for `find /` and `ls /` as defense-in-depth

## Testing

- `TestShellTool_FindRootBlocked` - verifies `find /`, `find /etc`, `ls /`, `ls /etc` are blocked
- `TestShellTool_FindInWorkspaceAllowed` - verifies `find .`, `find -name`, `echo hello` still work

Fixes #2688