### PR TITLE
fix(web): Fix the error when the frontend copy button is used in an HTTP (non-secure context) environment.

### DIFF
--- a/web/frontend/src/components/chat/assistant-message.tsx
+++ b/web/frontend/src/components/chat/assistant-message.tsx
@@ -56,11 +56,38 @@ export function AssistantMessage({
   const formattedTimestamp =
     timestamp !== "" ? formatMessageTime(timestamp) : ""
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(content).then(() => {
+  const handleCopy = async () => {
+    const markCopied = () => {
       setIsCopied(true)
       setTimeout(() => setIsCopied(false), 2000)
-    })
+    }
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(content)
+        markCopied()
+        return
+      }
+    } catch {
+      // HTTP 或受限环境下可能不支持 Clipboard API，继续走降级方案
+    }
+
+    const textArea = document.createElement("textarea")
+    textArea.value = content
+    textArea.setAttribute("readonly", "")
+    textArea.style.position = "fixed"
+    textArea.style.left = "-9999px"
+    document.body.appendChild(textArea)
+    textArea.select()
+
+    try {
+      const copied = document.execCommand("copy")
+      if (copied) {
+        markCopied()
+      }
+    } finally {
+      document.body.removeChild(textArea)
+    }
   }
 
   const collapsedLabel = isThought


### PR DESCRIPTION
## 📝 Description

Fixed an error with the frontend copy button in non-secure (HTTP) contexts. Previously, directly calling `navigator.clipboard.writeText` would throw an exception when the Clipboard API was unavailable. The implementation now prioritizes the Clipboard API and automatically degrades to `document.execCommand("copy")` upon failure, ensuring the copy functionality remains operational.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** The Clipboard API is more reliable in secure contexts such as HTTPS or localhost, but may be unavailable in HTTP environments; a fallback mechanism is required to prevent runtime errors and maintain functionality.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** macOS
- **Model/Provider:** OpenAI Codex (GPT-5)
- **Channels:** Web UI


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- Original error: `Cannot read properties of undefined (reading 'writeText')`
- After fix: Copying via the button in the HTTP environment works correctly, and the above error is no longer thrown.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.