### PR TITLE
fix(agent): send SVG attachments as files

### DIFF
--- a/pkg/agent/agent_utils.go
+++ b/pkg/agent/agent_utils.go
@@ -285,6 +285,12 @@ func inferMediaType(filename, contentType string) string {
 	ct := strings.ToLower(contentType)
 	fn := strings.ToLower(filename)
 
+	// SVG is an image MIME type, but raster-only delivery endpoints such as
+	// Telegram SendPhoto reject it. Treat it as a file/document instead.
+	if strings.HasPrefix(ct, "image/svg") || filepath.Ext(fn) == ".svg" {
+		return "file"
+	}
+
 	if strings.HasPrefix(ct, "image/") {
 		return "image"
 	}
@@ -298,7 +304,7 @@ func inferMediaType(filename, contentType string) string {
 	// Fallback: infer from extension
 	ext := filepath.Ext(fn)
 	switch ext {
-	case ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg":
+	case ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp":
 		return "image"
 	case ".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac", ".wma", ".opus":
 		return "audio"

--- a/pkg/agent/agent_utils_test.go
+++ b/pkg/agent/agent_utils_test.go
@@ -1,0 +1,76 @@
+package agent
+
+import "testing"
+
+func TestInferMediaType(t *testing.T) {
+	tests := []struct {
+		name        string
+		filename    string
+		contentType string
+		want        string
+	}{
+		{
+			name:        "png content type",
+			filename:    "diagram",
+			contentType: "image/png",
+			want:        "image",
+		},
+		{
+			name:        "jpeg extension fallback",
+			filename:    "photo.JPG",
+			contentType: "",
+			want:        "image",
+		},
+		{
+			name:        "svg content type is file",
+			filename:    "diagram",
+			contentType: "image/svg+xml",
+			want:        "file",
+		},
+		{
+			name:        "svg content type with parameters is file",
+			filename:    "diagram",
+			contentType: "image/svg+xml; charset=utf-8",
+			want:        "file",
+		},
+		{
+			name:        "svg extension fallback is file",
+			filename:    "diagram.SVG",
+			contentType: "",
+			want:        "file",
+		},
+		{
+			name:        "audio content type",
+			filename:    "voice",
+			contentType: "audio/ogg",
+			want:        "audio",
+		},
+		{
+			name:        "ogg application content type",
+			filename:    "voice.ogg",
+			contentType: "application/ogg",
+			want:        "audio",
+		},
+		{
+			name:        "video extension fallback",
+			filename:    "clip.MP4",
+			contentType: "",
+			want:        "video",
+		},
+		{
+			name:        "unknown type",
+			filename:    "archive.bin",
+			contentType: "application/octet-stream",
+			want:        "file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferMediaType(tt.filename, tt.contentType)
+			if got != tt.want {
+				t.Fatalf("inferMediaType(%q, %q) = %q, want %q", tt.filename, tt.contentType, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Description

Treat SVG attachments as files in `inferMediaType` so SVG uploads use document/file delivery instead of the raster image path. Raster image MIME types and extensions still classify as `image`.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #2716

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/2716
- **Reasoning:** SVG uses an `image/svg+xml` MIME type, but Telegram photo delivery expects raster image formats. Classifying SVG as `file` sends it through document/file delivery while leaving raster images unchanged.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows
- **Model/Provider:** N/A
- **Channels:** Telegram media delivery classification

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```console
go test -tags goolm,stdjson ./pkg/agent -run '^TestInferMediaType$' -count=1
ok  	github.com/sipeed/picoclaw/pkg/agent	0.246s

go test -tags goolm,stdjson ./pkg/agent -run '^(TestInferMediaType|TestProcessMessage_MediaToolHandledSkipsFollowUpLLMAndFinalText|TestProcessMessage_MediaArtifactCanBeForwardedBySendFile)$' -count=1
ok  	github.com/sipeed/picoclaw/pkg/agent	0.887s
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] Documentation update is not required for this internal bug fix.