### PR TITLE
fix(seahorse): enforce target token thresholds for leaf summaries

### DIFF
--- a/pkg/seahorse/short_compaction.go
+++ b/pkg/seahorse/short_compaction.go
@@ -602,8 +602,8 @@ func (e *CompactionEngine) generateLeafSummary(
 		}
 	}
 
-	// Check if level 1 succeeded
-	if content != "" && tokenizer.EstimateMessageTokens(providers.Message{Content: content}) < inputTokens {
+	// Level 1 only succeeds if it actually reaches the requested target size.
+	if content != "" && tokenizer.EstimateMessageTokens(providers.Message{Content: content}) <= targetTokens {
 		return content, nil
 	}
 
@@ -627,7 +627,7 @@ func (e *CompactionEngine) generateLeafSummary(
 			return "", err
 		}
 	}
-	if content != "" && tokenizer.EstimateMessageTokens(providers.Message{Content: content}) < inputTokens {
+	if content != "" && tokenizer.EstimateMessageTokens(providers.Message{Content: content}) <= aggressiveTarget {
 		return content, nil
 	}
 

--- a/pkg/seahorse/short_compaction_test.go
+++ b/pkg/seahorse/short_compaction_test.go
@@ -3,6 +3,7 @@ package seahorse
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -694,6 +695,69 @@ func TestGenerateLeafSummaryEscalationToAggressive(t *testing.T) {
 	}
 	if !foundAggressive {
 		t.Error("expected aggressive LLM call (level 2 escalation)")
+	}
+}
+
+func TestGenerateLeafSummaryEscalatesWhenLevel1MissesTarget(t *testing.T) {
+	var calls []string
+	normalContent := strings.Repeat("n", 1000)    // ~404 tokens: below input, above target
+	aggressiveContent := strings.Repeat("a", 450) // ~184 tokens: within aggressive target
+	escalateComplete := func(ctx context.Context, prompt string, opts CompleteOptions) (string, error) {
+		if contains(prompt, "Aggressive summary policy") {
+			calls = append(calls, "aggressive")
+			return aggressiveContent, nil
+		}
+		calls = append(calls, "normal")
+		return normalContent, nil
+	}
+
+	s := openTestStore(t)
+	ce, _ := newTestCompactionEngineWithStore(s, escalateComplete)
+
+	msgs := []Message{
+		{Role: "user", Content: "hello world", TokenCount: 500},
+		{Role: "assistant", Content: "response", TokenCount: 500},
+	}
+
+	content, err := ce.generateLeafSummary(context.Background(), msgs, "")
+	if err != nil {
+		t.Fatalf("generateLeafSummary: %v", err)
+	}
+	if content != aggressiveContent {
+		t.Fatalf("expected aggressive summary after level 1 missed target")
+	}
+	if len(calls) != 2 || calls[0] != "normal" || calls[1] != "aggressive" {
+		t.Fatalf("expected normal then aggressive calls, got %v", calls)
+	}
+}
+
+func TestGenerateLeafSummaryAcceptsContentAtTargetBoundary(t *testing.T) {
+	exactTargetContent := strings.Repeat("x", 488) // (488 + 12) * 2 / 5 = 200 tokens
+	var aggressiveCalled bool
+	complete := func(ctx context.Context, prompt string, opts CompleteOptions) (string, error) {
+		if contains(prompt, "Aggressive summary policy") {
+			aggressiveCalled = true
+		}
+		return exactTargetContent, nil
+	}
+
+	s := openTestStore(t)
+	ce, _ := newTestCompactionEngineWithStore(s, complete)
+
+	msgs := []Message{
+		{Role: "user", Content: "hello world", TokenCount: 286},
+		{Role: "assistant", Content: "response", TokenCount: 286},
+	}
+
+	content, err := ce.generateLeafSummary(context.Background(), msgs, "")
+	if err != nil {
+		t.Fatalf("generateLeafSummary: %v", err)
+	}
+	if content != exactTargetContent {
+		t.Fatalf("expected level 1 summary at target boundary to be accepted")
+	}
+	if aggressiveCalled {
+		t.Fatal("did not expect aggressive retry when level 1 hit target exactly")
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

This PR fixes the acceptance criteria used by `generateLeafSummary` in `pkg/seahorse/short_compaction.go`.

Previously, level 1 and level 2 leaf summaries were accepted as soon as they were smaller than the original input, even if they did not actually reach the intended compression target. This made the check too permissive and could prevent escalation to the more aggressive summarization step.

The fix updates the validation logic so that:
- level 1 output must be `<= targetTokens`
- level 2 output must be `<= aggressiveTarget`

This PR also adds targeted tests to verify:
- summaries that are only slightly smaller than the input are no longer accepted
- summaries exactly at the target boundary are accepted

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Closes #2726  
Related: [#2726](https://github.com/sipeed/picoclaw/issues/2726)

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** [Issue #2726](https://github.com/sipeed/picoclaw/issues/2726)
- **Reasoning:** `generateLeafSummary` already computes `targetTokens` and `aggressiveTarget` and includes them in the prompt, so the acceptance logic should enforce those thresholds as well. Using `inputTokens` was too lenient because it allowed outputs that were only marginally smaller than the original content, reducing the effectiveness of compaction.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** macOS
- **Model/Provider:** N/A 
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

`go test ./pkg/seahorse`

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
