### PR TITLE
fix(gateway): keep media store aligned after reload

### DIFF
--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -100,6 +100,10 @@ type Manager struct {
 	channelHashes map[string]string // channel name → config hash
 }
 
+type mediaStoreSetter interface {
+	SetMediaStore(s media.MediaStore)
+}
+
 // ManagerOption configures a channel Manager.
 type ManagerOption func(*Manager)
 
@@ -485,6 +489,22 @@ func NewManager(
 	return m, nil
 }
 
+// SetMediaStore updates the store used by the manager and every channel that
+// accepts media store injection. Gateway reload creates a fresh store, so
+// keeping existing channels on the same store as the agent is required for
+// inbound media refs to remain resolvable after reload.
+func (m *Manager) SetMediaStore(store media.MediaStore) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.mediaStore = store
+	for _, ch := range m.channels {
+		if setter, ok := ch.(mediaStoreSetter); ok {
+			setter.SetMediaStore(store)
+		}
+	}
+}
+
 // GetStreamer implements bus.StreamDelegate.
 // It checks if the named channel supports streaming and returns a Streamer.
 func (m *Manager) GetStreamer(ctx context.Context, channelName, chatID string) (bus.Streamer, bool) {
@@ -582,7 +602,7 @@ func (m *Manager) initChannel(typeName, channelName string) {
 	} else {
 		// Inject MediaStore if channel supports it
 		if m.mediaStore != nil {
-			if setter, ok := ch.(interface{ SetMediaStore(s media.MediaStore) }); ok {
+			if setter, ok := ch.(mediaStoreSetter); ok {
 				setter.SetMediaStore(m.mediaStore)
 			}
 		}

--- a/pkg/channels/manager_test.go
+++ b/pkg/channels/manager_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
 	runtimeevents "github.com/sipeed/picoclaw/pkg/events"
+	"github.com/sipeed/picoclaw/pkg/media"
 	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
@@ -146,6 +147,26 @@ func newTestManager() *Manager {
 		channels: make(map[string]Channel),
 		workers:  make(map[string]*channelWorker),
 		bus:      bus.NewMessageBus(),
+	}
+}
+
+func TestSetMediaStorePropagatesToExistingChannels(t *testing.T) {
+	oldStore := media.NewFileMediaStore()
+	newStore := media.NewFileMediaStore()
+	ch := &mockChannel{}
+	ch.SetMediaStore(oldStore)
+
+	m := newTestManager()
+	m.mediaStore = oldStore
+	m.channels["telegram"] = ch
+
+	m.SetMediaStore(newStore)
+
+	if m.mediaStore != newStore {
+		t.Fatal("manager media store was not updated")
+	}
+	if got := ch.GetMediaStore(); got != newStore {
+		t.Fatalf("channel media store = %p, want %p", got, newStore)
 	}
 }
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -646,6 +646,9 @@ func restartServices(
 	if fms, ok := runningServices.MediaStore.(*media.FileMediaStore); ok {
 		fms.Start()
 	}
+	if runningServices.ChannelManager != nil {
+		runningServices.ChannelManager.SetMediaStore(runningServices.MediaStore)
+	}
 	al.SetMediaStore(runningServices.MediaStore)
 
 	al.SetChannelManager(runningServices.ChannelManager)


### PR DESCRIPTION
##  Description

Keep the channel manager media store aligned with the agent media store after gateway reloads.

The reload path creates a fresh media store for cleanup lifecycle, then injects it into the agent. Existing channels were still holding the previous store, so inbound media refs created by channels after `/reload` could not be resolved by the agent during voice transcription. This updates the channel manager store and propagates it to existing channels before channel reload completes.

##  Type of Change
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Documentation update
- [ ]  Code refactoring (no functional changes, no api changes)

##  AI Code Generation
- [ ]  Fully AI-generated (100% AI, 0% Human)
- [x]  Mostly AI-generated (AI draft, Human verified/modified)
- [ ]  Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #2780

##  Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/2780
- **Reasoning:** Telegram and other channels store inbound media through the channel media store, while the agent resolves those refs for transcription. Both sides must share the same store after reload.

##  Test Environment
- **Hardware:** PC
- **OS:** Windows
- **Model/Provider:** N/A
- **Channels:** Telegram voice reload path covered by channel/gateway media-store tests

##  Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```console
go test -tags goolm,stdjson ./pkg/channels -run '^TestSetMediaStorePropagatesToExistingChannels$' -count=1
ok  	github.com/sipeed/picoclaw/pkg/channels	0.251s

go test -tags goolm,stdjson ./pkg/channels -count=1
ok  	github.com/sipeed/picoclaw/pkg/channels	14.195s

go test -tags goolm,stdjson ./pkg/gateway -count=1
ok  	github.com/sipeed/picoclaw/pkg/gateway	1.025s
```

</details>

##  Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] Documentation update is not required for this internal bug fix.