### PR TITLE
feat(subagent): support agent_id on sync subagent

### DIFF
--- a/pkg/agent/agent_init.go
+++ b/pkg/agent/agent_init.go
@@ -329,6 +329,18 @@ func registerSharedTools(
 				// Also register the synchronous subagent tool
 				subagentTool := tools.NewSubagentTool(subagentManager)
 				subagentTool.SetSpawner(NewSubTurnSpawner(al))
+				subagentTool.SetAllowlistChecker(func(targetAgentID string) bool {
+					return registry.CanSpawnSubagent(currentAgentID, targetAgentID)
+				})
+				subagentTool.SetTargetModelResolver(func(targetAgentID string) string {
+					if targetAgentID == "" {
+						return agent.Model
+					}
+					if targetAgent, ok := al.GetRegistry().GetAgent(targetAgentID); ok {
+						return targetAgent.Model
+					}
+					return agent.Model
+				})
 				agent.Tools.Register(subagentTool)
 			}
 			if spawnStatusEnabled {

--- a/pkg/tools/subagent.go
+++ b/pkg/tools/subagent.go
@@ -337,10 +337,12 @@ func (sm *SubagentManager) ListTaskCopies() []SubagentTask {
 // SubagentTool executes a subagent task synchronously and returns the result.
 // It directly calls SubTurnSpawner with Async=false for synchronous execution.
 type SubagentTool struct {
-	spawner      SubTurnSpawner
-	defaultModel string
-	maxTokens    int
-	temperature  float64
+	spawner             SubTurnSpawner
+	defaultModel        string
+	maxTokens           int
+	temperature         float64
+	allowlistCheck      func(targetAgentID string) bool
+	targetModelResolver func(targetAgentID string) string
 }
 
 func NewSubagentTool(manager *SubagentManager) *SubagentTool {
@@ -357,6 +359,14 @@ func NewSubagentTool(manager *SubagentManager) *SubagentTool {
 // SetSpawner sets the SubTurnSpawner for direct sub-turn execution.
 func (t *SubagentTool) SetSpawner(spawner SubTurnSpawner) {
 	t.spawner = spawner
+}
+
+func (t *SubagentTool) SetAllowlistChecker(check func(targetAgentID string) bool) {
+	t.allowlistCheck = check
+}
+
+func (t *SubagentTool) SetTargetModelResolver(resolver func(targetAgentID string) string) {
+	t.targetModelResolver = resolver
 }
 
 func (t *SubagentTool) Name() string {
@@ -379,6 +389,10 @@ func (t *SubagentTool) Parameters() map[string]any {
 				"type":        "string",
 				"description": "Optional short label for the task (for display)",
 			},
+			"agent_id": map[string]any{
+				"type":        "string",
+				"description": "Optional target agent ID to delegate the task to",
+			},
 		},
 		"required": []string{"task"},
 	}
@@ -391,6 +405,17 @@ func (t *SubagentTool) Execute(ctx context.Context, args map[string]any) *ToolRe
 	}
 
 	label, _ := args["label"].(string)
+	agentID, _ := args["agent_id"].(string)
+	if agentID != "" && t.allowlistCheck != nil && !t.allowlistCheck(agentID) {
+		return ErrorResult(fmt.Sprintf("Not allowed to target agent '%s'", agentID))
+	}
+
+	modelToUse := t.defaultModel
+	if agentID != "" && t.targetModelResolver != nil {
+		if resolved := t.targetModelResolver(agentID); resolved != "" {
+			modelToUse = resolved
+		}
+	}
 
 	// Build system prompt for subagent
 	systemPrompt := fmt.Sprintf(
@@ -413,7 +438,7 @@ Task: %s`,
 	// Use spawner if available (direct SpawnSubTurn call)
 	if t.spawner != nil {
 		result, err := t.spawner.SpawnSubTurn(ctx, SubTurnConfig{
-			Model:        t.defaultModel,
+			Model:        modelToUse,
 			Tools:        nil, // Will inherit from parent via context
 			SystemPrompt: systemPrompt,
 			MaxTokens:    t.maxTokens,

--- a/pkg/tools/subagent_targeting_test.go
+++ b/pkg/tools/subagent_targeting_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+type capturingSubTurnSpawner struct {
+	lastCfg SubTurnConfig
+}
+
+func (s *capturingSubTurnSpawner) SpawnSubTurn(_ context.Context, cfg SubTurnConfig) (*ToolResult, error) {
+	s.lastCfg = cfg
+	return &ToolResult{ForLLM: "ok", ForUser: "ok"}, nil
+}
+
+func TestSubagentToolRejectsDisallowedAgentID(t *testing.T) {
+	tool := &SubagentTool{defaultModel: "main-model"}
+	tool.SetAllowlistChecker(func(targetAgentID string) bool {
+		return targetAgentID != "code"
+	})
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"task":     "do something",
+		"agent_id": "code",
+	})
+
+	if result == nil || !result.IsError {
+		t.Fatalf("expected error result, got %#v", result)
+	}
+}
+
+func TestSubagentToolUsesResolvedTargetModelForAgentID(t *testing.T) {
+	spawner := &capturingSubTurnSpawner{}
+	tool := &SubagentTool{defaultModel: "main-model"}
+	tool.SetSpawner(spawner)
+	tool.SetAllowlistChecker(func(targetAgentID string) bool {
+		return targetAgentID == "code"
+	})
+	tool.SetTargetModelResolver(func(targetAgentID string) string {
+		if targetAgentID == "code" {
+			return "code-model"
+		}
+		return ""
+	})
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"task":     "do something",
+		"agent_id": "code",
+	})
+
+	if result == nil || result.IsError {
+		t.Fatalf("expected success result, got %#v", result)
+	}
+	if spawner.lastCfg.Model != "code-model" {
+		t.Fatalf("expected model code-model, got %q", spawner.lastCfg.Model)
+	}
+}
+
+func TestSubagentToolFallsBackToDefaultModelWithoutAgentID(t *testing.T) {
+	spawner := &capturingSubTurnSpawner{}
+	tool := &SubagentTool{defaultModel: "main-model"}
+	tool.SetSpawner(spawner)
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"task": "do something",
+	})
+
+	if result == nil || result.IsError {
+		t.Fatalf("expected success result, got %#v", result)
+	}
+	if spawner.lastCfg.Model != "main-model" {
+		t.Fatalf("expected model main-model, got %q", spawner.lastCfg.Model)
+	}
+}


### PR DESCRIPTION
📝 Description

This PR adds agent_id support to the synchronous subagent tool so callers can explicitly choose which configured subagent lane should handle a same-turn task.

Before this change, explicit lane selection was available for asynchronous/background delegation patterns, but not for the normal synchronous subagent path. That made it harder to reliably route work to specialized agents such as code, mini, or other configured lanes when the result was needed immediately in the current turn.

With this change:
- synchronous subagent calls can accept an optional agent_id
- the requested agent is validated against the configured allowlist
- existing behavior remains unchanged when agent_id is omitted

The goal is to make same-turn delegation more consistent with the broader subagent model, while keeping the feature backward-compatible and simple for existing users.

🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


🔗 Related Issue

No linked issue.

📚 Technical Context (Skip for Docs)
- Reference URL:
- Reasoning:
  - PicoClaw already supports multi-agent setups where different subagents are configured for different kinds of work.
  - In practice, synchronous delegation is often the most natural path when the caller needs the result in the same turn.
  - Adding optional agent_id support to sync subagent makes routing more explicit and predictable, and aligns the sync path better with existing agent-specialization workflows.
  - The change is intentionally backward-compatible by preserving the prior default behavior when no agent_id is provided.

🧪 Test Environment
- Hardware: PC
- OS: Ubuntu 24.04
- Model/Provider: OpenAI, gpt-5.4 and local configured multi-agent lanes
- Channels: Telegram

📸 Evidence (Optional)

- Verified local build from source after go generate ./...
- Verified branch-built binary runs successfully in isolated temp-home testing
- Verified synchronous subagent call with explicit agent_id in a live conversation path
- Verified service startup and agent registration after deployment-oriented validation


☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.