### PR TITLE
feat(providers): add gemini web search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ PicoClaw can search the web to provide up-to-date information. Configure in `too
 | Search Engine | API Key | Free Tier | Link |
 |--------------|---------|-----------|------|
 | DuckDuckGo | Not needed | Unlimited | Built-in fallback |
+| [Gemini Google Search](https://aistudio.google.com/apikey) | Required | Varies | Gemini with Google Search grounding |
 | [Baidu Search](https://cloud.baidu.com/doc/qianfan-api/s/Wmbq4z7e5) | Required | 1500/month (daily allocation) | AI-powered, China-optimized |
 | [Tavily](https://tavily.com) | Required | 1000 queries/month | Optimized for AI Agents |
 | [Brave Search](https://brave.com/search/api) | Required | 2000 queries/month | Fast and private |

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -282,6 +282,12 @@
         "enabled": false,
         "max_results": 5
       },
+      "gemini": {
+        "enabled": false,
+        "api_key": "",
+        "model": "gemini-2.5-flash",
+        "max_results": 5
+      },
       "perplexity": {
         "enabled": false,
         "api_key": "pplx-xxx",

--- a/docs/reference/tools_configuration.md
+++ b/docs/reference/tools_configuration.md
@@ -66,6 +66,32 @@ General settings for fetching and processing webpage content.
 | `enabled`     | bool | true    | Enable DuckDuckGo search  |
 | `max_results` | int  | 5       | Maximum number of results |
 
+### Gemini Google Search
+
+Gemini search uses Gemini with Google Search grounding. It returns an AI-synthesized answer with citations from Google Search.
+
+| Config        | Type   | Default              | Description                       |
+|---------------|--------|----------------------|-----------------------------------|
+| `enabled`     | bool   | false                | Enable Gemini Google Search       |
+| `api_key`     | string | -                    | Google Gemini API key             |
+| `model`       | string | `gemini-2.5-flash`   | Gemini model used for search      |
+| `max_results` | int    | 5                    | Maximum number of citations       |
+
+```json
+{
+  "tools": {
+    "web": {
+      "gemini": {
+        "enabled": true,
+        "api_key": "YOUR_GEMINI_API_KEY",
+        "model": "gemini-2.5-flash",
+        "max_results": 5
+      }
+    }
+  }
+}
+```
+
 ### Baidu Search
 
 Baidu Search uses the [Qianfan AI Search API](https://cloud.baidu.com/doc/qianfan-api/s/Wmbq4z7e5), which is AI-powered and optimized for Chinese-language queries.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -896,12 +896,12 @@ type BaiduSearchConfig struct {
 }
 
 type WebToolsConfig struct {
-	ToolConfig  `                  yaml:"-"                      envPrefix:"PICOCLAW_TOOLS_WEB_"`
+	ToolConfig  `                   yaml:"-"                      envPrefix:"PICOCLAW_TOOLS_WEB_"`
 	Brave       BraveConfig        `yaml:"brave,omitempty"                                        json:"brave"`
 	Tavily      TavilyConfig       `yaml:"tavily,omitempty"                                       json:"tavily"`
 	Sogou       SogouConfig        `yaml:"-"                                                      json:"sogou"`
 	DuckDuckGo  DuckDuckGoConfig   `yaml:"-"                                                      json:"duckduckgo"`
-	Gemini      GeminiSearchConfig `yaml:"gemini,omitempty"                                      json:"gemini"`
+	Gemini      GeminiSearchConfig `yaml:"gemini,omitempty"                                       json:"gemini"`
 	Perplexity  PerplexityConfig   `yaml:"perplexity,omitempty"                                   json:"perplexity"`
 	SearXNG     SearXNGConfig      `yaml:"-"                                                      json:"searxng"`
 	GLMSearch   GLMSearchConfig    `yaml:"glm_search,omitempty"                                   json:"glm_search"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -846,6 +846,13 @@ type SogouConfig struct {
 	MaxResults int  `json:"max_results" env:"PICOCLAW_TOOLS_WEB_SOGOU_MAX_RESULTS"`
 }
 
