### PR TITLE
feat: add DeepSeek vision unsupported error detection

### DIFF
--- a/pkg/agent/llm_media.go
+++ b/pkg/agent/llm_media.go
@@ -56,5 +56,12 @@ func isVisionUnsupportedError(err error) bool {
 		return true
 	}
 
+	// DeepSeek and other strict providers reject the image_url field at the
+	// JSON schema level with an "unknown variant" error rather than a semantic
+	// "not supported" message.
+	if strings.Contains(msg, "unknown variant") && strings.Contains(msg, "image_url") {
+		return true
+	}
+
 	return false
 }


### PR DESCRIPTION
## Summary

Add detection for DeepSeek and other strict providers that reject the `image_url` field at the JSON schema level with an `unknown variant` error, rather than returning a semantic 'not supported' message.

## Changes

- `pkg/agent/llm_media.go`: Added new error pattern check in `isVisionUnsupportedError` — if the error message contains both `"unknown variant"` and `"image_url"`, it's treated as a vision-unsupported error.

## Motivation

DeepSeek and similar providers do not return a standard 'image not supported' error. Instead they return a JSON schema validation error like `unknown variant \image_url\`. Without this detection, the system would not properly fall back to stripping media content for such providers.

## fix issue
https://github.com/sipeed/picoclaw/issues/2718