### PR TITLE
feat(mcp): support per-request dynamic headers from channel context

### DIFF
--- a/pkg/agent/agent_utils.go
+++ b/pkg/agent/agent_utils.go
@@ -47,7 +47,11 @@ func withMCPHeadersFromRaw(ctx context.Context, raw map[string]string) context.C
 	var headers map[string]string
 	for k, v := range raw {
 		after, ok := strings.CutPrefix(k, "mcp:")
-		if !ok || after == "" {
+		if !ok {
+			continue
+		}
+		after = strings.TrimSpace(after)
+		if after == "" {
 			continue
 		}
 		if headers == nil {

--- a/pkg/agent/agent_utils.go
+++ b/pkg/agent/agent_utils.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/config"
 	"github.com/sipeed/picoclaw/pkg/providers"
 	"github.com/sipeed/picoclaw/pkg/session"
+	"github.com/sipeed/picoclaw/pkg/tools"
 	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
@@ -37,6 +38,27 @@ func outboundContextFromInbound(
 		outboundCtx.ReplyToMessageID = replyToMessageID
 	}
 	return outboundCtx
+}
+
+func withMCPHeadersFromRaw(ctx context.Context, raw map[string]string) context.Context {
+	if len(raw) == 0 {
+		return ctx
+	}
+	var headers map[string]string
+	for k, v := range raw {
+		after, ok := strings.CutPrefix(k, "mcp:")
+		if !ok || after == "" {
+			continue
+		}
+		if headers == nil {
+			headers = make(map[string]string)
+		}
+		headers[after] = v
+	}
+	if len(headers) == 0 {
+		return ctx
+	}
+	return tools.WithMCPHeaders(ctx, headers)
 }
 
 func outboundScopeFromSessionScope(scope *session.SessionScope) *bus.OutboundScope {

--- a/pkg/agent/pipeline_execute.go
+++ b/pkg/agent/pipeline_execute.go
@@ -436,6 +436,9 @@ toolLoop:
 			ts.sessionKey,
 			ts.opts.Dispatch.SessionScope,
 		)
+		if inbound := ts.opts.Dispatch.InboundContext; inbound != nil {
+			execCtx = withMCPHeadersFromRaw(execCtx, inbound.Raw)
+		}
 		toolResult := ts.agent.Tools.ExecuteWithContext(
 			execCtx,
 			toolName,

--- a/pkg/agent/pipeline_execute.go
+++ b/pkg/agent/pipeline_execute.go
@@ -572,6 +572,9 @@ toolLoop:
 			ts.sessionKey,
 			ts.opts.Dispatch.SessionScope,
 		)
+		if inbound := ts.opts.Dispatch.InboundContext; inbound != nil {
+			execCtx = withMCPHeadersFromRaw(execCtx, inbound.Raw)
+		}
 		toolResult := ts.agent.Tools.ExecuteWithContext(
 			execCtx,
 			toolName,

--- a/pkg/channels/pico/pico.go
+++ b/pkg/channels/pico/pico.go
@@ -948,6 +948,14 @@ func (c *PicoChannel) handleMessageSend(pc *picoConn, msg PicoMessage) {
 		"conn_id":    pc.id,
 	}
 
+	if payloadMeta, ok := msg.Payload["metadata"].(map[string]any); ok {
+		for k, v := range payloadMeta {
+			if s, ok := v.(string); ok && s != "" {
+				metadata[k] = s
+			}
+		}
+	}
+
 	logger.DebugCF("pico", "Received message", map[string]any{
 		"session_id": sessionID,
 		"preview":    truncate(content, 50),

--- a/pkg/channels/pico/pico.go
+++ b/pkg/channels/pico/pico.go
@@ -44,6 +44,23 @@ var allowedInlineImageMIMETypes = map[string]struct{}{
 	"image/bmp":  {},
 }
 
+// reservedRawKeys are internal metadata keys that cannot be overwritten by client-provided metadata.
+// This prevents clients from spoofing internal identity or session information.
+var reservedRawKeys = map[string]struct{}{
+	"platform":     {},
+	"session_id":   {},
+	"conn_id":      {},
+	"message_id":   {},
+	"sender_id":    {},
+	"chat_id":      {},
+	"message_kind": {},
+}
+
+func isReservedRawKey(key string) bool {
+	_, reserved := reservedRawKeys[key]
+	return reserved
+}
+
 func outboundMessageIsThought(msg bus.OutboundMessage) bool {
 	if len(msg.Context.Raw) == 0 {
 		return false
@@ -951,6 +968,9 @@ func (c *PicoChannel) handleMessageSend(pc *picoConn, msg PicoMessage) {
 	if payloadMeta, ok := msg.Payload["metadata"].(map[string]any); ok {
 		for k, v := range payloadMeta {
 			if s, ok := v.(string); ok && s != "" {
+				if isReservedRawKey(k) {
+					continue
+				}
 				metadata[k] = s
 			}
 		}

--- a/pkg/channels/pico/pico.go
+++ b/pkg/channels/pico/pico.go
@@ -1201,6 +1201,14 @@ func (c *PicoChannel) handleMessageSend(pc *picoConn, msg PicoMessage) {
 		"conn_id":    pc.id,
 	}
 
+	if payloadMeta, ok := msg.Payload["metadata"].(map[string]any); ok {
+		for k, v := range payloadMeta {
+			if s, ok := v.(string); ok && s != "" {
+				metadata[k] = s
+			}
+		}
+	}
+
 	logger.DebugCF("pico", "Received message", map[string]any{
 		"session_id": sessionID,
 		"preview":    truncate(content, 50),

--- a/pkg/channels/pico/pico.go
+++ b/pkg/channels/pico/pico.go
@@ -44,6 +44,23 @@ var allowedInlineImageMIMETypes = map[string]struct{}{
 	"image/bmp":  {},
 }
 
+// reservedRawKeys are internal metadata keys that cannot be overwritten by client-provided metadata.
+// This prevents clients from spoofing internal identity or session information.
+var reservedRawKeys = map[string]struct{}{
+	"platform":     {},
+	"session_id":   {},
+	"conn_id":      {},
+	"message_id":   {},
+	"sender_id":    {},
+	"chat_id":      {},
+	"message_kind": {},
+}
+
+func isReservedRawKey(key string) bool {
+	_, reserved := reservedRawKeys[key]
+	return reserved
+}
+
 func outboundMessageIsThought(msg bus.OutboundMessage) bool {
 	if len(msg.Context.Raw) == 0 {
 		return false
@@ -1204,6 +1221,9 @@ func (c *PicoChannel) handleMessageSend(pc *picoConn, msg PicoMessage) {
 	if payloadMeta, ok := msg.Payload["metadata"].(map[string]any); ok {
 		for k, v := range payloadMeta {
 			if s, ok := v.(string); ok && s != "" {
+				if isReservedRawKey(k) {
+					continue
+				}
 				metadata[k] = s
 			}
 		}

--- a/pkg/channels/pico/pico_test.go
+++ b/pkg/channels/pico/pico_test.go
@@ -547,3 +547,32 @@ func newTestPicoWebSocket(t *testing.T) (*websocket.Conn, <-chan PicoMessage, fu
 	defer resp.Body.Close()
 	return clientConn, received, cleanup
 }
+
+func TestIsReservedRawKey(t *testing.T) {
+	reserved := []string{
+		"platform",
+		"session_id",
+		"conn_id",
+		"message_id",
+		"sender_id",
+		"chat_id",
+		"message_kind",
+	}
+	for _, key := range reserved {
+		if !isReservedRawKey(key) {
+			t.Errorf("isReservedRawKey(%q) = false, want true", key)
+		}
+	}
+
+	allowed := []string{
+		"mcp:Authorization",
+		"mcp:X-Custom-Header",
+		"custom_field",
+		"user_data",
+	}
+	for _, key := range allowed {
+		if isReservedRawKey(key) {
+			t.Errorf("isReservedRawKey(%q) = true, want false", key)
+		}
+	}
+}

--- a/pkg/channels/pico/pico_test.go
+++ b/pkg/channels/pico/pico_test.go
@@ -962,3 +962,32 @@ func newTestPicoWebSocket(t *testing.T) (*websocket.Conn, <-chan PicoMessage, fu
 	defer resp.Body.Close()
 	return clientConn, received, cleanup
 }
+
+func TestIsReservedRawKey(t *testing.T) {
+	reserved := []string{
+		"platform",
+		"session_id",
+		"conn_id",
+		"message_id",
+		"sender_id",
+		"chat_id",
+		"message_kind",
+	}
+	for _, key := range reserved {
+		if !isReservedRawKey(key) {
+			t.Errorf("isReservedRawKey(%q) = false, want true", key)
+		}
+	}
+
+	allowed := []string{
+		"mcp:Authorization",
+		"mcp:X-Custom-Header",
+		"custom_field",
+		"user_data",
+	}
+	for _, key := range allowed {
+		if isReservedRawKey(key) {
+			t.Errorf("isReservedRawKey(%q) = true, want false", key)
+		}
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -953,6 +953,35 @@ func (c *SkillRegistryConfig) DecodeParam(target any) error {
 	return json.Unmarshal(data, target)
 }
 
+// DynamicHeadersConfig controls which headers can be forwarded from channel context to MCP servers.
+// By default (when nil or empty), no dynamic headers are allowed - this is secure by default.
+type DynamicHeadersConfig struct {
+	// Allowed is a list of header names that may be forwarded from channel context.
+	// Only headers explicitly listed here will be passed to this MCP server.
+	// Header names are matched case-insensitively.
+	Allowed []string `json:"allowed,omitempty"`
+	// MaxCount limits the number of dynamic headers per request (default: 10).
+	MaxCount int `json:"max_count,omitempty"`
+	// MaxValueLen limits the maximum length of each header value (default: 4096).
+	MaxValueLen int `json:"max_value_len,omitempty"`
+}
+
+// GetMaxCount returns the max header count, defaulting to 10.
+func (c *DynamicHeadersConfig) GetMaxCount() int {
+	if c == nil || c.MaxCount <= 0 {
+		return 10
+	}
+	return c.MaxCount
+}
+
+// GetMaxValueLen returns the max value length, defaulting to 4096.
+func (c *DynamicHeadersConfig) GetMaxValueLen() int {
+	if c == nil || c.MaxValueLen <= 0 {
+		return 4096
+	}
+	return c.MaxValueLen
+}
+
 // MCPServerConfig defines configuration for a single MCP server
 type MCPServerConfig struct {
 	// Enabled indicates whether this MCP server is active
@@ -975,6 +1004,9 @@ type MCPServerConfig struct {
 	URL string `json:"url,omitempty"`
 	// Headers are HTTP headers to send with requests (sse/http only)
 	Headers map[string]string `json:"headers,omitempty"`
+	// DynamicHeaders controls which headers from channel context can be forwarded to this server.
+	// When nil or empty, no dynamic headers are allowed (secure by default).
+	DynamicHeaders *DynamicHeadersConfig `json:"dynamic_headers,omitempty"`
 }
 
 // MCPConfig defines configuration for all MCP servers

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1139,6 +1139,35 @@ func (c *SkillRegistryConfig) DecodeParam(target any) error {
 	return json.Unmarshal(data, target)
 }
 
+// DynamicHeadersConfig controls which headers can be forwarded from channel context to MCP servers.
+// By default (when nil or empty), no dynamic headers are allowed - this is secure by default.
+type DynamicHeadersConfig struct {
+	// Allowed is a list of header names that may be forwarded from channel context.
+	// Only headers explicitly listed here will be passed to this MCP server.
+	// Header names are matched case-insensitively.
+	Allowed []string `json:"allowed,omitempty"`
+	// MaxCount limits the number of dynamic headers per request (default: 10).
+	MaxCount int `json:"max_count,omitempty"`
+	// MaxValueLen limits the maximum length of each header value (default: 4096).
+	MaxValueLen int `json:"max_value_len,omitempty"`
+}
+
+// GetMaxCount returns the max header count, defaulting to 10.
+func (c *DynamicHeadersConfig) GetMaxCount() int {
+	if c == nil || c.MaxCount <= 0 {
+		return 10
+	}
+	return c.MaxCount
+}
+
+// GetMaxValueLen returns the max value length, defaulting to 4096.
+func (c *DynamicHeadersConfig) GetMaxValueLen() int {
+	if c == nil || c.MaxValueLen <= 0 {
+		return 4096
+	}
+	return c.MaxValueLen
+}
+
 // MCPServerConfig defines configuration for a single MCP server
 type MCPServerConfig struct {
 	// Enabled indicates whether this MCP server is active
@@ -1165,6 +1194,9 @@ type MCPServerConfig struct {
 	URL string `json:"url,omitempty"`
 	// Headers are HTTP headers to send with requests (sse/http only)
 	Headers map[string]string `json:"headers,omitempty"`
+	// DynamicHeaders controls which headers from channel context can be forwarded to this server.
+	// When nil or empty, no dynamic headers are allowed (secure by default).
+	DynamicHeaders *DynamicHeadersConfig `json:"dynamic_headers,omitempty"`
 }
 
 // MCPConfig defines configuration for all MCP servers

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -23,8 +23,9 @@ import (
 
 // headerTransport is an http.RoundTripper that adds custom headers to requests
 type headerTransport struct {
-	base    http.RoundTripper
-	headers map[string]string
+	base           http.RoundTripper
+	headers        map[string]string
+	dynamicHeaders *config.DynamicHeadersConfig
 }
 
 func expandHomeCommandPath(command string) string {
@@ -51,7 +52,8 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		req.Header.Set(key, value)
 	}
 	if dynamic := toolshared.MCPHeaders(req.Context()); len(dynamic) > 0 {
-		for key, value := range dynamic {
+		filtered := t.filterDynamicHeaders(dynamic)
+		for key, value := range filtered {
 			req.Header.Set(key, value)
 		}
 	}
@@ -60,6 +62,39 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		base = http.DefaultTransport
 	}
 	return base.RoundTrip(req)
+}
+
+// filterDynamicHeaders applies the allowlist and limits from DynamicHeadersConfig.
+// Returns nil if no dynamic headers config is set (secure by default).
+func (t *headerTransport) filterDynamicHeaders(headers map[string]string) map[string]string {
+	if t.dynamicHeaders == nil || len(t.dynamicHeaders.Allowed) == 0 {
+		return nil
+	}
+
+	allowedSet := make(map[string]struct{}, len(t.dynamicHeaders.Allowed))
+	for _, h := range t.dynamicHeaders.Allowed {
+		allowedSet[strings.ToLower(h)] = struct{}{}
+	}
+
+	maxCount := t.dynamicHeaders.GetMaxCount()
+	maxValueLen := t.dynamicHeaders.GetMaxValueLen()
+
+	result := make(map[string]string)
+	count := 0
+	for key, value := range headers {
+		if count >= maxCount {
+			break
+		}
+		if _, ok := allowedSet[strings.ToLower(key)]; !ok {
+			continue
+		}
+		if len(value) > maxValueLen {
+			value = value[:maxValueLen]
+		}
+		result[key] = value
+		count++
+	}
+	return result
 }
 
 // loadEnvFile loads environment variables from a file in .env format
@@ -384,8 +419,9 @@ func connectServer(
 
 		sseTransport.HTTPClient = &http.Client{
 			Transport: &headerTransport{
-				base:    http.DefaultTransport,
-				headers: cfg.Headers,
+				base:           http.DefaultTransport,
+				headers:        cfg.Headers,
+				dynamicHeaders: cfg.DynamicHeaders,
 			},
 		}
 		if len(cfg.Headers) > 0 {

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/config"
 	runtimeevents "github.com/sipeed/picoclaw/pkg/events"
 	"github.com/sipeed/picoclaw/pkg/logger"
+	toolshared "github.com/sipeed/picoclaw/pkg/tools/shared"
 )
 
 // headerTransport is an http.RoundTripper that adds custom headers to requests
@@ -45,15 +46,15 @@ func expandHomeCommandPath(command string) string {
 }
 
 func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Clone the request to avoid modifying the original
 	req = req.Clone(req.Context())
-
-	// Add custom headers
 	for key, value := range t.headers {
 		req.Header.Set(key, value)
 	}
-
-	// Use the base transport
+	if dynamic := toolshared.MCPHeaders(req.Context()); len(dynamic) > 0 {
+		for key, value := range dynamic {
+			req.Header.Set(key, value)
+		}
+	}
 	base := t.base
 	if base == nil {
 		base = http.DefaultTransport
@@ -381,15 +382,13 @@ func connectServer(
 			DisableStandaloneSSE: disableStandaloneSSE,
 		}
 
-		// Add custom headers if provided
+		sseTransport.HTTPClient = &http.Client{
+			Transport: &headerTransport{
+				base:    http.DefaultTransport,
+				headers: cfg.Headers,
+			},
+		}
 		if len(cfg.Headers) > 0 {
-			// Create a custom HTTP client with header-injecting transport
-			sseTransport.HTTPClient = &http.Client{
-				Transport: &headerTransport{
-					base:    http.DefaultTransport,
-					headers: cfg.Headers,
-				},
-			}
 			logger.DebugCF("mcp", "Added custom HTTP headers",
 				map[string]any{
 					"server":       name,

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -23,8 +23,9 @@ import (
 
 // headerTransport is an http.RoundTripper that adds custom headers to requests
 type headerTransport struct {
-	base    http.RoundTripper
-	headers map[string]string
+	base           http.RoundTripper
+	headers        map[string]string
+	dynamicHeaders *config.DynamicHeadersConfig
 }
 
 func expandHomeCommandPath(command string) string {
@@ -51,7 +52,8 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		req.Header.Set(key, value)
 	}
 	if dynamic := toolshared.MCPHeaders(req.Context()); len(dynamic) > 0 {
-		for key, value := range dynamic {
+		filtered := t.filterDynamicHeaders(dynamic)
+		for key, value := range filtered {
 			req.Header.Set(key, value)
 		}
 	}
@@ -60,6 +62,39 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		base = http.DefaultTransport
 	}
 	return base.RoundTrip(req)
+}
+
+// filterDynamicHeaders applies the allowlist and limits from DynamicHeadersConfig.
+// Returns nil if no dynamic headers config is set (secure by default).
+func (t *headerTransport) filterDynamicHeaders(headers map[string]string) map[string]string {
+	if t.dynamicHeaders == nil || len(t.dynamicHeaders.Allowed) == 0 {
+		return nil
+	}
+
+	allowedSet := make(map[string]struct{}, len(t.dynamicHeaders.Allowed))
+	for _, h := range t.dynamicHeaders.Allowed {
+		allowedSet[strings.ToLower(h)] = struct{}{}
+	}
+
+	maxCount := t.dynamicHeaders.GetMaxCount()
+	maxValueLen := t.dynamicHeaders.GetMaxValueLen()
+
+	result := make(map[string]string)
+	count := 0
+	for key, value := range headers {
+		if count >= maxCount {
+			break
+		}
+		if _, ok := allowedSet[strings.ToLower(key)]; !ok {
+			continue
+		}
+		if len(value) > maxValueLen {
+			value = value[:maxValueLen]
+		}
+		result[key] = value
+		count++
+	}
+	return result
 }
 
 // loadEnvFile loads environment variables from a file in .env format
@@ -377,8 +412,9 @@ func connectServer(
 
 		sseTransport.HTTPClient = &http.Client{
 			Transport: &headerTransport{
-				base:    http.DefaultTransport,
-				headers: cfg.Headers,
+				base:           http.DefaultTransport,
+				headers:        cfg.Headers,
+				dynamicHeaders: cfg.DynamicHeaders,
 			},
 		}
 		if len(cfg.Headers) > 0 {

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/config"
 	runtimeevents "github.com/sipeed/picoclaw/pkg/events"
 	"github.com/sipeed/picoclaw/pkg/logger"
+	toolshared "github.com/sipeed/picoclaw/pkg/tools/shared"
 )
 
 // headerTransport is an http.RoundTripper that adds custom headers to requests
@@ -45,15 +46,15 @@ func expandHomeCommandPath(command string) string {
 }
 
 func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Clone the request to avoid modifying the original
 	req = req.Clone(req.Context())
-
-	// Add custom headers
 	for key, value := range t.headers {
 		req.Header.Set(key, value)
 	}
-
-	// Use the base transport
+	if dynamic := toolshared.MCPHeaders(req.Context()); len(dynamic) > 0 {
+		for key, value := range dynamic {
+			req.Header.Set(key, value)
+		}
+	}
 	base := t.base
 	if base == nil {
 		base = http.DefaultTransport
@@ -374,15 +375,13 @@ func connectServer(
 			DisableStandaloneSSE: disableStandaloneSSE,
 		}
 
-		// Add custom headers if provided
+		sseTransport.HTTPClient = &http.Client{
+			Transport: &headerTransport{
+				base:    http.DefaultTransport,
+				headers: cfg.Headers,
+			},
+		}
 		if len(cfg.Headers) > 0 {
-			// Create a custom HTTP client with header-injecting transport
-			sseTransport.HTTPClient = &http.Client{
-				Transport: &headerTransport{
-					base:    http.DefaultTransport,
-					headers: cfg.Headers,
-				},
-			}
 			logger.DebugCF("mcp", "Added custom HTTP headers",
 				map[string]any{
 					"server":       name,

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -651,10 +651,11 @@ func TestHeaderTransport_DynamicHeaders(t *testing.T) {
 	})
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
 
-	_, err := transport.RoundTrip(req)
+	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		t.Fatalf("RoundTrip() error = %v", err)
 	}
+	resp.Body.Close()
 
 	if got := captured.Get("X-Static"); got != "from-config" {
 		t.Errorf("X-Static = %q, want %q", got, "from-config")
@@ -686,10 +687,11 @@ func TestHeaderTransport_DynamicOverridesStatic(t *testing.T) {
 	})
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
 
-	_, err := transport.RoundTrip(req)
+	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		t.Fatalf("RoundTrip() error = %v", err)
 	}
+	resp.Body.Close()
 
 	if got := captured.Get("Authorization"); got != "Bearer dynamic" {
 		t.Errorf("Authorization = %q, want dynamic to override static %q", got, "Bearer dynamic")
@@ -711,10 +713,11 @@ func TestHeaderTransport_NoDynamicHeaders(t *testing.T) {
 	}
 
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", nil)
-	_, err := transport.RoundTrip(req)
+	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		t.Fatalf("RoundTrip() error = %v", err)
 	}
+	resp.Body.Close()
 
 	if got := captured.Get("X-Static"); got != "val" {
 		t.Errorf("X-Static = %q, want %q", got, "val")

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/sipeed/picoclaw/pkg/config"
 	runtimeevents "github.com/sipeed/picoclaw/pkg/events"
+	toolshared "github.com/sipeed/picoclaw/pkg/tools/shared"
 )
 
 func TestLoadEnvFile(t *testing.T) {
@@ -627,4 +629,103 @@ func (t *scriptedTransport) Close() error {
 
 func (t *scriptedTransport) SessionID() string {
 	return t.sessionID
+}
+
+func TestHeaderTransport_DynamicHeaders(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base:    base,
+		headers: map[string]string{"X-Static": "from-config"},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"Authorization": "Bearer tok123",
+		"X-Custom":      "dynamic-val",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	_, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+
+	if got := captured.Get("X-Static"); got != "from-config" {
+		t.Errorf("X-Static = %q, want %q", got, "from-config")
+	}
+	if got := captured.Get("Authorization"); got != "Bearer tok123" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer tok123")
+	}
+	if got := captured.Get("X-Custom"); got != "dynamic-val" {
+		t.Errorf("X-Custom = %q, want %q", got, "dynamic-val")
+	}
+}
+
+func TestHeaderTransport_DynamicOverridesStatic(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base:    base,
+		headers: map[string]string{"Authorization": "Bearer static"},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"Authorization": "Bearer dynamic",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	_, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+
+	if got := captured.Get("Authorization"); got != "Bearer dynamic" {
+		t.Errorf("Authorization = %q, want dynamic to override static %q", got, "Bearer dynamic")
+	}
+}
+
+func TestHeaderTransport_NoDynamicHeaders(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base:    base,
+		headers: map[string]string{"X-Static": "val"},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", nil)
+	_, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+
+	if got := captured.Get("X-Static"); got != "val" {
+		t.Errorf("X-Static = %q, want %q", got, "val")
+	}
+	if got := captured.Get("Authorization"); got != "" {
+		t.Errorf("Authorization should be empty, got %q", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -643,6 +643,9 @@ func TestHeaderTransport_DynamicHeaders(t *testing.T) {
 	transport := &headerTransport{
 		base:    base,
 		headers: map[string]string{"X-Static": "from-config"},
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed: []string{"Authorization", "X-Custom"},
+		},
 	}
 
 	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
@@ -680,6 +683,9 @@ func TestHeaderTransport_DynamicOverridesStatic(t *testing.T) {
 	transport := &headerTransport{
 		base:    base,
 		headers: map[string]string{"Authorization": "Bearer static"},
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed: []string{"Authorization"},
+		},
 	}
 
 	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
@@ -724,6 +730,195 @@ func TestHeaderTransport_NoDynamicHeaders(t *testing.T) {
 	}
 	if got := captured.Get("Authorization"); got != "" {
 		t.Errorf("Authorization should be empty, got %q", got)
+	}
+}
+
+func TestHeaderTransport_NoAllowlist_BlocksDynamic(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	// No dynamicHeaders config = secure by default, blocks all dynamic headers
+	transport := &headerTransport{
+		base:    base,
+		headers: map[string]string{"X-Static": "val"},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"Authorization": "Bearer should-be-blocked",
+		"X-Custom":      "also-blocked",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	resp.Body.Close()
+
+	if got := captured.Get("X-Static"); got != "val" {
+		t.Errorf("X-Static = %q, want %q", got, "val")
+	}
+	if got := captured.Get("Authorization"); got != "" {
+		t.Errorf("Authorization should be blocked without allowlist, got %q", got)
+	}
+	if got := captured.Get("X-Custom"); got != "" {
+		t.Errorf("X-Custom should be blocked without allowlist, got %q", got)
+	}
+}
+
+func TestHeaderTransport_AllowlistFilters(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base: base,
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed: []string{"X-Allowed-Header"},
+		},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"X-Allowed-Header": "this-passes",
+		"X-Blocked-Header": "this-is-blocked",
+		"Authorization":    "also-blocked",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	resp.Body.Close()
+
+	if got := captured.Get("X-Allowed-Header"); got != "this-passes" {
+		t.Errorf("X-Allowed-Header = %q, want %q", got, "this-passes")
+	}
+	if got := captured.Get("X-Blocked-Header"); got != "" {
+		t.Errorf("X-Blocked-Header should be blocked, got %q", got)
+	}
+	if got := captured.Get("Authorization"); got != "" {
+		t.Errorf("Authorization should be blocked, got %q", got)
+	}
+}
+
+func TestHeaderTransport_AllowlistCaseInsensitive(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base: base,
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed: []string{"X-Grafana-Token"}, // lowercase in allowlist
+		},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"x-grafana-token": "token-value", // different case in request
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	resp.Body.Close()
+
+	if got := captured.Get("X-Grafana-Token"); got != "token-value" {
+		t.Errorf("X-Grafana-Token = %q, want %q (case-insensitive match)", got, "token-value")
+	}
+}
+
+func TestHeaderTransport_MaxCountLimit(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base: base,
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed:  []string{"X-Header-1", "X-Header-2", "X-Header-3"},
+			MaxCount: 2,
+		},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"X-Header-1": "val1",
+		"X-Header-2": "val2",
+		"X-Header-3": "val3",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	resp.Body.Close()
+
+	// Only 2 headers should be set (MaxCount=2), but we can't predict which due to map iteration order
+	count := 0
+	for _, h := range []string{"X-Header-1", "X-Header-2", "X-Header-3"} {
+		if captured.Get(h) != "" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("Expected exactly 2 headers due to MaxCount=2, got %d", count)
+	}
+}
+
+func TestHeaderTransport_MaxValueLenLimit(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base: base,
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed:     []string{"X-Long-Header"},
+			MaxValueLen: 10,
+		},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"X-Long-Header": "this-value-is-way-too-long-and-should-be-truncated",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	resp.Body.Close()
+
+	got := captured.Get("X-Long-Header")
+	if len(got) != 10 {
+		t.Errorf("X-Long-Header length = %d, want 10 (truncated)", len(got))
+	}
+	if got != "this-value" {
+		t.Errorf("X-Long-Header = %q, want %q", got, "this-value")
 	}
 }
 

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sipeed/picoclaw/pkg/config"
 	runtimeevents "github.com/sipeed/picoclaw/pkg/events"
+	toolshared "github.com/sipeed/picoclaw/pkg/tools/shared"
 )
 
 func TestLoadEnvFile(t *testing.T) {
@@ -756,4 +757,103 @@ func (t *scriptedTransport) Close() error {
 
 func (t *scriptedTransport) SessionID() string {
 	return t.sessionID
+}
+
+func TestHeaderTransport_DynamicHeaders(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base:    base,
+		headers: map[string]string{"X-Static": "from-config"},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"Authorization": "Bearer tok123",
+		"X-Custom":      "dynamic-val",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	_, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+
+	if got := captured.Get("X-Static"); got != "from-config" {
+		t.Errorf("X-Static = %q, want %q", got, "from-config")
+	}
+	if got := captured.Get("Authorization"); got != "Bearer tok123" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer tok123")
+	}
+	if got := captured.Get("X-Custom"); got != "dynamic-val" {
+		t.Errorf("X-Custom = %q, want %q", got, "dynamic-val")
+	}
+}
+
+func TestHeaderTransport_DynamicOverridesStatic(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base:    base,
+		headers: map[string]string{"Authorization": "Bearer static"},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"Authorization": "Bearer dynamic",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	_, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+
+	if got := captured.Get("Authorization"); got != "Bearer dynamic" {
+		t.Errorf("Authorization = %q, want dynamic to override static %q", got, "Bearer dynamic")
+	}
+}
+
+func TestHeaderTransport_NoDynamicHeaders(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base:    base,
+		headers: map[string]string{"X-Static": "val"},
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", nil)
+	_, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+
+	if got := captured.Get("X-Static"); got != "val" {
+		t.Errorf("X-Static = %q, want %q", got, "val")
+	}
+	if got := captured.Get("Authorization"); got != "" {
+		t.Errorf("Authorization should be empty, got %q", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -779,10 +779,11 @@ func TestHeaderTransport_DynamicHeaders(t *testing.T) {
 	})
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
 
-	_, err := transport.RoundTrip(req)
+	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		t.Fatalf("RoundTrip() error = %v", err)
 	}
+	resp.Body.Close()
 
 	if got := captured.Get("X-Static"); got != "from-config" {
 		t.Errorf("X-Static = %q, want %q", got, "from-config")
@@ -814,10 +815,11 @@ func TestHeaderTransport_DynamicOverridesStatic(t *testing.T) {
 	})
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
 
-	_, err := transport.RoundTrip(req)
+	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		t.Fatalf("RoundTrip() error = %v", err)
 	}
+	resp.Body.Close()
 
 	if got := captured.Get("Authorization"); got != "Bearer dynamic" {
 		t.Errorf("Authorization = %q, want dynamic to override static %q", got, "Bearer dynamic")
@@ -839,10 +841,11 @@ func TestHeaderTransport_NoDynamicHeaders(t *testing.T) {
 	}
 
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", nil)
-	_, err := transport.RoundTrip(req)
+	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		t.Fatalf("RoundTrip() error = %v", err)
 	}
+	resp.Body.Close()
 
 	if got := captured.Get("X-Static"); got != "val" {
 		t.Errorf("X-Static = %q, want %q", got, "val")

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -771,6 +771,9 @@ func TestHeaderTransport_DynamicHeaders(t *testing.T) {
 	transport := &headerTransport{
 		base:    base,
 		headers: map[string]string{"X-Static": "from-config"},
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed: []string{"Authorization", "X-Custom"},
+		},
 	}
 
 	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
@@ -808,6 +811,9 @@ func TestHeaderTransport_DynamicOverridesStatic(t *testing.T) {
 	transport := &headerTransport{
 		base:    base,
 		headers: map[string]string{"Authorization": "Bearer static"},
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed: []string{"Authorization"},
+		},
 	}
 
 	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
@@ -852,6 +858,195 @@ func TestHeaderTransport_NoDynamicHeaders(t *testing.T) {
 	}
 	if got := captured.Get("Authorization"); got != "" {
 		t.Errorf("Authorization should be empty, got %q", got)
+	}
+}
+
+func TestHeaderTransport_NoAllowlist_BlocksDynamic(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	// No dynamicHeaders config = secure by default, blocks all dynamic headers
+	transport := &headerTransport{
+		base:    base,
+		headers: map[string]string{"X-Static": "val"},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"Authorization": "Bearer should-be-blocked",
+		"X-Custom":      "also-blocked",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	resp.Body.Close()
+
+	if got := captured.Get("X-Static"); got != "val" {
+		t.Errorf("X-Static = %q, want %q", got, "val")
+	}
+	if got := captured.Get("Authorization"); got != "" {
+		t.Errorf("Authorization should be blocked without allowlist, got %q", got)
+	}
+	if got := captured.Get("X-Custom"); got != "" {
+		t.Errorf("X-Custom should be blocked without allowlist, got %q", got)
+	}
+}
+
+func TestHeaderTransport_AllowlistFilters(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base: base,
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed: []string{"X-Allowed-Header"},
+		},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"X-Allowed-Header": "this-passes",
+		"X-Blocked-Header": "this-is-blocked",
+		"Authorization":    "also-blocked",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	resp.Body.Close()
+
+	if got := captured.Get("X-Allowed-Header"); got != "this-passes" {
+		t.Errorf("X-Allowed-Header = %q, want %q", got, "this-passes")
+	}
+	if got := captured.Get("X-Blocked-Header"); got != "" {
+		t.Errorf("X-Blocked-Header should be blocked, got %q", got)
+	}
+	if got := captured.Get("Authorization"); got != "" {
+		t.Errorf("Authorization should be blocked, got %q", got)
+	}
+}
+
+func TestHeaderTransport_AllowlistCaseInsensitive(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base: base,
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed: []string{"X-Grafana-Token"}, // lowercase in allowlist
+		},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"x-grafana-token": "token-value", // different case in request
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	resp.Body.Close()
+
+	if got := captured.Get("X-Grafana-Token"); got != "token-value" {
+		t.Errorf("X-Grafana-Token = %q, want %q (case-insensitive match)", got, "token-value")
+	}
+}
+
+func TestHeaderTransport_MaxCountLimit(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base: base,
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed:  []string{"X-Header-1", "X-Header-2", "X-Header-3"},
+			MaxCount: 2,
+		},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"X-Header-1": "val1",
+		"X-Header-2": "val2",
+		"X-Header-3": "val3",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	resp.Body.Close()
+
+	// Only 2 headers should be set (MaxCount=2), but we can't predict which due to map iteration order
+	count := 0
+	for _, h := range []string{"X-Header-1", "X-Header-2", "X-Header-3"} {
+		if captured.Get(h) != "" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("Expected exactly 2 headers due to MaxCount=2, got %d", count)
+	}
+}
+
+func TestHeaderTransport_MaxValueLenLimit(t *testing.T) {
+	captured := make(http.Header)
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		for k, v := range req.Header {
+			captured[k] = v
+		}
+		return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+	})
+
+	transport := &headerTransport{
+		base: base,
+		dynamicHeaders: &config.DynamicHeadersConfig{
+			Allowed:     []string{"X-Long-Header"},
+			MaxValueLen: 10,
+		},
+	}
+
+	ctx := toolshared.WithMCPHeaders(context.Background(), map[string]string{
+		"X-Long-Header": "this-value-is-way-too-long-and-should-be-truncated",
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example.com", nil)
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	resp.Body.Close()
+
+	got := captured.Get("X-Long-Header")
+	if len(got) != 10 {
+		t.Errorf("X-Long-Header length = %d, want 10 (truncated)", len(got))
+	}
+	if got != "this-value" {
+		t.Errorf("X-Long-Header = %q, want %q", got, "this-value")
 	}
 }
 

--- a/pkg/tools/shared/base.go
+++ b/pkg/tools/shared/base.go
@@ -132,14 +132,30 @@ func ToolSessionScope(ctx context.Context) *session.SessionScope {
 }
 
 // WithMCPHeaders returns a child context carrying per-request headers for MCP HTTP transports.
+// The map is cloned to prevent callers from mutating it after storage.
 func WithMCPHeaders(ctx context.Context, headers map[string]string) context.Context {
-	return context.WithValue(ctx, ctxKeyMCPHeaders, headers)
+	if len(headers) == 0 {
+		return ctx
+	}
+	clone := make(map[string]string, len(headers))
+	for k, v := range headers {
+		clone[k] = v
+	}
+	return context.WithValue(ctx, ctxKeyMCPHeaders, clone)
 }
 
 // MCPHeaders extracts per-request MCP headers from ctx, or nil if unset.
+// Returns a clone so callers cannot mutate the stored map.
 func MCPHeaders(ctx context.Context) map[string]string {
 	v, _ := ctx.Value(ctxKeyMCPHeaders).(map[string]string)
-	return v
+	if len(v) == 0 {
+		return nil
+	}
+	clone := make(map[string]string, len(v))
+	for k, val := range v {
+		clone[k] = val
+	}
+	return clone
 }
 
 // AsyncCallback is a function type that async tools use to notify completion.

--- a/pkg/tools/shared/base.go
+++ b/pkg/tools/shared/base.go
@@ -50,6 +50,7 @@ var (
 	ctxKeyAgentID          = &toolCtxKey{"agentID"}
 	ctxKeySessionKey       = &toolCtxKey{"sessionKey"}
 	ctxKeySessionScope     = &toolCtxKey{"sessionScope"}
+	ctxKeyMCPHeaders       = &toolCtxKey{"mcpHeaders"}
 )
 
 // WithToolContext returns a child context carrying channel and chatID.
@@ -128,6 +129,17 @@ func ToolSessionKey(ctx context.Context) string {
 func ToolSessionScope(ctx context.Context) *session.SessionScope {
 	scope, _ := ctx.Value(ctxKeySessionScope).(*session.SessionScope)
 	return session.CloneScope(scope)
+}
+
+// WithMCPHeaders returns a child context carrying per-request headers for MCP HTTP transports.
+func WithMCPHeaders(ctx context.Context, headers map[string]string) context.Context {
+	return context.WithValue(ctx, ctxKeyMCPHeaders, headers)
+}
+
+// MCPHeaders extracts per-request MCP headers from ctx, or nil if unset.
+func MCPHeaders(ctx context.Context) map[string]string {
+	v, _ := ctx.Value(ctxKeyMCPHeaders).(map[string]string)
+	return v
 }
 
 // AsyncCallback is a function type that async tools use to notify completion.

--- a/pkg/tools/shared_facade.go
+++ b/pkg/tools/shared_facade.go
@@ -61,6 +61,14 @@ func WithToolSessionContext(
 	return toolshared.WithToolSessionContext(ctx, agentID, sessionKey, scope)
 }
 
+func WithMCPHeaders(ctx context.Context, headers map[string]string) context.Context {
+	return toolshared.WithMCPHeaders(ctx, headers)
+}
+
+func MCPHeaders(ctx context.Context) map[string]string {
+	return toolshared.MCPHeaders(ctx)
+}
+
 func ToolChannel(ctx context.Context) string {
 	return toolshared.ToolChannel(ctx)
 }


### PR DESCRIPTION
## Summary
- Channels can now forward HTTP headers to MCP servers per-request by storing keys with a `mcp:` prefix in `InboundContext.Raw` (e.g. `Raw["mcp:Authorization"] = "Bearer ..."`)
- Headers flow through `context.Context` from the agent pipeline to the MCP HTTP transport's `RoundTrip`, where they are injected alongside static config headers
- SSE/HTTP transports now always use `headerTransport` so dynamic headers work without requiring static headers in config
- **Security**: Dynamic headers require an explicit per-server allowlist — without configuration, no headers are forwarded (secure by default)

## How it works
```
Channel sets Raw["mcp:X-Token"] = "secret"
  → pipeline_execute.go extracts mcp:* keys → WithMCPHeaders(ctx, headers)
    → MCPTool.Execute(ctx) → Manager.CallTool(ctx) → Session.CallTool(ctx)
      → http.NewRequestWithContext(ctx) → headerTransport.RoundTrip(req)
        → filterDynamicHeaders() applies allowlist → req.Header.Set(...)
```

## Files changed
- `pkg/tools/shared/base.go` — new `WithMCPHeaders`/`MCPHeaders` context helpers (with defensive cloning)
- `pkg/tools/shared_facade.go` — facade re-exports
- `pkg/agent/agent_utils.go` — `withMCPHeadersFromRaw` extracts `mcp:`-prefixed keys, trims whitespace
- `pkg/agent/pipeline_execute.go` — attaches MCP headers to tool execution context
- `pkg/mcp/manager.go` — `headerTransport.RoundTrip` filters dynamic headers via allowlist; SSE/HTTP always uses `headerTransport`
- `pkg/config/config.go` — new `DynamicHeadersConfig` struct with `allowed`, `max_count`, `max_value_len` fields
- `pkg/channels/pico/pico.go` — forwards `message.send` payload `metadata` into `InboundContext.Raw`; protects reserved internal keys from client overwrites

## Security measures
1. **Allowlist required**: Only headers listed in `dynamic_headers.allowed` are forwarded
2. **Limits enforced**: `max_count` (default 10) and `max_value_len` (default 4096) prevent abuse
3. **Reserved keys protected**: Internal metadata fields (`platform`, `session_id`, `conn_id`, etc.) cannot be overwritten by clients

Example config:
```json
"servers": {
  "grafana": {
    "url": "http://grafana-mcp:8080/mcp",
    "dynamic_headers": {
      "allowed": ["X-Grafana-Service-Account-Token"],
      "max_count": 5,
      "max_value_len": 2048
    }
  }
}
```

## Test plan
- [x] `go build ./pkg/tools/shared/ ./pkg/tools/ ./pkg/mcp/ ./pkg/agent/` passes
- [x] `go test ./pkg/tools/ ./pkg/mcp/ ./pkg/agent/ ./pkg/channels/pico/` all green
- [x] New tests for allowlist filtering, case-insensitivity, max count/value limits
- [x] New test for reserved key protection in pico channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)