+type GeminiSearchConfig struct {
+	Enabled    bool         `json:"enabled"          yaml:"-"                 env:"PICOCLAW_TOOLS_WEB_GEMINI_ENABLED"`
+	APIKey     SecureString `json:"api_key,omitzero" yaml:"api_key,omitempty" env:"PICOCLAW_TOOLS_WEB_GEMINI_API_KEY"`
+	Model      string       `json:"model"            yaml:"-"                 env:"PICOCLAW_TOOLS_WEB_GEMINI_MODEL"`
+	MaxResults int          `json:"max_results"      yaml:"-"                 env:"PICOCLAW_TOOLS_WEB_GEMINI_MAX_RESULTS"`
+}
+
 type PerplexityConfig struct {
 	Enabled    bool          `json:"enabled"           yaml:"-"                  env:"PICOCLAW_TOOLS_WEB_PERPLEXITY_ENABLED"`
 	APIKeys    SecureStrings `json:"api_keys,omitzero" yaml:"api_keys,omitempty" env:"PICOCLAW_TOOLS_WEB_PERPLEXITY_API_KEYS"`
@@ -890,15 +897,16 @@ type BaiduSearchConfig struct {
 
 type WebToolsConfig struct {
 	ToolConfig  `                  yaml:"-"                      envPrefix:"PICOCLAW_TOOLS_WEB_"`
-	Brave       BraveConfig       `yaml:"brave,omitempty"                                        json:"brave"`
-	Tavily      TavilyConfig      `yaml:"tavily,omitempty"                                       json:"tavily"`
-	Sogou       SogouConfig       `yaml:"-"                                                      json:"sogou"`
-	DuckDuckGo  DuckDuckGoConfig  `yaml:"-"                                                      json:"duckduckgo"`
-	Perplexity  PerplexityConfig  `yaml:"perplexity,omitempty"                                   json:"perplexity"`
-	SearXNG     SearXNGConfig     `yaml:"-"                                                      json:"searxng"`
-	GLMSearch   GLMSearchConfig   `yaml:"glm_search,omitempty"                                   json:"glm_search"`
-	BaiduSearch BaiduSearchConfig `yaml:"baidu_search,omitempty"                                 json:"baidu_search"`
-	Provider    string            `yaml:"-"                                                      json:"provider,omitempty" env:"PICOCLAW_TOOLS_WEB_PROVIDER"`
+	Brave       BraveConfig        `yaml:"brave,omitempty"                                        json:"brave"`
+	Tavily      TavilyConfig       `yaml:"tavily,omitempty"                                       json:"tavily"`
+	Sogou       SogouConfig        `yaml:"-"                                                      json:"sogou"`
+	DuckDuckGo  DuckDuckGoConfig   `yaml:"-"                                                      json:"duckduckgo"`
+	Gemini      GeminiSearchConfig `yaml:"gemini,omitempty"                                      json:"gemini"`
+	Perplexity  PerplexityConfig   `yaml:"perplexity,omitempty"                                   json:"perplexity"`
+	SearXNG     SearXNGConfig      `yaml:"-"                                                      json:"searxng"`
+	GLMSearch   GLMSearchConfig    `yaml:"glm_search,omitempty"                                   json:"glm_search"`
+	BaiduSearch BaiduSearchConfig  `yaml:"baidu_search,omitempty"                                 json:"baidu_search"`
+	Provider    string             `yaml:"-"                                                      json:"provider,omitempty" env:"PICOCLAW_TOOLS_WEB_PROVIDER"`
 	// PreferNative controls whether to use provider-native web search when
 	// the active LLM supports it (e.g. OpenAI web_search_preview). When true,
 	// the client-side web_search tool is hidden to avoid duplicate search surfaces,

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -341,6 +341,11 @@ func DefaultConfig() *Config {
 					Enabled:    false,
 					MaxResults: 5,
 				},
+				Gemini: GeminiSearchConfig{
+					Enabled:    false,
+					Model:      "gemini-2.5-flash",
+					MaxResults: 5,
+				},
 				Perplexity: PerplexityConfig{
 					Enabled:    false,
 					MaxResults: 5,

--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -504,13 +504,16 @@ func (p *GeminiSearchProvider) Search(
 		return "", fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent", url.PathEscape(model))
+	endpoint := fmt.Sprintf(
+		"https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent",
+		url.PathEscape(model),
+	)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-goog-api-key", p.apiKey)
+	req.Header.Set("X-Goog-Api-Key", p.apiKey)
 	req.Header.Set("User-Agent", fmt.Sprintf(userAgentHonest, config.Version))
 
 	resp, err := p.client.Do(req)
@@ -1330,12 +1333,6 @@ func (opts WebSearchToolOptions) resolveProviderName(query string) (string, erro
 	}
 	if duckReady {
 		return "duckduckgo", nil
-	}
-
-	for _, name := range autoFallbackWebSearchProviders {
-		if opts.providerReady(name) {
-			return name, nil
-		}
 	}
 
 	for _, name := range autoFallbackWebSearchProviders {

--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -472,6 +472,110 @@ type SogouSearchProvider struct {
 	client *http.Client
 }
 
+type GeminiSearchProvider struct {
+	apiKey string
+	model  string
+	proxy  string
+	client *http.Client
+}
+
+func (p *GeminiSearchProvider) Search(
+	ctx context.Context,
+	query string,
+	count int,
+	rangeCode string,
+) (string, error) {
+	if strings.TrimSpace(p.apiKey) == "" {
+		return "", errors.New("no API key provided")
+	}
+	model := strings.TrimSpace(p.model)
+	if model == "" {
+		model = "gemini-2.5-flash"
+	}
+
+	payload := map[string]any{
+		"contents": []map[string]any{{
+			"parts": []map[string]string{{"text": query}},
+		}},
+		"tools": []map[string]any{{"google_search": map[string]any{}}},
+	}
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent", url.PathEscape(model))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", p.apiKey)
+	req.Header.Set("User-Agent", fmt.Sprintf(userAgentHonest, config.Version))
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("gemini search api error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var searchResp struct {
+		Candidates []struct {
+			Content struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"content"`
+			GroundingMetadata struct {
+				GroundingChunks []struct {
+					Web struct {
+						URI   string `json:"uri"`
+						Title string `json:"title"`
+					} `json:"web"`
+				} `json:"groundingChunks"`
+			} `json:"groundingMetadata"`
+		} `json:"candidates"`
+	}
+	if err := json.Unmarshal(body, &searchResp); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+	if len(searchResp.Candidates) == 0 {
+		return fmt.Sprintf("No results for: %s", query), nil
+	}
+
+	candidate := searchResp.Candidates[0]
+	lines := []string{fmt.Sprintf("Results for: %s (via Gemini Google Search)", query)}
+	for _, part := range candidate.Content.Parts {
+		if strings.TrimSpace(part.Text) != "" {
+			lines = append(lines, strings.TrimSpace(part.Text))
+		}
+	}
+	citationCount := 0
+	for _, chunk := range candidate.GroundingMetadata.GroundingChunks {
+		if strings.TrimSpace(chunk.Web.URI) == "" {
+			continue
+		}
+		citationCount++
+		title := strings.TrimSpace(chunk.Web.Title)
+		if title == "" {
+			title = chunk.Web.URI
+		}
+		lines = append(lines, fmt.Sprintf("%d. %s\n   %s", citationCount, title, chunk.Web.URI))
+		if citationCount >= count {
+			break
+		}
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
 func (p *SogouSearchProvider) Search(
 	ctx context.Context,
 	query string,
@@ -1072,6 +1176,10 @@ type WebSearchToolOptions struct {
 	SogouEnabled          bool
 	DuckDuckGoMaxResults  int
 	DuckDuckGoEnabled     bool
+	GeminiAPIKey          string
+	GeminiModel           string
+	GeminiMaxResults      int
+	GeminiEnabled         bool
 	PerplexityAPIKeys     []string
 	PerplexityMaxResults  int
 	PerplexityEnabled     bool
@@ -1104,6 +1212,10 @@ func WebSearchToolOptionsFromConfig(cfg *config.Config) WebSearchToolOptions {
 		SogouEnabled:          cfg.Tools.Web.Sogou.Enabled,
 		DuckDuckGoMaxResults:  cfg.Tools.Web.DuckDuckGo.MaxResults,
 		DuckDuckGoEnabled:     cfg.Tools.Web.DuckDuckGo.Enabled,
+		GeminiAPIKey:          cfg.Tools.Web.Gemini.APIKey.String(),
+		GeminiModel:           cfg.Tools.Web.Gemini.Model,
+		GeminiMaxResults:      cfg.Tools.Web.Gemini.MaxResults,
+		GeminiEnabled:         cfg.Tools.Web.Gemini.Enabled,
 		PerplexityAPIKeys:     cfg.Tools.Web.Perplexity.APIKeys.Values(),
 		PerplexityMaxResults:  cfg.Tools.Web.Perplexity.MaxResults,
 		PerplexityEnabled:     cfg.Tools.Web.Perplexity.Enabled,
@@ -1135,6 +1247,7 @@ var (
 	knownWebSearchProviders = []string{
 		"sogou",
 		"duckduckgo",
+		"gemini",
 		"brave",
 		"tavily",
 		"perplexity",
@@ -1142,7 +1255,7 @@ var (
 		"glm_search",
 		"baidu_search",
 	}
-	autoPrimaryWebSearchProviders  = []string{"perplexity", "brave", "searxng", "tavily"}
+	autoPrimaryWebSearchProviders  = []string{"gemini", "perplexity", "brave", "searxng", "tavily"}
 	autoFallbackWebSearchProviders = []string{"baidu_search", "glm_search"}
 )
 
@@ -1162,6 +1275,8 @@ func (opts WebSearchToolOptions) providerReady(name string) bool {
 		return opts.SogouEnabled
 	case "duckduckgo":
 		return opts.DuckDuckGoEnabled
+	case "gemini":
+		return opts.GeminiEnabled && strings.TrimSpace(opts.GeminiAPIKey) != ""
 	case "brave":
 		return opts.BraveEnabled && len(opts.BraveAPIKeys) > 0
 	case "tavily":
@@ -1278,6 +1393,24 @@ func (opts WebSearchToolOptions) providerByName(name string) (SearchProvider, in
 			keyPool: NewAPIKeyPool(opts.BraveAPIKeys),
 			proxy:   opts.Proxy,
 			client:  client,
+		}, maxResults, nil
+	case "gemini":
+		if !opts.providerReady("gemini") {
+			return nil, 0, nil
+		}
+		client, err := utils.CreateHTTPClient(opts.Proxy, searchTimeout)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to create HTTP client for Gemini: %w", err)
+		}
+		maxResults := 10
+		if opts.GeminiMaxResults > 0 {
+			maxResults = min(opts.GeminiMaxResults, 10)
+		}
+		return &GeminiSearchProvider{
+			apiKey: opts.GeminiAPIKey,
+			model:  opts.GeminiModel,
+			proxy:  opts.Proxy,
+			client: client,
 		}, maxResults, nil
 	case "searxng":
 		if !opts.providerReady("searxng") {

--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -1310,12 +1310,6 @@ func (opts WebSearchToolOptions) resolveProviderName(query string) (string, erro
 		return providerName, nil
 	}
 
-	for _, name := range autoPrimaryWebSearchProviders {
-		if opts.providerReady(name) {
-			return name, nil
-		}
-	}
-
 	sogouReady := opts.providerReady("sogou")
 	duckReady := opts.providerReady("duckduckgo")
 	if sogouReady && duckReady {
@@ -1329,6 +1323,12 @@ func (opts WebSearchToolOptions) resolveProviderName(query string) (string, erro
 	}
 	if duckReady {
 		return "duckduckgo", nil
+	}
+
+	for _, name := range autoPrimaryWebSearchProviders {
+		if opts.providerReady(name) {
+			return name, nil
+		}
 	}
 
 	for _, name := range autoFallbackWebSearchProviders {

--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -1312,6 +1312,13 @@ func (opts WebSearchToolOptions) resolveProviderName(query string) (string, erro
 
 	sogouReady := opts.providerReady("sogou")
 	duckReady := opts.providerReady("duckduckgo")
+
+	for _, name := range autoPrimaryWebSearchProviders {
+		if opts.providerReady(name) {
+			return name, nil
+		}
+	}
+
 	if sogouReady && duckReady {
 		if prefersDuckDuckGoQuery(query) {
 			return "duckduckgo", nil
@@ -1325,7 +1332,7 @@ func (opts WebSearchToolOptions) resolveProviderName(query string) (string, erro
 		return "duckduckgo", nil
 	}
 
-	for _, name := range autoPrimaryWebSearchProviders {
+	for _, name := range autoFallbackWebSearchProviders {
 		if opts.providerReady(name) {
 			return name, nil
 		}

--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -485,9 +485,6 @@ func (p *GeminiSearchProvider) Search(
 	count int,
 	rangeCode string,
 ) (string, error) {
-	if rangeCode != "" {
-		return "", fmt.Errorf("gemini search does not support range filter")
-	}
 	if strings.TrimSpace(p.apiKey) == "" {
 		return "", errors.New("no API key provided")
 	}

--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -485,6 +485,9 @@ func (p *GeminiSearchProvider) Search(
 	count int,
 	rangeCode string,
 ) (string, error) {
+	if rangeCode != "" {
+		return "", fmt.Errorf("gemini search does not support range filter")
+	}
 	if strings.TrimSpace(p.apiKey) == "" {
 		return "", errors.New("no API key provided")
 	}
@@ -1258,7 +1261,7 @@ var (
 		"glm_search",
 		"baidu_search",
 	}
-	autoPrimaryWebSearchProviders  = []string{"gemini", "perplexity", "brave", "searxng", "tavily"}
+	autoPrimaryWebSearchProviders  = []string{"perplexity", "brave", "searxng", "tavily", "gemini"}
 	autoFallbackWebSearchProviders = []string{"baidu_search", "glm_search"}
 )
 

--- a/pkg/tools/integration/web_test.go
+++ b/pkg/tools/integration/web_test.go
@@ -1959,6 +1959,22 @@ func TestGeminiSearchProvider_SearchSuccess(t *testing.T) {
 	}
 }
 
+func TestGeminiSearchProvider_SearchRejectsRange(t *testing.T) {
+	provider := &GeminiSearchProvider{
+		apiKey: "google-key",
+		model:  "gemini-2.5-flash",
+		client: http.DefaultClient,
+	}
+
+	_, err := provider.Search(context.Background(), "robotics", 2, "d")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "does not support range") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestGeminiSearchProvider_SearchAPIError(t *testing.T) {
 	provider := &GeminiSearchProvider{
 		apiKey: "google-key",

--- a/pkg/tools/integration/web_test.go
+++ b/pkg/tools/integration/web_test.go
@@ -1853,6 +1853,43 @@ func TestWebTool_AutoProviderPrefersConfiguredProvidersBeforeSogou(t *testing.T)
 	}
 }
 
+func TestWebTool_AutoProviderPrefersGeminiBeforeOtherConfiguredProviders(t *testing.T) {
+	tool, err := NewWebSearchTool(WebSearchToolOptions{
+		GeminiEnabled:        true,
+		GeminiAPIKey:         "google-key",
+		GeminiModel:          "gemini-2.5-flash",
+		GeminiMaxResults:     5,
+		BraveEnabled:         true,
+		BraveAPIKeys:         []string{"brave-key"},
+		BraveMaxResults:      5,
+		SogouEnabled:         true,
+		SogouMaxResults:      5,
+		DuckDuckGoEnabled:    true,
+		DuckDuckGoMaxResults: 5,
+	})
+	if err != nil {
+		t.Fatalf("NewWebSearchTool() error: %v", err)
+	}
+	if _, ok := tool.provider.(*GeminiSearchProvider); !ok {
+		t.Fatalf("expected GeminiSearchProvider, got %T", tool.provider)
+	}
+}
+
+func TestWebTool_GeminiRequiresAPIKey(t *testing.T) {
+	tool, err := NewWebSearchTool(WebSearchToolOptions{
+		Provider:        "gemini",
+		GeminiEnabled:   true,
+		SogouEnabled:    true,
+		SogouMaxResults: 5,
+	})
+	if err != nil {
+		t.Fatalf("NewWebSearchTool() error: %v", err)
+	}
+	if _, ok := tool.provider.(*SogouSearchProvider); !ok {
+		t.Fatalf("expected SogouSearchProvider after missing Gemini API key fallback, got %T", tool.provider)
+	}
+}
+
 func TestWebTool_ExplicitProviderFallsBackWhenMissingCredentials(t *testing.T) {
 	tool, err := NewWebSearchTool(WebSearchToolOptions{
 		Provider:        "brave",

--- a/pkg/tools/integration/web_test.go
+++ b/pkg/tools/integration/web_test.go
@@ -1853,8 +1853,8 @@ func TestWebTool_AutoProviderPrefersConfiguredProvidersBeforeSogou(t *testing.T)
 	}
 }
 
-func TestWebTool_AutoProviderPrefersGeminiBeforeOtherConfiguredProviders(t *testing.T) {
-	tool, err := NewWebSearchTool(WebSearchToolOptions{
+func TestWebTool_AutoProviderPrefersFreeProvidersBeforeGemini(t *testing.T) {
+	opts := WebSearchToolOptions{
 		GeminiEnabled:        true,
 		GeminiAPIKey:         "google-key",
 		GeminiModel:          "gemini-2.5-flash",
@@ -1866,12 +1866,22 @@ func TestWebTool_AutoProviderPrefersGeminiBeforeOtherConfiguredProviders(t *test
 		SogouMaxResults:      5,
 		DuckDuckGoEnabled:    true,
 		DuckDuckGoMaxResults: 5,
-	})
-	if err != nil {
-		t.Fatalf("NewWebSearchTool() error: %v", err)
 	}
-	if _, ok := tool.provider.(*GeminiSearchProvider); !ok {
-		t.Fatalf("expected GeminiSearchProvider, got %T", tool.provider)
+
+	name, err := ResolveWebSearchProviderName(opts, "best robotics companies")
+	if err != nil {
+		t.Fatalf("ResolveWebSearchProviderName() error: %v", err)
+	}
+	if name != "duckduckgo" {
+		t.Fatalf("provider = %q, want duckduckgo", name)
+	}
+
+	name, err = ResolveWebSearchProviderName(opts, "今天上海天气")
+	if err != nil {
+		t.Fatalf("ResolveWebSearchProviderName() error: %v", err)
+	}
+	if name != "sogou" {
+		t.Fatalf("provider = %q, want sogou", name)
 	}
 }
 
@@ -1887,6 +1897,111 @@ func TestWebTool_GeminiRequiresAPIKey(t *testing.T) {
 	}
 	if _, ok := tool.provider.(*SogouSearchProvider); !ok {
 		t.Fatalf("expected SogouSearchProvider after missing Gemini API key fallback, got %T", tool.provider)
+	}
+}
+
+func TestGeminiSearchProvider_SearchSuccess(t *testing.T) {
+	provider := &GeminiSearchProvider{
+		apiKey: "google-key",
+		model:  "gemini-2.5-flash",
+		client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodPost {
+					t.Fatalf("method = %s, want POST", req.Method)
+				}
+				if got := req.Header.Get("x-goog-api-key"); got != "google-key" {
+					t.Fatalf("x-goog-api-key = %q, want google-key", got)
+				}
+				if !strings.Contains(req.URL.String(), "/models/gemini-2.5-flash:generateContent") {
+					t.Fatalf("unexpected URL: %s", req.URL.String())
+				}
+				rec := httptest.NewRecorder()
+				rec.WriteHeader(http.StatusOK)
+				fmt.Fprint(rec, `{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {"text": "Answer paragraph one."},
+          {"text": "Answer paragraph two."}
+        ]
+      },
+      "groundingMetadata": {
+        "groundingChunks": [
+          {"web": {"uri": "https://example.com/a", "title": "Result A"}},
+          {"web": {"uri": "https://example.com/b", "title": "Result B"}},
+          {"web": {"uri": "https://example.com/c", "title": "Result C"}}
+        ]
+      }
+    }
+  ]
+}`)
+				return rec.Result(), nil
+			}),
+		},
+	}
+
+	out, err := provider.Search(context.Background(), "robotics", 2, "")
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if !strings.Contains(out, "Results for: robotics (via Gemini Google Search)") {
+		t.Fatalf("missing header in output: %s", out)
+	}
+	if !strings.Contains(out, "Answer paragraph one.") || !strings.Contains(out, "Answer paragraph two.") {
+		t.Fatalf("missing response text in output: %s", out)
+	}
+	if !strings.Contains(out, "1. Result A") || !strings.Contains(out, "2. Result B") {
+		t.Fatalf("missing citations in output: %s", out)
+	}
+	if strings.Contains(out, "Result C") {
+		t.Fatalf("expected citations to be limited to count=2, got: %s", out)
+	}
+}
+
+func TestGeminiSearchProvider_SearchAPIError(t *testing.T) {
+	provider := &GeminiSearchProvider{
+		apiKey: "google-key",
+		model:  "gemini-2.5-flash",
+		client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				rec := httptest.NewRecorder()
+				rec.WriteHeader(http.StatusTooManyRequests)
+				fmt.Fprint(rec, `{"error":"quota exceeded"}`)
+				return rec.Result(), nil
+			}),
+		},
+	}
+
+	_, err := provider.Search(context.Background(), "robotics", 2, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "status 429") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGeminiSearchProvider_SearchEmptyCandidates(t *testing.T) {
+	provider := &GeminiSearchProvider{
+		apiKey: "google-key",
+		model:  "gemini-2.5-flash",
+		client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				rec := httptest.NewRecorder()
+				rec.WriteHeader(http.StatusOK)
+				fmt.Fprint(rec, `{"candidates":[]}`)
+				return rec.Result(), nil
+			}),
+		},
+	}
+
+	out, err := provider.Search(context.Background(), "robotics", 2, "")
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if out != "No results for: robotics" {
+		t.Fatalf("output = %q, want %q", out, "No results for: robotics")
 	}
 }
 

--- a/pkg/tools/integration/web_test.go
+++ b/pkg/tools/integration/web_test.go
@@ -1853,7 +1853,7 @@ func TestWebTool_AutoProviderPrefersConfiguredProvidersBeforeSogou(t *testing.T)
 	}
 }
 
-func TestWebTool_AutoProviderPrefersFreeProvidersBeforeGemini(t *testing.T) {
+func TestWebTool_AutoProviderPrefersConfiguredProvidersBeforeGemini(t *testing.T) {
 	opts := WebSearchToolOptions{
 		GeminiEnabled:        true,
 		GeminiAPIKey:         "google-key",
@@ -1872,16 +1872,16 @@ func TestWebTool_AutoProviderPrefersFreeProvidersBeforeGemini(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveWebSearchProviderName() error: %v", err)
 	}
-	if name != "duckduckgo" {
-		t.Fatalf("provider = %q, want duckduckgo", name)
+	if name != "gemini" {
+		t.Fatalf("provider = %q, want gemini", name)
 	}
 
 	name, err = ResolveWebSearchProviderName(opts, "今天上海天气")
 	if err != nil {
 		t.Fatalf("ResolveWebSearchProviderName() error: %v", err)
 	}
-	if name != "sogou" {
-		t.Fatalf("provider = %q, want sogou", name)
+	if name != "gemini" {
+		t.Fatalf("provider = %q, want gemini", name)
 	}
 }
 

--- a/pkg/tools/integration/web_test.go
+++ b/pkg/tools/integration/web_test.go
@@ -1872,16 +1872,16 @@ func TestWebTool_AutoProviderPrefersConfiguredProvidersBeforeGemini(t *testing.T
 	if err != nil {
 		t.Fatalf("ResolveWebSearchProviderName() error: %v", err)
 	}
-	if name != "gemini" {
-		t.Fatalf("provider = %q, want gemini", name)
+	if name != "brave" {
+		t.Fatalf("provider = %q, want brave", name)
 	}
 
 	name, err = ResolveWebSearchProviderName(opts, "今天上海天气")
 	if err != nil {
 		t.Fatalf("ResolveWebSearchProviderName() error: %v", err)
 	}
-	if name != "gemini" {
-		t.Fatalf("provider = %q, want gemini", name)
+	if name != "brave" {
+		t.Fatalf("provider = %q, want brave", name)
 	}
 }
 

--- a/pkg/tools/integration/web_test.go
+++ b/pkg/tools/integration/web_test.go
@@ -1909,8 +1909,8 @@ func TestGeminiSearchProvider_SearchSuccess(t *testing.T) {
 				if req.Method != http.MethodPost {
 					t.Fatalf("method = %s, want POST", req.Method)
 				}
-				if got := req.Header.Get("x-goog-api-key"); got != "google-key" {
-					t.Fatalf("x-goog-api-key = %q, want google-key", got)
+				if got := req.Header.Get("X-Goog-Api-Key"); got != "google-key" {
+					t.Fatalf("X-Goog-Api-Key = %q, want google-key", got)
 				}
 				if !strings.Contains(req.URL.String(), "/models/gemini-2.5-flash:generateContent") {
 					t.Fatalf("unexpected URL: %s", req.URL.String())

--- a/pkg/tools/integration/web_test.go
+++ b/pkg/tools/integration/web_test.go
@@ -1959,19 +1959,36 @@ func TestGeminiSearchProvider_SearchSuccess(t *testing.T) {
 	}
 }
 
-func TestGeminiSearchProvider_SearchRejectsRange(t *testing.T) {
+func TestGeminiSearchProvider_SearchIgnoresRange(t *testing.T) {
 	provider := &GeminiSearchProvider{
 		apiKey: "google-key",
 		model:  "gemini-2.5-flash",
-		client: http.DefaultClient,
+		client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				rec := httptest.NewRecorder()
+				rec.WriteHeader(http.StatusOK)
+				fmt.Fprint(rec, `{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {"text": "Recent robotics result."}
+        ]
+      }
+    }
+  ]
+}`)
+				return rec.Result(), nil
+			}),
+		},
 	}
 
-	_, err := provider.Search(context.Background(), "robotics", 2, "d")
-	if err == nil {
-		t.Fatal("expected error")
+	out, err := provider.Search(context.Background(), "robotics", 2, "d")
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "does not support range") {
-		t.Fatalf("unexpected error: %v", err)
+	if !strings.Contains(out, "Recent robotics result.") {
+		t.Fatalf("missing response text in output: %s", out)
 	}
 }
 

--- a/pkg/tools/integration_facade.go
+++ b/pkg/tools/integration_facade.go
@@ -28,6 +28,7 @@ type (
 	TavilySearchProvider     = integrationtools.TavilySearchProvider
 	SogouSearchProvider      = integrationtools.SogouSearchProvider
 	DuckDuckGoSearchProvider = integrationtools.DuckDuckGoSearchProvider
+	GeminiSearchProvider     = integrationtools.GeminiSearchProvider
 	PerplexitySearchProvider = integrationtools.PerplexitySearchProvider
 	SearXNGSearchProvider    = integrationtools.SearXNGSearchProvider
 	GLMSearchProvider        = integrationtools.GLMSearchProvider

--- a/web/backend/api/tools.go
+++ b/web/backend/api/tools.go
@@ -49,6 +49,7 @@ type webSearchProviderConfig struct {
 	BaseURL    string   `json:"base_url,omitempty"`
 	APIKey     string   `json:"api_key,omitempty"`
 	APIKeys    []string `json:"api_keys,omitempty"`
+	Model      string   `json:"model,omitempty"`
 	APIKeySet  bool     `json:"api_key_set,omitempty"`
 }
 
@@ -446,6 +447,14 @@ func (h *Handler) handleUpdateWebSearchConfig(w http.ResponseWriter, r *http.Req
 		cfg.Tools.Web.DuckDuckGo.Enabled = settings.Enabled
 		cfg.Tools.Web.DuckDuckGo.MaxResults = settings.MaxResults
 	}
+	if settings, ok := req.Settings["gemini"]; ok {
+		cfg.Tools.Web.Gemini.Enabled = settings.Enabled
+		cfg.Tools.Web.Gemini.MaxResults = settings.MaxResults
+		cfg.Tools.Web.Gemini.Model = strings.TrimSpace(settings.Model)
+		if key := strings.TrimSpace(settings.APIKey); key != "" {
+			cfg.Tools.Web.Gemini.APIKey = *config.NewSecureString(key)
+		}
+	}
 	if settings, ok := req.Settings["brave"]; ok {
 		cfg.Tools.Web.Brave.Enabled = settings.Enabled
 		cfg.Tools.Web.Brave.MaxResults = settings.MaxResults
@@ -505,7 +514,7 @@ func normalizeWebSearchProvider(provider string) string {
 	switch strings.ToLower(strings.TrimSpace(provider)) {
 	case "", "auto":
 		return "auto"
-	case "sogou", "brave", "tavily", "duckduckgo", "perplexity", "searxng", "glm_search", "baidu_search":
+	case "sogou", "brave", "tavily", "duckduckgo", "gemini", "perplexity", "searxng", "glm_search", "baidu_search":
 		return strings.ToLower(strings.TrimSpace(provider))
 	default:
 		return ""
@@ -548,6 +557,12 @@ func buildWebSearchConfigResponse(cfg *config.Config) webSearchConfigResponse {
 		"duckduckgo": {
 			Enabled:    cfg.Tools.Web.DuckDuckGo.Enabled,
 			MaxResults: cfg.Tools.Web.DuckDuckGo.MaxResults,
+		},
+		"gemini": {
+			Enabled:    cfg.Tools.Web.Gemini.Enabled,
+			MaxResults: cfg.Tools.Web.Gemini.MaxResults,
+			Model:      cfg.Tools.Web.Gemini.Model,
+			APIKeySet:  cfg.Tools.Web.Gemini.APIKey.String() != "",
 		},
 		"brave": {
 			Enabled:    cfg.Tools.Web.Brave.Enabled,
@@ -603,6 +618,13 @@ func buildWebSearchConfigResponse(cfg *config.Config) webSearchConfigResponse {
 			Label:      "DuckDuckGo",
 			Configured: picotools.WebSearchProviderReady(opts, "duckduckgo"),
 			Current:    current == "duckduckgo",
+		},
+		{
+			ID:           "gemini",
+			Label:        "Gemini (Google Search)",
+			Configured:   picotools.WebSearchProviderReady(opts, "gemini"),
+			Current:      current == "gemini",
+			RequiresAuth: true,
 		},
 		{
 			ID:           "brave",

--- a/web/backend/api/tools_test.go
+++ b/web/backend/api/tools_test.go
@@ -540,15 +540,15 @@ func TestHandleUpdateWebSearchConfig_PreservesAndReplacesMultiKeys(t *testing.T)
 	}
 }
 
-func TestResolveCurrentWebSearchProvider_PrefersFreeProvidersInAutoMode(t *testing.T) {
+func TestResolveCurrentWebSearchProvider_PrefersConfiguredProvidersInAutoMode(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Tools.Web.Provider = "auto"
 	cfg.Tools.Web.Sogou.Enabled = true
 	cfg.Tools.Web.Brave.Enabled = true
 	cfg.Tools.Web.Brave.SetAPIKey("brave-test-key")
 
-	if got := resolveCurrentWebSearchProvider(cfg); got != "sogou" {
-		t.Fatalf("resolveCurrentWebSearchProvider() = %q, want sogou", got)
+	if got := resolveCurrentWebSearchProvider(cfg); got != "brave" {
+		t.Fatalf("resolveCurrentWebSearchProvider() = %q, want brave", got)
 	}
 }
 

--- a/web/backend/api/tools_test.go
+++ b/web/backend/api/tools_test.go
@@ -540,15 +540,15 @@ func TestHandleUpdateWebSearchConfig_PreservesAndReplacesMultiKeys(t *testing.T)
 	}
 }
 
-func TestResolveCurrentWebSearchProvider_PrefersConfiguredProvidersBeforeSogou(t *testing.T) {
+func TestResolveCurrentWebSearchProvider_PrefersFreeProvidersInAutoMode(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Tools.Web.Provider = "auto"
 	cfg.Tools.Web.Sogou.Enabled = true
 	cfg.Tools.Web.Brave.Enabled = true
 	cfg.Tools.Web.Brave.SetAPIKey("brave-test-key")
 
-	if got := resolveCurrentWebSearchProvider(cfg); got != "brave" {
-		t.Fatalf("resolveCurrentWebSearchProvider() = %q, want brave", got)
+	if got := resolveCurrentWebSearchProvider(cfg); got != "sogou" {
+		t.Fatalf("resolveCurrentWebSearchProvider() = %q, want sogou", got)
 	}
 }
 

--- a/web/frontend/src/api/tools.ts
+++ b/web/frontend/src/api/tools.ts
@@ -30,6 +30,7 @@ export interface WebSearchProviderConfig {
   max_results: number
   base_url?: string
   api_key?: string
+  model?: string
   api_key_set?: boolean
 }
 

--- a/web/frontend/src/components/agent/tools/web-search-provider-settings.tsx
+++ b/web/frontend/src/components/agent/tools/web-search-provider-settings.tsx
@@ -30,9 +30,12 @@ const apiKeyProviders = new Set([
   "brave",
   "tavily",
   "perplexity",
+  "gemini",
   "glm_search",
   "baidu_search",
 ])
+
+const modelProviders = new Set(["gemini"])
 
 export function WebSearchProviderSettings({
   providerLabelMap,
@@ -223,6 +226,27 @@ function ProviderCard({
                   }
                   placeholder={apiKeyPlaceholder}
                   className="bg-muted/40 hover:bg-muted/60 focus:bg-background focus:ring-primary/20 h-10 rounded-xl border-transparent transition-colors"
+                />
+              </ProviderField>
+            )}
+
+            {modelProviders.has(providerId) && (
+              <ProviderField
+                label={t("pages.agent.tools.web_search.model", "Model")}
+              >
+                <Input
+                  value={settings.model ?? ""}
+                  onChange={(event) =>
+                    updateSettings((current) => ({
+                      ...current,
+                      model: event.target.value,
+                    }))
+                  }
+                  placeholder={t(
+                    "pages.agent.tools.web_search.model_placeholder",
+                    "Optional model override",
+                  )}
+                  className="bg-muted/40 hover:bg-muted/60 focus:bg-background focus:ring-primary/20 h-10 rounded-xl border-transparent shadow-none transition-colors"
                 />
               </ProviderField>
             )}


### PR DESCRIPTION
## Summary

Adds a Gemini Google Search provider for the existing `web_search` tool.

The provider calls Gemini `generateContent` with Google Search grounding and formats the synthesized answer plus grounding citations for the agent. It can be selected explicitly with `tools.web.provider = "gemini"`, and `auto` prefers the existing free providers first before falling through to Gemini and other API-key-backed providers when they are enabled and configured.

## Changes

- Add `tools.web.gemini` config with `enabled`, `api_key`, `model`, and `max_results`.
- Add `GeminiSearchProvider` and provider readiness/routing support.
- Expose Gemini in the web search config API and frontend config type.
- Add Gemini web UI fields for:
  - API key / token
  - model override
- Document the provider in README and tools configuration docs.
- Add tests for auto selection and missing-key fallback behavior.
- Add unit tests for `GeminiSearchProvider.Search()` covering:
  - normal response parsing with grounding citations
  - API error status handling
  - empty candidates
  - citation count limiting

## Validation

- `go test ./pkg/tools/integration -run 'Test(WebTool_AutoProviderPrefersFreeProvidersBeforeGemini|WebTool_GeminiRequiresAPIKey|GeminiSearchProvider_SearchSuccess|GeminiSearchProvider_SearchAPIError|GeminiSearchProvider_SearchEmptyCandidates)' -count=1`
- `go test ./pkg/config ./web/backend/api -count=1`
- Manual web UI validation on the launcher dashboard:
  - Gemini shows `Max Results`, `API Key / Token`, and `Model`
  - API key persists through the secure config path
  - model persists through `config.json`
  - explicit Gemini search works end-to-end against the live Gemini API
  - `auto` mode behavior was smoke-tested with native search disabled and Sogou disabled

## Notes

- `malformed JSON` is not a realistic manual web-UI scenario for the live Gemini endpoint; that branch is better covered by mocked/unit tests than by interactive dashboard testing.
- Gemini does not require a Base URL field in the UI.
