### PR TITLE
fix(channels): dismiss tool feedback animation when turn ends via ResponseHandled

### DIFF
--- a/pkg/agent/adapters/channelmanager.go
+++ b/pkg/agent/adapters/channelmanager.go
@@ -44,6 +44,8 @@ func (a *channelManagerAdapter) SendPlaceholder(ctx context.Context, channel, ch
 	return a.inner.SendPlaceholder(ctx, channel, chatID)
 }
 
-func (a *channelManagerAdapter) DismissToolFeedback(ctx context.Context, channel, chatID string, outboundCtx *bus.InboundContext) {
+func (a *channelManagerAdapter) DismissToolFeedback(
+	ctx context.Context, channel, chatID string, outboundCtx *bus.InboundContext,
+) {
 	a.inner.DismissToolFeedback(ctx, channel, chatID, outboundCtx)
 }

--- a/pkg/agent/adapters/channelmanager.go
+++ b/pkg/agent/adapters/channelmanager.go
@@ -44,6 +44,6 @@ func (a *channelManagerAdapter) SendPlaceholder(ctx context.Context, channel, ch
 	return a.inner.SendPlaceholder(ctx, channel, chatID)
 }
 
-func (a *channelManagerAdapter) DismissToolFeedback(ctx context.Context, channel, chatID string) {
-	a.inner.DismissToolFeedback(ctx, channel, chatID)
+func (a *channelManagerAdapter) DismissToolFeedback(ctx context.Context, channel, chatID string, outboundCtx *bus.InboundContext) {
+	a.inner.DismissToolFeedback(ctx, channel, chatID, outboundCtx)
 }

--- a/pkg/agent/adapters/channelmanager.go
+++ b/pkg/agent/adapters/channelmanager.go
@@ -43,3 +43,7 @@ func (a *channelManagerAdapter) SendMedia(ctx context.Context, msg bus.OutboundM
 func (a *channelManagerAdapter) SendPlaceholder(ctx context.Context, channel, chatID string) bool {
 	return a.inner.SendPlaceholder(ctx, channel, chatID)
 }
+
+func (a *channelManagerAdapter) DismissToolFeedback(ctx context.Context, channel, chatID string) {
+	a.inner.DismissToolFeedback(ctx, channel, chatID)
+}

--- a/pkg/agent/interfaces/interfaces.go
+++ b/pkg/agent/interfaces/interfaces.go
@@ -44,4 +44,9 @@ type ChannelManager interface {
 
 	// SendPlaceholder sends a placeholder message (e.g., for audio transcription).
 	SendPlaceholder(ctx context.Context, channel, chatID string) bool
+
+	// DismissToolFeedback clears any tracked tool feedback animation for the
+	// given channel/chat. Call this when a turn ends without a final response
+	// (e.g., ResponseHandled tools) to avoid orphaned animation goroutines.
+	DismissToolFeedback(ctx context.Context, channel, chatID string)
 }

--- a/pkg/agent/interfaces/interfaces.go
+++ b/pkg/agent/interfaces/interfaces.go
@@ -48,5 +48,7 @@ type ChannelManager interface {
 	// DismissToolFeedback clears any tracked tool feedback animation for the
 	// given channel/chat. Call this when a turn ends without a final response
 	// (e.g., ResponseHandled tools) to avoid orphaned animation goroutines.
-	DismissToolFeedback(ctx context.Context, channel, chatID string)
+	// outboundCtx carries topic/thread info needed for channels that use
+	// scoped tracker keys (e.g., Telegram forum topics); may be nil.
+	DismissToolFeedback(ctx context.Context, channel, chatID string, outboundCtx *bus.InboundContext)
 }

--- a/pkg/agent/pipeline_execute.go
+++ b/pkg/agent/pipeline_execute.go
@@ -705,7 +705,7 @@ toolLoop:
 		ts.setPhase(TurnPhaseCompleted)
 		ts.setFinalContent("")
 		if al.channelManager != nil && ts.channel != "" {
-			al.channelManager.DismissToolFeedback(ctx, ts.channel, ts.chatID)
+			al.channelManager.DismissToolFeedback(ctx, ts.channel, ts.chatID, ts.opts.InboundContext)
 		}
 		logger.InfoCF("agent", "Tool output satisfied delivery; ending turn without follow-up LLM",
 			map[string]any{

--- a/pkg/agent/pipeline_execute.go
+++ b/pkg/agent/pipeline_execute.go
@@ -704,6 +704,9 @@ toolLoop:
 		}
 		ts.setPhase(TurnPhaseCompleted)
 		ts.setFinalContent("")
+		if al.channelManager != nil && ts.channel != "" {
+			al.channelManager.DismissToolFeedback(ctx, ts.channel, ts.chatID)
+		}
 		logger.InfoCF("agent", "Tool output satisfied delivery; ending turn without follow-up LLM",
 			map[string]any{
 				"agent_id":   ts.agent.ID,

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -197,7 +197,9 @@ func clearTrackedToolFeedbackMessage(
 // response (e.g., ResponseHandled tools) to stop orphaned animation goroutines.
 // outboundCtx carries topic/thread info for channels that use scoped tracker
 // keys (e.g., Telegram forum topics); may be nil for non-topic channels.
-func (m *Manager) DismissToolFeedback(ctx context.Context, channelName, chatID string, outboundCtx *bus.InboundContext) {
+func (m *Manager) DismissToolFeedback(
+	ctx context.Context, channelName, chatID string, outboundCtx *bus.InboundContext,
+) {
 	ch, ok := m.GetChannel(channelName)
 	if !ok {
 		return

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -192,6 +192,17 @@ func clearTrackedToolFeedbackMessage(
 	}
 }
 
+// DismissToolFeedback clears any tracked tool feedback animation for the
+// given channel/chat. This is called when a turn ends without a final
+// response (e.g., ResponseHandled tools) to stop orphaned animation goroutines.
+func (m *Manager) DismissToolFeedback(ctx context.Context, channelName, chatID string) {
+	ch, ok := m.GetChannel(channelName)
+	if !ok {
+		return
+	}
+	dismissTrackedToolFeedbackMessage(ctx, ch, chatID, nil)
+}
+
 func prepareToolFeedbackMessageContent(ch Channel, content string) string {
 	prepared := strings.TrimSpace(content)
 	if prepared == "" {

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -195,12 +195,14 @@ func clearTrackedToolFeedbackMessage(
 // DismissToolFeedback clears any tracked tool feedback animation for the
 // given channel/chat. This is called when a turn ends without a final
 // response (e.g., ResponseHandled tools) to stop orphaned animation goroutines.
-func (m *Manager) DismissToolFeedback(ctx context.Context, channelName, chatID string) {
+// outboundCtx carries topic/thread info for channels that use scoped tracker
+// keys (e.g., Telegram forum topics); may be nil for non-topic channels.
+func (m *Manager) DismissToolFeedback(ctx context.Context, channelName, chatID string, outboundCtx *bus.InboundContext) {
 	ch, ok := m.GetChannel(channelName)
 	if !ok {
 		return
 	}
-	dismissTrackedToolFeedbackMessage(ctx, ch, chatID, nil)
+	dismissTrackedToolFeedbackMessage(ctx, ch, chatID, outboundCtx)
 }
 
 func prepareToolFeedbackMessageContent(ch Channel, content string) string {


### PR DESCRIPTION
## 📝 Description

When a tool sets `ResponseHandled=true` (e.g., `send_file`), the turn ends without producing a final assistant response. This means no outbound message triggers `FinalizeToolFeedbackMessage` on the channel, leaving the animation goroutine running indefinitely — editing the Feishu card every 3 seconds with `.` / `..` suffixes long after the tool had finished.

Root cause: the tool feedback outbound goes through the text worker queue, while the tool's media output goes through the media worker queue. The media worker often finishes first (before the text worker even creates the feedback card), so `SendMedia`'s dismiss logic finds nothing to clean up. The text worker then creates the feedback card and starts the animation goroutine, but since the turn has already ended with no final response, nobody ever calls `FinalizeToolFeedbackMessage` or `DismissToolFeedbackMessage`.

Fix: call `DismissToolFeedback` at the "Tool output satisfied delivery" exit point so the tracker is cleared and the animation goroutine is stopped immediately when the turn ends.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Observed on Feishu channel: after calling `send_file`, the tool feedback card kept animating indefinitely with `.`/`..` suffix every 3 seconds.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** `pkg/channels/tool_feedback_animator.go` (animation goroutine lifecycle), `pkg/agent/pipeline_execute.go:707` (ResponseHandled turn-end path)
- **Reasoning:** The animation goroutine is started by `ToolFeedbackAnimator.Record()` and stopped by `Take()` / `Clear()`. When a turn ends via ResponseHandled, no outbound flows through `Send()` to trigger finalize/dismiss, so the goroutine is orphaned. Adding an explicit `DismissToolFeedback` call at the turn-end point ensures cleanup regardless of how the turn ends.

## 🧪 Test Environment
- **Hardware:** MacBook Pro (Apple Silicon)
- **OS:** macOS 15.4
- **Model/Provider:** GPT-5.5 via OpenAI-compatible proxy
- **Channels:** Feishu (websocket mode)

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Before fix — animation continues after turn end:
```
05:02:20 INF agent Tool output satisfied delivery; ending turn without follow-up LLM
05:02:23 DBG feishu EditMessage called content_len=210 preview="🔧 `send_file.`..."
05:02:26 DBG feishu EditMessage called content_len=211 preview="🔧 `send_file..`..."
05:02:29 DBG feishu EditMessage called content_len=210 preview="🔧 `send_file.`..."
05:02:32 DBG feishu EditMessage called content_len=211 preview="🔧 `send_file..`..."
(continues forever)
```

After fix: animation stops at turn end, card is dismissed.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.