### PR TITLE
* fix(ci): isolate rcodesign setup for macOS launcher signing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -235,24 +235,30 @@ jobs:
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
         run: |
-          pip3 install rcodesign
+          cleanup() {
+            rm -rf .venv-rcodesign
+            rm -f cert.p12 notary-key.p8
+          }
+          trap cleanup EXIT
+
+          python3 -m venv .venv-rcodesign
+          ./.venv-rcodesign/bin/python -m pip install --upgrade pip
+          ./.venv-rcodesign/bin/python -m pip install rcodesign
 
           echo "$MACOS_SIGN_P12" | base64 -d > cert.p12
 
-          rcodesign sign \
+          ./.venv-rcodesign/bin/rcodesign sign \
             --p12-file cert.p12 \
             --p12-password "$MACOS_SIGN_PASSWORD" \
             picoclaw-launcher-cgo
 
           echo "$MACOS_NOTARY_KEY" > notary-key.p8
 
-          rcodesign notary-submit \
+          ./.venv-rcodesign/bin/rcodesign notary-submit \
             --api-key-path notary-key.p8 \
             --api-issuer "$MACOS_NOTARY_ISSUER_ID" \
             --wait \
             picoclaw-launcher-cgo
-
-          rm -f cert.p12 notary-key.p8
 
       - name: Upload launcher artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,24 +194,30 @@ jobs:
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
         run: |
-          pip3 install rcodesign
+          cleanup() {
+            rm -rf .venv-rcodesign
+            rm -f cert.p12 notary-key.p8
+          }
+          trap cleanup EXIT
+
+          python3 -m venv .venv-rcodesign
+          ./.venv-rcodesign/bin/python -m pip install --upgrade pip
+          ./.venv-rcodesign/bin/python -m pip install rcodesign
 
           echo "$MACOS_SIGN_P12" | base64 -d > cert.p12
 
-          rcodesign sign \
+          ./.venv-rcodesign/bin/rcodesign sign \
             --p12-file cert.p12 \
             --p12-password "$MACOS_SIGN_PASSWORD" \
             picoclaw-launcher-cgo
 
           echo "$MACOS_NOTARY_KEY" > notary-key.p8
 
-          rcodesign notary-submit \
+          ./.venv-rcodesign/bin/rcodesign notary-submit \
             --api-key-path notary-key.p8 \
             --api-issuer "$MACOS_NOTARY_ISSUER_ID" \
             --wait \
             picoclaw-launcher-cgo
-
-          rm -f cert.p12 notary-key.p8
 
       - name: Upload launcher artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 📝 Description

This PR fixes the macOS launcher signing and notarization step used in both the nightly and release workflows.

The change replaces the global `pip3 install rcodesign` setup with an isolated Python virtual environment, invokes `rcodesign` from that environment explicitly, and adds guaranteed cleanup for temporary signing artifacts.

Summary of changes:
- Create a dedicated `.venv-rcodesign` environment in the workflow job
- Install `rcodesign` inside that virtual environment instead of relying on global `pip3`
- Call the venv-scoped `rcodesign` binary explicitly for both signing and notarization
- Add a `trap`-based cleanup function to remove the venv and temporary certificate/notary key files on exit
- Apply the same fix to both `.github/workflows/nightly.yml` and `.github/workflows/release.yml`

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** The macOS launcher workflow previously depended on a global `pip3 install rcodesign`, which is more fragile on hosted runners. Installing `rcodesign` in a local virtual environment makes the job setup more isolated and predictable, while the cleanup trap ensures signing materials are removed even if the step exits early.

## 🧪 Test Environment
- **Hardware:** GitHub Actions hosted runner
- **OS:** `macos-latest`
- **Model/Provider:** N/A
- **Channels:** GitHub Actions

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- Verified the branch diff against `origin/main`
- `git diff --check origin/main...HEAD` completed successfully
- Functional validation should come from the next nightly/release GitHub Actions run

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.