### PR TITLE
fix(telegram): Preserve Telegram forum topic for message tool sends

### DIFF
--- a/pkg/agent/agent_init.go
+++ b/pkg/agent/agent_init.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sipeed/picoclaw/pkg/agent/interfaces"
@@ -157,6 +158,7 @@ func registerSharedTools(
 					tools.ToolSessionKey(ctx),
 					tools.ToolSessionScope(ctx),
 				)
+				inheritToolTopic(ctx, &outboundCtx, channel, chatID, outboundScope)
 				return msgBus.PublishOutbound(pubCtx, bus.OutboundMessage{
 					Context:          outboundCtx,
 					AgentID:          outboundAgentID,
@@ -337,5 +339,31 @@ func registerSharedTools(
 		} else if (spawnEnabled || spawnStatusEnabled) && !cfg.Tools.IsToolEnabled("subagent") {
 			logger.WarnCF("agent", "spawn/spawn_status tools require subagent to be enabled", nil)
 		}
+	}
+}
+
+func inheritToolTopic(
+	ctx context.Context,
+	outboundCtx *bus.InboundContext,
+	channel, chatID string,
+	scope *bus.OutboundScope,
+) {
+	if outboundCtx == nil || strings.TrimSpace(outboundCtx.TopicID) != "" {
+		return
+	}
+	if strings.TrimSpace(channel) != strings.TrimSpace(tools.ToolChannel(ctx)) ||
+		strings.TrimSpace(chatID) != strings.TrimSpace(tools.ToolChatID(ctx)) {
+		return
+	}
+	if scope == nil || scope.Values == nil {
+		return
+	}
+	if topic := strings.TrimPrefix(strings.TrimSpace(scope.Values["topic"]), "topic:"); topic != "" {
+		outboundCtx.TopicID = topic
+		return
+	}
+	chatScope := strings.TrimSpace(scope.Values["chat"])
+	if idx := strings.LastIndex(chatScope, "/"); idx >= 0 && idx+1 < len(chatScope) {
+		outboundCtx.TopicID = strings.TrimSpace(chatScope[idx+1:])
 	}
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1721,6 +1721,40 @@ func (m *messageToolProvider) GetDefaultModel() string {
 	return "message-tool-model"
 }
 
+type explicitChatMessageToolProvider struct {
+	calls int
+}
+
+func (m *explicitChatMessageToolProvider) Chat(
+	ctx context.Context,
+	messages []providers.Message,
+	tools []providers.ToolDefinition,
+	model string,
+	opts map[string]any,
+) (*providers.LLMResponse, error) {
+	m.calls++
+	if m.calls == 1 {
+		return &providers.LLMResponse{
+			Content: "",
+			ToolCalls: []providers.ToolCall{{
+				ID:   "call_message",
+				Type: "function",
+				Name: "message",
+				Arguments: map[string]any{
+					"channel": "telegram",
+					"chat_id": "-1001234567890",
+					"content": "topic tool message",
+				},
+			}},
+		}, nil
+	}
+	return &providers.LLMResponse{}, nil
+}
+
+func (m *explicitChatMessageToolProvider) GetDefaultModel() string {
+	return "message-tool-model"
+}
+
 type reasoningVisibleToolProvider struct {
 	filePath string
 	calls    int
@@ -4438,6 +4472,52 @@ func TestProcessMessage_MessageToolPublishesOutboundWithTurnMetadata(t *testing.
 		}
 		if outbound.Context.Channel != "telegram" || outbound.Context.ChatID != "chat-1" {
 			t.Fatalf("unexpected message tool outbound context: %+v", outbound.Context)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected message tool outbound")
+	}
+}
+
+func TestProcessMessage_MessageToolInheritsTelegramTopicWithExplicitChatID(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Agents.Defaults.Workspace = t.TempDir()
+	cfg.Agents.Defaults.ModelName = "test-model"
+	cfg.Agents.Defaults.MaxTokens = 4096
+	cfg.Agents.Defaults.MaxToolIterations = 10
+	cfg.Session.Dimensions = []string{"chat"}
+
+	msgBus := bus.NewMessageBus()
+	provider := &explicitChatMessageToolProvider{}
+	al := NewAgentLoop(cfg, msgBus, provider)
+
+	response, err := al.processMessage(context.Background(), testInboundMessage(bus.InboundMessage{
+		Context: bus.InboundContext{
+			Channel:   "telegram",
+			ChatID:    "-1001234567890",
+			ChatType:  "group",
+			TopicID:   "6",
+			SenderID:  "user-1",
+			MessageID: "475",
+		},
+		Content: "send an interim message",
+	}))
+	if err != nil {
+		t.Fatalf("processMessage() error = %v", err)
+	}
+	if response == "" {
+		t.Fatal("expected processMessage() to return a final loop response")
+	}
+
+	select {
+	case outbound := <-msgBus.OutboundChan():
+		if outbound.Content != "topic tool message" {
+			t.Fatalf("outbound content = %q, want topic tool message", outbound.Content)
+		}
+		if outbound.Context.Channel != "telegram" || outbound.Context.ChatID != "-1001234567890" {
+			t.Fatalf("unexpected message tool outbound context: %+v", outbound.Context)
+		}
+		if outbound.Context.TopicID != "6" {
+			t.Fatalf("outbound topic = %q, want 6; context=%+v scope=%+v", outbound.Context.TopicID, outbound.Context, outbound.Scope)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected message tool outbound")


### PR DESCRIPTION
## Summary

This PR preserves Telegram forum topic routing for messages sent through the `message` tool.

When an agent is handling a Telegram forum topic, normal final assistant responses already preserve the inbound `TopicID`. However, interim messages sent through the `message` tool could lose the topic when the model supplied an explicit `chat_id` without a forum thread suffix.

## Problem

For Telegram forum groups, this sequence could happen:

1. User sends a message in topic `6`.
2. The agent calls the `message` tool with an explicit target like:
   ```json
   {"channel":"telegram","chat_id":"-1001234567890","content":"Working on it..."}
   ```
3. The `message` tool builds a fresh outbound context with only channel/chat/reply fields.
4. The Telegram channel sends `sendMessage` without `message_thread_id`.
5. Telegram delivers the interim message to the default topic instead of the active topic.

Final assistant responses did not have this issue because they are built from the inbound context and keep `TopicID`.

## Fix

The `message` tool send callback now inherits the current topic when:

- the tool is sending to the same channel/chat as the current turn,
- the outbound context does not already specify a topic,
- and the current session scope contains a topic.

It supports both scope forms PicoClaw already uses:

- explicit `topic` dimension values like `topic:6`, and
- Telegram forum isolation encoded in the `chat` scope value, e.g. `group:-1001234567890/6`.

The fix does not override an explicitly provided topic and does not apply when sending to a different chat.

## Validation

Added a regression test covering a Telegram forum message where the model calls `message` with an explicit `chat_id`; the outbound message now keeps `Context.TopicID == "6"`.

Ran:

```bash
go test ./pkg/agent -run 'TestProcessMessage_MessageTool|TestProcessMessageSync_PreservesInboundTopicOnFinalResponse'
```
