### PR TITLE
fix(pid): verify gateway identity before blocking startup on stale PID

### DIFF
--- a/pkg/pid/pidfile.go
+++ b/pkg/pid/pidfile.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -45,6 +46,18 @@ func generateToken() string {
 	return hex.EncodeToString(b)
 }
 
+// Does a heath check of the port if already a gateway is running
+func isGatewayAlive(port int) bool {
+	url := fmt.Sprintf("http://localhost:%d/health", port)
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == 200
+}
+
 // WritePidFile creates (or overwrites) the PID file atomically.
 // It returns an error if another gateway instance appears to be running
 // (a valid PID file exists with a live process).
@@ -63,7 +76,7 @@ func WritePidFile(homePath, host string, port int) (*PidFileData, error) {
 			// PID file on a shared volume, the host's PID 1 (init) would
 			// pass the isProcessRunning check, blocking new gateway starts.
 			// Treat recorded PID 1 as always stale.
-			if data.PID != 1 && isProcessRunning(data.PID) {
+			if data.PID != 1 && isProcessRunning(data.PID) && isGatewayAlive(data.Port) {
 				return nil, fmt.Errorf("gateway is already running (PID: %d, version: %s)", data.PID, data.Version)
 			}
 			logger.Warnf("not running (PID: %d) so will remove the pid file: %s", data.PID, pidPath)


### PR DESCRIPTION
…ng gateway alive check

## 📝 Description

Fix stale PID file causing gateway startup failure when a foreign process 
reuses the PID of a previously crashed gateway instance. Added isGatewayAlive() 
health check to verify the PID belongs to an actual picoclaw gateway before 
blocking startup.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

Fixes #2720

## 📚 Technical Context (Skip for Docs)

(https://github.com/sipeed/picoclaw/issues/2720)
The fix is suggested in the issue.

Fix stale PID file causing gateway startup failure when a foreign process 
reuses the PID of a previously crashed gateway instance. Added isGatewayAlive() 
health check to verify the PID belongs to an actual picoclaw gateway before 
blocking startup.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:**  Ubuntu 22.04 

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.