### PR TITLE
fix(openai_compat): parse reasoning_content in streaming responses

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -419,6 +419,7 @@ func parseStreamResponse(
 	onChunk func(accumulated string),
 ) (*LLMResponse, error) {
 	var textContent strings.Builder
+	var reasoningContent strings.Builder
 	var finishReason string
 	var usage *UsageInfo
 
@@ -451,8 +452,9 @@ func parseStreamResponse(
 		var chunk struct {
 			Choices []struct {
 				Delta struct {
-					Content   string `json:"content"`
-					ToolCalls []struct {
+					Content          string `json:"content"`
+					ReasoningContent string `json:"reasoning_content"`
+					ToolCalls        []struct {
 						Index    int    `json:"index"`
 						ID       string `json:"id"`
 						Function *struct {
@@ -486,6 +488,9 @@ func parseStreamResponse(
 			if onChunk != nil {
 				onChunk(textContent.String())
 			}
+		}
+		if choice.Delta.ReasoningContent != "" {
+			reasoningContent.WriteString(choice.Delta.ReasoningContent)
 		}
 
 		// Accumulate tool call deltas
@@ -544,10 +549,11 @@ func parseStreamResponse(
 	}
 
 	return &LLMResponse{
-		Content:      textContent.String(),
-		ToolCalls:    toolCalls,
-		FinishReason: finishReason,
-		Usage:        usage,
+		Content:          textContent.String(),
+		ReasoningContent: reasoningContent.String(),
+		ToolCalls:        toolCalls,
+		FinishReason:     finishReason,
+		Usage:            usage,
 	}, nil
 }
 

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -420,6 +420,8 @@ func parseStreamResponse(
 ) (*LLMResponse, error) {
 	var textContent strings.Builder
 	var reasoningContent strings.Builder
+	var reasoning strings.Builder
+	var reasoningDetails []ReasoningDetail
 	var finishReason string
 	var usage *UsageInfo
 
@@ -431,29 +433,21 @@ func parseStreamResponse(
 	}
 	activeTools := map[int]*toolAccum{}
 
-	scanner := bufio.NewScanner(reader)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024) // 1MB initial, 10MB max
-	for scanner.Scan() {
-		// Check for context cancellation between chunks
-		if err := ctx.Err(); err != nil {
-			return nil, err
+	processEvent := func(data string) error {
+		if strings.TrimSpace(data) == "" {
+			return nil
 		}
-
-		line := scanner.Text()
-
-		if !strings.HasPrefix(line, "data: ") {
-			continue
-		}
-		data := strings.TrimPrefix(line, "data: ")
-		if data == "[DONE]" {
-			break
+		if strings.TrimSpace(data) == "[DONE]" {
+			return io.EOF
 		}
 
 		var chunk struct {
 			Choices []struct {
 				Delta struct {
-					Content          string `json:"content"`
-					ReasoningContent string `json:"reasoning_content"`
+					Content          string            `json:"content"`
+					ReasoningContent string            `json:"reasoning_content"`
+					Reasoning        string            `json:"reasoning"`
+					ReasoningDetails []ReasoningDetail `json:"reasoning_details"`
 					ToolCalls        []struct {
 						Index    int    `json:"index"`
 						ID       string `json:"id"`
@@ -469,7 +463,7 @@ func parseStreamResponse(
 		}
 
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
-			continue // skip malformed chunks
+			return fmt.Errorf("failed to decode stream event: %w", err)
 		}
 
 		if chunk.Usage != nil {
@@ -477,7 +471,7 @@ func parseStreamResponse(
 		}
 
 		if len(chunk.Choices) == 0 {
-			continue
+			return nil
 		}
 
 		choice := chunk.Choices[0]
@@ -491,6 +485,12 @@ func parseStreamResponse(
 		}
 		if choice.Delta.ReasoningContent != "" {
 			reasoningContent.WriteString(choice.Delta.ReasoningContent)
+		}
+		if choice.Delta.Reasoning != "" {
+			reasoning.WriteString(choice.Delta.Reasoning)
+		}
+		if len(choice.Delta.ReasoningDetails) > 0 {
+			reasoningDetails = append(reasoningDetails, choice.Delta.ReasoningDetails...)
 		}
 
 		// Accumulate tool call deltas
@@ -516,10 +516,54 @@ func parseStreamResponse(
 		if choice.FinishReason != nil {
 			finishReason = *choice.FinishReason
 		}
+
+		return nil
+	}
+
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024) // 1MB initial, 10MB max
+	var eventData strings.Builder
+	for scanner.Scan() {
+		// Check for context cancellation between chunks
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		line := scanner.Text()
+		if line == "" {
+			err := processEvent(eventData.String())
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+			eventData.Reset()
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data:")
+		data = strings.TrimPrefix(data, " ")
+		if eventData.Len() > 0 {
+			eventData.WriteByte('\n')
+		}
+		eventData.WriteString(data)
 	}
 
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("streaming read error: %w", err)
+	}
+	if eventData.Len() > 0 {
+		err := processEvent(eventData.String())
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
 	}
 
 	// Assemble tool calls from accumulated deltas
@@ -551,6 +595,8 @@ func parseStreamResponse(
 	return &LLMResponse{
 		Content:          textContent.String(),
 		ReasoningContent: reasoningContent.String(),
+		Reasoning:        reasoning.String(),
+		ReasoningDetails: reasoningDetails,
 		ToolCalls:        toolCalls,
 		FinishReason:     finishReason,
 		Usage:            usage,

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -1195,6 +1195,57 @@ func TestProviderChatStream_CustomHeadersInjected(t *testing.T) {
 	}
 }
 
+func TestProviderChatStream_ParsesReasoningContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(
+			"data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"Let me \",\"content\":\"Checking \",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\"}}]}}]}\n\n",
+		))
+		_, _ = w.Write([]byte(
+			"data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"think step by step.\",\"content\":\"the weather\",\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"Hangzhou\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":6,\"total_tokens\":16}}\n\n",
+		))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	out, err := p.ChatStream(
+		t.Context(),
+		[]Message{{Role: "user", Content: "weather?"}},
+		nil,
+		"deepseek-v4-flash",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ChatStream() error = %v", err)
+	}
+	if out.Content != "Checking the weather" {
+		t.Fatalf("Content = %q, want %q", out.Content, "Checking the weather")
+	}
+	if out.ReasoningContent != "Let me think step by step." {
+		t.Fatalf("ReasoningContent = %q, want %q", out.ReasoningContent, "Let me think step by step.")
+	}
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(out.ToolCalls))
+	}
+	if out.ToolCalls[0].ID != "call_1" {
+		t.Fatalf("ToolCalls[0].ID = %q, want %q", out.ToolCalls[0].ID, "call_1")
+	}
+	if out.ToolCalls[0].Name != "get_weather" {
+		t.Fatalf("ToolCalls[0].Name = %q, want %q", out.ToolCalls[0].Name, "get_weather")
+	}
+	if out.ToolCalls[0].Arguments["city"] != "Hangzhou" {
+		t.Fatalf("ToolCalls[0].Arguments[city] = %v, want %q", out.ToolCalls[0].Arguments["city"], "Hangzhou")
+	}
+	if out.FinishReason != "tool_calls" {
+		t.Fatalf("FinishReason = %q, want %q", out.FinishReason, "tool_calls")
+	}
+	if out.Usage == nil || out.Usage.TotalTokens != 16 {
+		t.Fatalf("Usage = %#v, want total tokens 16", out.Usage)
+	}
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -1246,6 +1246,117 @@ func TestProviderChatStream_ParsesReasoningContent(t *testing.T) {
 	}
 }
 
+func TestProviderChatStream_ParsesMultilineSSEEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(
+			"data: {\"choices\":[{\"delta\":{\n" +
+				"data: \"content\":\"Hello\",\"reasoning_content\":\"Thinking\",\n" +
+				"data: \"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"echo\",\"arguments\":\"{\\\"message\\\":\\\"hello\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}],\n" +
+				"data: \"usage\":{\"prompt_tokens\":3,\"completion_tokens\":4,\"total_tokens\":7}}\n\n",
+		))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	out, err := p.ChatStream(
+		t.Context(),
+		[]Message{{Role: "user", Content: "say hello"}},
+		nil,
+		"gpt-4o",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ChatStream() error = %v", err)
+	}
+	if out.Content != "Hello" {
+		t.Fatalf("Content = %q, want %q", out.Content, "Hello")
+	}
+	if out.ReasoningContent != "Thinking" {
+		t.Fatalf("ReasoningContent = %q, want %q", out.ReasoningContent, "Thinking")
+	}
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(out.ToolCalls))
+	}
+	if out.ToolCalls[0].Name != "echo" {
+		t.Fatalf("ToolCalls[0].Name = %q, want %q", out.ToolCalls[0].Name, "echo")
+	}
+	if out.ToolCalls[0].Arguments["message"] != "hello" {
+		t.Fatalf("ToolCalls[0].Arguments[message] = %v, want %q", out.ToolCalls[0].Arguments["message"], "hello")
+	}
+	if out.FinishReason != "tool_calls" {
+		t.Fatalf("FinishReason = %q, want %q", out.FinishReason, "tool_calls")
+	}
+	if out.Usage == nil || out.Usage.TotalTokens != 7 {
+		t.Fatalf("Usage = %#v, want total tokens 7", out.Usage)
+	}
+}
+
+func TestProviderChatStream_ParsesReasoningVariants(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(
+			"data: {\"choices\":[{\"delta\":{\"reasoning\":\"step 1\",\"reasoning_details\":[{\"format\":\"text\",\"index\":0,\"type\":\"summary\",\"text\":\"first\"}]}}]}\n\n",
+		))
+		_, _ = w.Write([]byte(
+			"data: {\"choices\":[{\"delta\":{\"reasoning\":\" + step 2\",\"reasoning_details\":[{\"format\":\"text\",\"index\":1,\"type\":\"summary\",\"text\":\"second\"}],\"content\":\"done\"},\"finish_reason\":\"stop\"}]}\n\n",
+		))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	out, err := p.ChatStream(
+		t.Context(),
+		[]Message{{Role: "user", Content: "think"}},
+		nil,
+		"gpt-4o",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ChatStream() error = %v", err)
+	}
+	if out.Content != "done" {
+		t.Fatalf("Content = %q, want %q", out.Content, "done")
+	}
+	if out.Reasoning != "step 1 + step 2" {
+		t.Fatalf("Reasoning = %q, want %q", out.Reasoning, "step 1 + step 2")
+	}
+	if len(out.ReasoningDetails) != 2 {
+		t.Fatalf("len(ReasoningDetails) = %d, want 2", len(out.ReasoningDetails))
+	}
+	if out.ReasoningDetails[0].Text != "first" || out.ReasoningDetails[1].Text != "second" {
+		t.Fatalf("ReasoningDetails = %#v, want texts first/second", out.ReasoningDetails)
+	}
+}
+
+func TestProviderChatStream_InvalidEventReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[\n\n"))
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	_, err := p.ChatStream(
+		t.Context(),
+		[]Message{{Role: "user", Content: "hi"}},
+		nil,
+		"gpt-4o",
+		nil,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error for malformed stream event")
+	}
+	if !strings.Contains(err.Error(), "failed to decode stream event") {
+		t.Fatalf("error = %v, want decode stream event error", err)
+	}
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## 📝 Description

This PR hardens OpenAI-compatible streaming response parsing so reasoning fields are preserved consistently and SSE payloads are parsed correctly.

It does this by:
- accumulating streamed `reasoning_content` deltas in `pkg/providers/openai_compat/provider.go` and returning them in the final `LLMResponse`;
- parsing SSE responses by event boundary instead of treating each `data:` line as a complete JSON payload, so multi-line events are handled correctly;
- preserving additional reasoning fields already supported by the non-streaming path, including `reasoning` and `reasoning_details`;
- surfacing malformed stream events as errors instead of silently skipping invalid JSON payloads;
- adding regression coverage for interleaved `reasoning_content`, visible content, tool-call deltas, multi-line SSE events, additional reasoning variants, usage metadata, and malformed payload handling.

This intentionally does **not** change the existing DeepSeek replay rules for non-tool vs tool-interaction turns. Those rules remain aligned with the DeepSeek thinking-mode and multi-round chat documentation already enforced on `main`.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue
Resolves #2706

## 📚 Technical Context
- **Reference URL:** https://api-docs.deepseek.com/zh-cn/guides/thinking_mode, https://api-docs.deepseek.com/zh-cn/guides/multi_round_chat
- **Reasoning:** The current agent path still uses non-streaming `Chat()` for DeepSeek, but `pkg/providers/openai_compat` already exposes a generic streaming SSE parser for OpenAI-compatible providers. That parser previously dropped streamed `reasoning_content`, assumed each `data:` line was a complete JSON document, and did not preserve `reasoning` or `reasoning_details` like the non-streaming parser already does. This PR fixes those provider-layer gaps and adds focused regression tests while deliberately leaving the documented DeepSeek replay filtering behavior unchanged.

## 🧪 Test Environment
- **Hardware:** Local x64 Server
- **OS:** Ubuntu Server 24
- **Model/Provider:** DeepSeek V4 Flash
- **Channels:** Web

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.