### PR TITLE
feat(session): add per-message created_at timestamps

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -370,6 +370,8 @@ func TestProcessMessage_BtwCommandRunsWithoutPersistingHistory(t *testing.T) {
 	defaultAgent.Sessions.SetHistory(sessionKey, initialHistory)
 	defaultAgent.Sessions.SetSummary(sessionKey, "The team decided to keep state request-scoped.")
 
+	initialHistory = defaultAgent.Sessions.GetHistory(sessionKey)
+
 	response, err := al.processMessage(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("processMessage() error = %v", err)
@@ -487,6 +489,8 @@ func TestProcessMessage_BtwCommandUsesIsolatedProvider(t *testing.T) {
 		{Role: "assistant", Content: "Right, keep it request-scoped."},
 	}
 	defaultAgent.Sessions.SetHistory(mainSessionKey, initialHistory)
+
+	initialHistory = defaultAgent.Sessions.GetHistory(mainSessionKey)
 
 	// Process a /btw command
 	response, err := al.processMessage(context.Background(), bus.InboundMessage{

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1062,6 +1062,8 @@ func TestProcessMessage_BtwCommandRunsWithoutPersistingHistory(t *testing.T) {
 	defaultAgent.Sessions.SetHistory(sessionKey, initialHistory)
 	defaultAgent.Sessions.SetSummary(sessionKey, "The team decided to keep state request-scoped.")
 
+	initialHistory = defaultAgent.Sessions.GetHistory(sessionKey)
+
 	response, err := al.processMessage(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("processMessage() error = %v", err)
@@ -1179,6 +1181,8 @@ func TestProcessMessage_BtwCommandUsesIsolatedProvider(t *testing.T) {
 		{Role: "assistant", Content: "Right, keep it request-scoped."},
 	}
 	defaultAgent.Sessions.SetHistory(mainSessionKey, initialHistory)
+
+	initialHistory = defaultAgent.Sessions.GetHistory(mainSessionKey)
 
 	// Process a /btw command
 	response, err := al.processMessage(context.Background(), bus.InboundMessage{

--- a/pkg/agent/steering_test.go
+++ b/pkg/agent/steering_test.go
@@ -1618,6 +1618,8 @@ func TestAgentLoop_InterruptHard_RestoresSession(t *testing.T) {
 	}
 	defaultAgent.Sessions.SetHistory(sessionKey, originalHistory)
 
+	originalHistory = defaultAgent.Sessions.GetHistory(sessionKey)
+
 	runtimeCh, closeRuntimeEvents := subscribeRuntimeEventsForTest(
 		t,
 		al,

--- a/pkg/agent/steering_test.go
+++ b/pkg/agent/steering_test.go
@@ -1306,6 +1306,8 @@ func TestAgentLoop_InterruptHard_RestoresSession(t *testing.T) {
 	}
 	defaultAgent.Sessions.SetHistory(sessionKey, originalHistory)
 
+	originalHistory = defaultAgent.Sessions.GetHistory(sessionKey)
+
 	runtimeCh, closeRuntimeEvents := subscribeRuntimeEventsForTest(
 		t,
 		al,

--- a/pkg/agent/turn_profile_test.go
+++ b/pkg/agent/turn_profile_test.go
@@ -105,9 +105,10 @@ func TestTurnProfile_DisabledPreservesDefaultHistoryAndPrompt(t *testing.T) {
 	al := newTurnProfileAgentLoop(t, cfg, provider)
 	agent := al.GetRegistry().GetDefaultAgent()
 	sessionKey := "agent:default:test-default"
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	initialHistory := []providers.Message{
-		{Role: "user", Content: "old user"},
-		{Role: "assistant", Content: "old assistant"},
+		{Role: "user", Content: "old user", CreatedAt: &ts},
+		{Role: "assistant", Content: "old assistant", CreatedAt: &ts},
 	}
 	agent.Sessions.SetHistory(sessionKey, initialHistory)
 	agent.Sessions.SetSummary(sessionKey, "old summary")
@@ -154,9 +155,10 @@ func TestTurnProfile_HistoryOffSuppressesHistoryAndPersistence(t *testing.T) {
 	al := newTurnProfileAgentLoop(t, cfg, provider)
 	agent := al.GetRegistry().GetDefaultAgent()
 	sessionKey := "agent:default:test-history-off"
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	initialHistory := []providers.Message{
-		{Role: "user", Content: "old user"},
-		{Role: "assistant", Content: "old assistant"},
+		{Role: "user", Content: "old user", CreatedAt: &ts},
+		{Role: "assistant", Content: "old assistant", CreatedAt: &ts},
 	}
 	agent.Sessions.SetHistory(sessionKey, initialHistory)
 	agent.Sessions.SetSummary(sessionKey, "old summary")

--- a/pkg/agent/turn_state.go
+++ b/pkg/agent/turn_state.go
@@ -511,10 +511,25 @@ func (ts *turnState) restoreSession(agent *AgentInstance) error {
 	return agent.Sessions.Save(ts.sessionKey)
 }
 
+// messagesContentEqual compares two message slices by content only, ignoring CreatedAt.
+// JSON roundtrip loses the monotonic clock portion of time.Time, so direct
+// reflect.DeepEqual would always differ on messages that roundtripped through
+// the JSONL store.
+func messagesContentEqual(a, b []providers.Message) bool {
+	for i := range a {
+		aCopy, bCopy := a[i], b[i]
+		aCopy.CreatedAt, bCopy.CreatedAt = nil, nil
+		if !reflect.DeepEqual(aCopy, bCopy) {
+			return false
+		}
+	}
+	return true
+}
+
 func matchingTurnMessageTail(history, persisted []providers.Message) int {
 	maxMatch := min(len(history), len(persisted))
 	for size := maxMatch; size > 0; size-- {
-		if reflect.DeepEqual(history[len(history)-size:], persisted[len(persisted)-size:]) {
+		if messagesContentEqual(history[len(history)-size:], persisted[len(persisted)-size:]) {
 			return size
 		}
 	}

--- a/pkg/agent/turn_state.go
+++ b/pkg/agent/turn_state.go
@@ -686,10 +686,25 @@ func (ts *turnState) restoreSession(agent *AgentInstance) error {
 	return agent.Sessions.Save(ts.sessionKey)
 }
 
+// messagesContentEqual compares two message slices by content only, ignoring CreatedAt.
+// JSON roundtrip loses the monotonic clock portion of time.Time, so direct
+// reflect.DeepEqual would always differ on messages that roundtripped through
+// the JSONL store.
+func messagesContentEqual(a, b []providers.Message) bool {
+	for i := range a {
+		aCopy, bCopy := a[i], b[i]
+		aCopy.CreatedAt, bCopy.CreatedAt = nil, nil
+		if !reflect.DeepEqual(aCopy, bCopy) {
+			return false
+		}
+	}
+	return true
+}
+
 func matchingTurnMessageTail(history, persisted []providers.Message) int {
 	maxMatch := min(len(history), len(persisted))
 	for size := maxMatch; size > 0; size-- {
-		if reflect.DeepEqual(history[len(history)-size:], persisted[len(persisted)-size:]) {
+		if messagesContentEqual(history[len(history)-size:], persisted[len(persisted)-size:]) {
 			return size
 		}
 	}

--- a/pkg/memory/jsonl.go
+++ b/pkg/memory/jsonl.go
@@ -561,6 +561,12 @@ func (s *JSONLStore) addMsg(sessionKey string, msg providers.Message) error {
 	l.Lock()
 	defer l.Unlock()
 
+	now := time.Now()
+
+	if msg.CreatedAt == nil {
+		msg.CreatedAt = &now
+	}
+
 	// Append the message as a single JSON line.
 	line, err := json.Marshal(msg)
 	if err != nil {
@@ -598,7 +604,6 @@ func (s *JSONLStore) addMsg(sessionKey string, msg providers.Message) error {
 	if err != nil {
 		return err
 	}
-	now := time.Now()
 	if meta.Count == 0 && meta.CreatedAt.IsZero() {
 		meta.CreatedAt = now
 	}
@@ -725,6 +730,12 @@ func (s *JSONLStore) SetHistory(
 	meta.Skip = 0
 	meta.Count = len(history)
 	meta.UpdatedAt = now
+
+	for i := range history {
+		if history[i].CreatedAt == nil {
+			history[i].CreatedAt = &now
+		}
+	}
 
 	// Write meta BEFORE rewriting the JSONL file. If we crash between
 	// the two writes, meta has Skip=0 and the old file is still intact,

--- a/pkg/memory/jsonl_test.go
+++ b/pkg/memory/jsonl_test.go
@@ -1032,6 +1032,137 @@ func TestMultipleSessions_Isolation(t *testing.T) {
 	}
 }
 
+func TestStore_SetsCreatedAtWhenNil(t *testing.T) {
+	type writeOp struct {
+		name string
+		fn   func(store *JSONLStore, key string) (expectedCount int)
+	}
+
+	ops := []writeOp{
+		{
+			name: "AddMessage",
+			fn: func(store *JSONLStore, key string) int {
+				if err := store.AddMessage(context.Background(), key, "user", "hello"); err != nil {
+					t.Fatalf("AddMessage: %v", err)
+				}
+				return 1
+			},
+		},
+		{
+			name: "AddFullMessage",
+			fn: func(store *JSONLStore, key string) int {
+				if err := store.AddFullMessage(context.Background(), key, providers.Message{
+					Role:    "user",
+					Content: "hello from full",
+				}); err != nil {
+					t.Fatalf("AddFullMessage: %v", err)
+				}
+				return 1
+			},
+		},
+		{
+			name: "SetHistory",
+			fn: func(store *JSONLStore, key string) int {
+				if err := store.SetHistory(context.Background(), key, []providers.Message{
+					{Role: "user", Content: "msg1"},
+					{Role: "assistant", Content: "msg2"},
+				}); err != nil {
+					t.Fatalf("SetHistory: %v", err)
+				}
+				return 2
+			},
+		},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			store := newTestStore(t)
+			key := "s1"
+
+			before := time.Now().Add(-time.Second)
+			expectedCount := op.fn(store, key)
+			after := time.Now().Add(time.Second)
+
+			history, err := store.GetHistory(context.Background(), key)
+			if err != nil {
+				t.Fatalf("GetHistory: %v", err)
+			}
+			if len(history) != expectedCount {
+				t.Fatalf("expected %d messages, got %d", expectedCount, len(history))
+			}
+			for i := range history {
+				if history[i].CreatedAt == nil || history[i].CreatedAt.IsZero() {
+					t.Errorf("message %d CreatedAt is zero — not set by %s", i, op.name)
+				}
+				if history[i].CreatedAt.Before(before) || history[i].CreatedAt.After(after) {
+					t.Errorf("message %d CreatedAt %v outside expected window [%v, %v]", i, history[i].CreatedAt, before, after)
+				}
+			}
+		})
+	}
+}
+
+func TestStore_PreservesExistingCreatedAt(t *testing.T) {
+	t1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 1, 1, 11, 0, 0, 0, time.UTC)
+
+	type writeOp struct {
+		name      string
+		fn        func(store *JSONLStore, key string)
+		wantTimes []time.Time
+	}
+
+	ops := []writeOp{
+		{
+			name: "AddFullMessage",
+			fn: func(store *JSONLStore, key string) {
+				if err := store.AddFullMessage(context.Background(), key, providers.Message{
+					Role:      "user",
+					Content:   "custom time",
+					CreatedAt: &t1,
+				}); err != nil {
+					t.Fatalf("AddFullMessage: %v", err)
+				}
+			},
+			wantTimes: []time.Time{t1},
+		},
+		{
+			name: "SetHistory",
+			fn: func(store *JSONLStore, key string) {
+				if err := store.SetHistory(context.Background(), key, []providers.Message{
+					{Role: "user", Content: "msg1", CreatedAt: &t1},
+					{Role: "assistant", Content: "msg2", CreatedAt: &t2},
+				}); err != nil {
+					t.Fatalf("SetHistory: %v", err)
+				}
+			},
+			wantTimes: []time.Time{t1, t2},
+		},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			store := newTestStore(t)
+			key := "s1"
+
+			op.fn(store, key)
+
+			history, err := store.GetHistory(context.Background(), key)
+			if err != nil {
+				t.Fatalf("GetHistory: %v", err)
+			}
+			if len(history) != len(op.wantTimes) {
+				t.Fatalf("expected %d messages, got %d", len(op.wantTimes), len(history))
+			}
+			for i, want := range op.wantTimes {
+				if history[i].CreatedAt == nil || !history[i].CreatedAt.Equal(want) {
+					t.Errorf("message %d CreatedAt = %v, want %v (should preserve caller-provided time)", i, history[i].CreatedAt, want)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkAddMessage(b *testing.B) {
 	dir := b.TempDir()
 	store, err := NewJSONLStore(dir)

--- a/pkg/memory/jsonl_test.go
+++ b/pkg/memory/jsonl_test.go
@@ -1095,7 +1095,10 @@ func TestStore_SetsCreatedAtWhenNil(t *testing.T) {
 					t.Errorf("message %d CreatedAt is zero — not set by %s", i, op.name)
 				}
 				if history[i].CreatedAt.Before(before) || history[i].CreatedAt.After(after) {
-					t.Errorf("message %d CreatedAt %v outside expected window [%v, %v]", i, history[i].CreatedAt, before, after)
+					t.Errorf(
+						"message %d CreatedAt %v outside expected window [%v, %v]",
+						i, history[i].CreatedAt, before, after,
+					)
 				}
 			}
 		})
@@ -1156,7 +1159,10 @@ func TestStore_PreservesExistingCreatedAt(t *testing.T) {
 			}
 			for i, want := range op.wantTimes {
 				if history[i].CreatedAt == nil || !history[i].CreatedAt.Equal(want) {
-					t.Errorf("message %d CreatedAt = %v, want %v (should preserve caller-provided time)", i, history[i].CreatedAt, want)
+					t.Errorf(
+						"message %d CreatedAt = %v, want %v (should preserve caller-provided time)",
+						i, history[i].CreatedAt, want,
+					)
 				}
 			}
 		})

--- a/pkg/memory/jsonl_test.go
+++ b/pkg/memory/jsonl_test.go
@@ -1121,7 +1121,10 @@ func TestStore_SetsCreatedAtWhenNil(t *testing.T) {
 					t.Errorf("message %d CreatedAt is zero — not set by %s", i, op.name)
 				}
 				if history[i].CreatedAt.Before(before) || history[i].CreatedAt.After(after) {
-					t.Errorf("message %d CreatedAt %v outside expected window [%v, %v]", i, history[i].CreatedAt, before, after)
+					t.Errorf(
+						"message %d CreatedAt %v outside expected window [%v, %v]",
+						i, history[i].CreatedAt, before, after,
+					)
 				}
 			}
 		})
@@ -1182,7 +1185,10 @@ func TestStore_PreservesExistingCreatedAt(t *testing.T) {
 			}
 			for i, want := range op.wantTimes {
 				if history[i].CreatedAt == nil || !history[i].CreatedAt.Equal(want) {
-					t.Errorf("message %d CreatedAt = %v, want %v (should preserve caller-provided time)", i, history[i].CreatedAt, want)
+					t.Errorf(
+						"message %d CreatedAt = %v, want %v (should preserve caller-provided time)",
+						i, history[i].CreatedAt, want,
+					)
 				}
 			}
 		})

--- a/pkg/memory/jsonl_test.go
+++ b/pkg/memory/jsonl_test.go
@@ -1058,6 +1058,137 @@ func TestMultipleSessions_Isolation(t *testing.T) {
 	}
 }
 
+func TestStore_SetsCreatedAtWhenNil(t *testing.T) {
+	type writeOp struct {
+		name string
+		fn   func(store *JSONLStore, key string) (expectedCount int)
+	}
+
+	ops := []writeOp{
+		{
+			name: "AddMessage",
+			fn: func(store *JSONLStore, key string) int {
+				if err := store.AddMessage(context.Background(), key, "user", "hello"); err != nil {
+					t.Fatalf("AddMessage: %v", err)
+				}
+				return 1
+			},
+		},
+		{
+			name: "AddFullMessage",
+			fn: func(store *JSONLStore, key string) int {
+				if err := store.AddFullMessage(context.Background(), key, providers.Message{
+					Role:    "user",
+					Content: "hello from full",
+				}); err != nil {
+					t.Fatalf("AddFullMessage: %v", err)
+				}
+				return 1
+			},
+		},
+		{
+			name: "SetHistory",
+			fn: func(store *JSONLStore, key string) int {
+				if err := store.SetHistory(context.Background(), key, []providers.Message{
+					{Role: "user", Content: "msg1"},
+					{Role: "assistant", Content: "msg2"},
+				}); err != nil {
+					t.Fatalf("SetHistory: %v", err)
+				}
+				return 2
+			},
+		},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			store := newTestStore(t)
+			key := "s1"
+
+			before := time.Now().Add(-time.Second)
+			expectedCount := op.fn(store, key)
+			after := time.Now().Add(time.Second)
+
+			history, err := store.GetHistory(context.Background(), key)
+			if err != nil {
+				t.Fatalf("GetHistory: %v", err)
+			}
+			if len(history) != expectedCount {
+				t.Fatalf("expected %d messages, got %d", expectedCount, len(history))
+			}
+			for i := range history {
+				if history[i].CreatedAt == nil || history[i].CreatedAt.IsZero() {
+					t.Errorf("message %d CreatedAt is zero — not set by %s", i, op.name)
+				}
+				if history[i].CreatedAt.Before(before) || history[i].CreatedAt.After(after) {
+					t.Errorf("message %d CreatedAt %v outside expected window [%v, %v]", i, history[i].CreatedAt, before, after)
+				}
+			}
+		})
+	}
+}
+
+func TestStore_PreservesExistingCreatedAt(t *testing.T) {
+	t1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 1, 1, 11, 0, 0, 0, time.UTC)
+
+	type writeOp struct {
+		name      string
+		fn        func(store *JSONLStore, key string)
+		wantTimes []time.Time
+	}
+
+	ops := []writeOp{
+		{
+			name: "AddFullMessage",
+			fn: func(store *JSONLStore, key string) {
+				if err := store.AddFullMessage(context.Background(), key, providers.Message{
+					Role:      "user",
+					Content:   "custom time",
+					CreatedAt: &t1,
+				}); err != nil {
+					t.Fatalf("AddFullMessage: %v", err)
+				}
+			},
+			wantTimes: []time.Time{t1},
+		},
+		{
+			name: "SetHistory",
+			fn: func(store *JSONLStore, key string) {
+				if err := store.SetHistory(context.Background(), key, []providers.Message{
+					{Role: "user", Content: "msg1", CreatedAt: &t1},
+					{Role: "assistant", Content: "msg2", CreatedAt: &t2},
+				}); err != nil {
+					t.Fatalf("SetHistory: %v", err)
+				}
+			},
+			wantTimes: []time.Time{t1, t2},
+		},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			store := newTestStore(t)
+			key := "s1"
+
+			op.fn(store, key)
+
+			history, err := store.GetHistory(context.Background(), key)
+			if err != nil {
+				t.Fatalf("GetHistory: %v", err)
+			}
+			if len(history) != len(op.wantTimes) {
+				t.Fatalf("expected %d messages, got %d", len(op.wantTimes), len(history))
+			}
+			for i, want := range op.wantTimes {
+				if history[i].CreatedAt == nil || !history[i].CreatedAt.Equal(want) {
+					t.Errorf("message %d CreatedAt = %v, want %v (should preserve caller-provided time)", i, history[i].CreatedAt, want)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkAddMessage(b *testing.B) {
 	dir := b.TempDir()
 	store, err := NewJSONLStore(dir)

--- a/pkg/providers/protocoltypes/types.go
+++ b/pkg/providers/protocoltypes/types.go
@@ -1,5 +1,7 @@
 package protocoltypes
 
+import "time"
+
 type ToolCall struct {
 	ID               string         `json:"id"`
 	Type             string         `json:"type,omitempty"`
@@ -81,6 +83,7 @@ type Attachment struct {
 type Message struct {
 	Role             string         `json:"role"`
 	Content          string         `json:"content"`
+	CreatedAt        *time.Time     `json:"created_at,omitempty"`
 	Media            []string       `json:"media,omitempty"`
 	Attachments      []Attachment   `json:"attachments,omitempty"`
 	ReasoningContent string         `json:"reasoning_content,omitempty"`

--- a/pkg/providers/protocoltypes/types.go
+++ b/pkg/providers/protocoltypes/types.go
@@ -1,5 +1,7 @@
 package protocoltypes
 
+import "time"
+
 type ToolCall struct {
 	ID               string         `json:"id"`
 	Type             string         `json:"type,omitempty"`
@@ -87,6 +89,7 @@ type Message struct {
 	Role             string         `json:"role"`
 	Content          string         `json:"content"`
 	ModelName        string         `json:"model_name,omitempty"`
+	CreatedAt        *time.Time     `json:"created_at,omitempty"`
 	Media            []string       `json:"media,omitempty"`
 	Attachments      []Attachment   `json:"attachments,omitempty"`
 	ReasoningContent string         `json:"reasoning_content,omitempty"`

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -87,8 +87,13 @@ func (sm *SessionManager) AddFullMessage(sessionKey string, msg providers.Messag
 		sm.sessions[sessionKey] = session
 	}
 
+	now := time.Now()
+	if msg.CreatedAt == nil {
+		msg.CreatedAt = &now
+	}
+
 	session.Messages = append(session.Messages, msg)
-	session.Updated = time.Now()
+	session.Updated = now
 }
 
 func (sm *SessionManager) GetHistory(key string) []providers.Message {
@@ -300,7 +305,13 @@ func (sm *SessionManager) SetHistory(key string, history []providers.Message) {
 		// from the caller's slice.
 		msgs := make([]providers.Message, len(history))
 		copy(msgs, history)
+		now := time.Now()
+		for i := range msgs {
+			if msgs[i].CreatedAt == nil {
+				msgs[i].CreatedAt = &now
+			}
+		}
 		session.Messages = msgs
-		session.Updated = time.Now()
+		session.Updated = now
 	}
 }

--- a/web/backend/api/session.go
+++ b/web/backend/api/session.go
@@ -50,6 +50,7 @@ type sessionChatMessage struct {
 	Role        string                  `json:"role"`
 	Content     string                  `json:"content"`
 	Kind        string                  `json:"kind,omitempty"`
+	CreatedAt   *time.Time              `json:"created_at,omitempty"`
 	Media       []string                `json:"media,omitempty"`
 	Attachments []sessionChatAttachment `json:"attachments,omitempty"`
 	ToolCalls   []utils.VisibleToolCall `json:"tool_calls,omitempty"`
@@ -510,6 +511,7 @@ func sessionTranscriptMessages(
 			chatMsg := sessionChatMessage{
 				Role:        "user",
 				Content:     msg.Content,
+				CreatedAt:   msg.CreatedAt,
 				Media:       append([]string(nil), msg.Media...),
 				Attachments: attachments,
 			}
@@ -530,8 +532,9 @@ func sessionTranscriptMessages(
 			toolCallsMsg, hasToolCallsMsg := assistantToolCallsMessage(
 				msg.ToolCalls,
 				toolFeedbackMaxArgsLength,
+				msg.CreatedAt,
 			)
-			visibleToolMessages := visibleAssistantToolMessages(msg.ToolCalls)
+			visibleToolMessages := visibleAssistantToolMessages(msg.ToolCalls, msg.CreatedAt)
 
 			// Pico web chat can persist both visible `message` tool output and a
 			// later plain assistant reply in the same turn. Hide only the fixed
@@ -556,6 +559,7 @@ func sessionTranscriptMessages(
 			chatMsg := sessionChatMessage{
 				Role:        "assistant",
 				Content:     content,
+				CreatedAt:   msg.CreatedAt,
 				Media:       append([]string(nil), msg.Media...),
 				Attachments: attachments,
 			}
@@ -682,15 +686,17 @@ func assistantThoughtMessage(msg providers.Message) (sessionChatMessage, bool) {
 		return sessionChatMessage{}, false
 	}
 	return sessionChatMessage{
-		Role:    "assistant",
-		Content: reasoning,
-		Kind:    "thought",
+		Role:      "assistant",
+		Content:   reasoning,
+		Kind:      "thought",
+		CreatedAt: msg.CreatedAt,
 	}, true
 }
 
 func assistantToolCallsMessage(
 	toolCalls []providers.ToolCall,
 	toolFeedbackMaxArgsLength int,
+	createdAt *time.Time,
 ) (sessionChatMessage, bool) {
 	if len(toolCalls) == 0 {
 		return sessionChatMessage{}, false
@@ -707,6 +713,7 @@ func assistantToolCallsMessage(
 	return sessionChatMessage{
 		Role:      "assistant",
 		Kind:      "tool_calls",
+		CreatedAt: createdAt,
 		ToolCalls: visibleToolCalls,
 	}, true
 }
@@ -718,7 +725,7 @@ func visibleAssistantToolArgsPreview(
 	return utils.VisibleToolCallArgumentsPreview(tc, toolFeedbackMaxArgsLength)
 }
 
-func visibleAssistantToolMessages(toolCalls []providers.ToolCall) []sessionChatMessage {
+func visibleAssistantToolMessages(toolCalls []providers.ToolCall, createdAt *time.Time) []sessionChatMessage {
 	if len(toolCalls) == 0 {
 		return nil
 	}
@@ -734,8 +741,9 @@ func visibleAssistantToolMessages(toolCalls []providers.ToolCall) []sessionChatM
 			continue
 		}
 		messages = append(messages, sessionChatMessage{
-			Role:    "assistant",
-			Content: content,
+			Role:      "assistant",
+			Content:   content,
+			CreatedAt: createdAt,
 		})
 	}
 
@@ -918,6 +926,11 @@ func (h *Handler) handleGetSession(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	for i := range sess.Messages {
+		if sess.Messages[i].CreatedAt == nil {
+			sess.Messages[i].CreatedAt = &sess.Updated
+		}
+	}
 	messages := detailSessionMessages(sess.Messages, toolFeedbackMaxArgsLength)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/web/backend/api/session.go
+++ b/web/backend/api/session.go
@@ -732,7 +732,11 @@ func visibleAssistantToolArgsPreview(
 	return utils.VisibleToolCallArgumentsPreview(tc, toolFeedbackMaxArgsLength)
 }
 
-func visibleAssistantToolMessages(toolCalls []providers.ToolCall, modelName string, createdAt *time.Time) []sessionChatMessage {
+func visibleAssistantToolMessages(
+	toolCalls []providers.ToolCall,
+	modelName string,
+	createdAt *time.Time,
+) []sessionChatMessage {
 	if len(toolCalls) == 0 {
 		return nil
 	}

--- a/web/backend/api/session.go
+++ b/web/backend/api/session.go
@@ -51,6 +51,7 @@ type sessionChatMessage struct {
 	Content     string                  `json:"content"`
 	Kind        string                  `json:"kind,omitempty"`
 	ModelName   string                  `json:"model_name,omitempty"`
+	CreatedAt   *time.Time              `json:"created_at,omitempty"`
 	Media       []string                `json:"media,omitempty"`
 	Attachments []sessionChatAttachment `json:"attachments,omitempty"`
 	ToolCalls   []utils.VisibleToolCall `json:"tool_calls,omitempty"`
@@ -512,6 +513,7 @@ func sessionTranscriptMessages(
 				Role:        "user",
 				Content:     msg.Content,
 				ModelName:   msg.ModelName,
+				CreatedAt:   msg.CreatedAt,
 				Media:       append([]string(nil), msg.Media...),
 				Attachments: attachments,
 			}
@@ -533,8 +535,9 @@ func sessionTranscriptMessages(
 				msg.ToolCalls,
 				msg.ModelName,
 				toolFeedbackMaxArgsLength,
+				msg.CreatedAt,
 			)
-			visibleToolMessages := visibleAssistantToolMessages(msg.ToolCalls, msg.ModelName)
+			visibleToolMessages := visibleAssistantToolMessages(msg.ToolCalls, msg.ModelName, msg.CreatedAt)
 
 			// Pico web chat can persist both visible `message` tool output and a
 			// later plain assistant reply in the same turn. Hide only the fixed
@@ -560,6 +563,7 @@ func sessionTranscriptMessages(
 				Role:        "assistant",
 				Content:     content,
 				ModelName:   msg.ModelName,
+				CreatedAt:   msg.CreatedAt,
 				Media:       append([]string(nil), msg.Media...),
 				Attachments: attachments,
 			}
@@ -690,6 +694,7 @@ func assistantThoughtMessage(msg providers.Message) (sessionChatMessage, bool) {
 		Content:   reasoning,
 		Kind:      "thought",
 		ModelName: msg.ModelName,
+		CreatedAt: msg.CreatedAt,
 	}, true
 }
 
@@ -697,6 +702,7 @@ func assistantToolCallsMessage(
 	toolCalls []providers.ToolCall,
 	modelName string,
 	toolFeedbackMaxArgsLength int,
+	createdAt *time.Time,
 ) (sessionChatMessage, bool) {
 	if len(toolCalls) == 0 {
 		return sessionChatMessage{}, false
@@ -714,6 +720,7 @@ func assistantToolCallsMessage(
 		Role:      "assistant",
 		Kind:      "tool_calls",
 		ModelName: modelName,
+		CreatedAt: createdAt,
 		ToolCalls: visibleToolCalls,
 	}, true
 }
@@ -725,7 +732,7 @@ func visibleAssistantToolArgsPreview(
 	return utils.VisibleToolCallArgumentsPreview(tc, toolFeedbackMaxArgsLength)
 }
 
-func visibleAssistantToolMessages(toolCalls []providers.ToolCall, modelName string) []sessionChatMessage {
+func visibleAssistantToolMessages(toolCalls []providers.ToolCall, modelName string, createdAt *time.Time) []sessionChatMessage {
 	if len(toolCalls) == 0 {
 		return nil
 	}
@@ -744,6 +751,7 @@ func visibleAssistantToolMessages(toolCalls []providers.ToolCall, modelName stri
 			Role:      "assistant",
 			Content:   content,
 			ModelName: modelName,
+			CreatedAt: createdAt,
 		})
 	}
 
@@ -926,6 +934,11 @@ func (h *Handler) handleGetSession(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	for i := range sess.Messages {
+		if sess.Messages[i].CreatedAt == nil {
+			sess.Messages[i].CreatedAt = &sess.Updated
+		}
+	}
 	messages := detailSessionMessages(sess.Messages, toolFeedbackMaxArgsLength)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/web/frontend/src/api/sessions.ts
+++ b/web/frontend/src/api/sessions.ts
@@ -14,6 +14,7 @@ export interface SessionDetail {
   messages: {
     role: "user" | "assistant"
     content: string
+    created_at?: string
     kind?: "normal" | "thought" | "tool_calls"
     media?: string[]
     attachments?: {

--- a/web/frontend/src/api/sessions.ts
+++ b/web/frontend/src/api/sessions.ts
@@ -14,6 +14,7 @@ export interface SessionDetail {
   messages: {
     role: "user" | "assistant"
     content: string
+    created_at?: string
     kind?: "normal" | "thought" | "tool_calls"
     model_name?: string
     media?: string[]

--- a/web/frontend/src/components/chat/assistant-message.tsx
+++ b/web/frontend/src/components/chat/assistant-message.tsx
@@ -132,12 +132,17 @@ export function AssistantMessage({
                 )}
                 <span>{collapsedLabel}</span>
               </div>
-              <IconChevronDown
-                className={cn(
-                  "size-3.5 opacity-0 transition-all duration-200 group-hover:opacity-100",
-                  isExpanded ? "rotate-180" : "",
+              <div className="flex items-center gap-2">
+                {formattedTimestamp && (
+                  <span className="opacity-50">{formattedTimestamp}</span>
                 )}
-              />
+                <IconChevronDown
+                  className={cn(
+                    "size-3.5 opacity-0 transition-all duration-200 group-hover:opacity-100",
+                    isExpanded ? "rotate-180" : "",
+                  )}
+                />
+              </div>
             </div>
           )}
           {(!isCollapsedBlock || isExpanded) && isToolCalls && hasToolCalls && (

--- a/web/frontend/src/components/chat/assistant-message.tsx
+++ b/web/frontend/src/components/chat/assistant-message.tsx
@@ -117,12 +117,17 @@ export function AssistantMessage({
                   <span className="text-muted-foreground/45">{trimmedModelName}</span>
                 )}
               </div>
-              <IconChevronDown
-                className={cn(
-                  "size-3.5 opacity-0 transition-all duration-200 group-hover:opacity-100",
-                  isExpanded ? "rotate-180" : "",
+              <div className="flex items-center gap-2">
+                {formattedTimestamp && (
+                  <span className="opacity-50">{formattedTimestamp}</span>
                 )}
-              />
+                <IconChevronDown
+                  className={cn(
+                    "size-3.5 opacity-0 transition-all duration-200 group-hover:opacity-100",
+                    isExpanded ? "rotate-180" : "",
+                  )}
+                />
+              </div>
             </div>
           )}
           {(!isCollapsedBlock || isExpanded) && isToolCalls && hasToolCalls && (

--- a/web/frontend/src/components/chat/chat-page.tsx
+++ b/web/frontend/src/components/chat/chat-page.tsx
@@ -346,6 +346,7 @@ export function ChatPage() {
                   <UserMessage
                     content={msg.content}
                     attachments={msg.attachments}
+                    timestamp={msg.timestamp}
                   />
                 )}
               </div>

--- a/web/frontend/src/components/chat/chat-page.tsx
+++ b/web/frontend/src/components/chat/chat-page.tsx
@@ -384,6 +384,7 @@ export function ChatPage() {
                   <UserMessage
                     content={msg.content}
                     attachments={msg.attachments}
+                    timestamp={msg.timestamp}
                   />
                 )}
               </div>

--- a/web/frontend/src/components/chat/user-message.tsx
+++ b/web/frontend/src/components/chat/user-message.tsx
@@ -1,17 +1,25 @@
+import { formatMessageTime } from "@/hooks/use-pico-chat"
 import { cn } from "@/lib/utils"
 import type { ChatAttachment } from "@/store/chat"
 
 interface UserMessageProps {
   content: string
   attachments?: ChatAttachment[]
+  timestamp?: string | number
 }
 
-export function UserMessage({ content, attachments = [] }: UserMessageProps) {
+export function UserMessage({
+  content,
+  attachments = [],
+  timestamp = "",
+}: UserMessageProps) {
   const hasText = content.trim().length > 0
   const isCommand = content.trim().startsWith("/")
   const imageAttachments = attachments.filter(
     (attachment) => attachment.type === "image",
   )
+  const formattedTimestamp =
+    timestamp !== "" ? formatMessageTime(timestamp) : ""
 
   return (
     <div className="flex w-full flex-col items-end gap-1.5">
@@ -48,6 +56,10 @@ export function UserMessage({ content, attachments = [] }: UserMessageProps) {
             content
           )}
         </div>
+      )}
+
+      {formattedTimestamp && (
+        <span className="px-1 text-[12px] text-zinc-400">{formattedTimestamp}</span>
       )}
     </div>
   )

--- a/web/frontend/src/components/chat/user-message.tsx
+++ b/web/frontend/src/components/chat/user-message.tsx
@@ -1,17 +1,23 @@
 import { IconCheck, IconCopy } from "@tabler/icons-react"
+import { useTranslation } from "react-i18next"
 
 import { Button } from "@/components/ui/button"
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard"
+import { formatMessageTime } from "@/hooks/use-pico-chat"
 import { cn } from "@/lib/utils"
 import type { ChatAttachment } from "@/store/chat"
-import { useTranslation } from "react-i18next"
 
 interface UserMessageProps {
   content: string
   attachments?: ChatAttachment[]
+  timestamp?: string | number
 }
 
-export function UserMessage({ content, attachments = [] }: UserMessageProps) {
+export function UserMessage({
+  content,
+  attachments = [],
+  timestamp = "",
+}: UserMessageProps) {
   const { t } = useTranslation()
   const { copy, isCopied } = useCopyToClipboard()
   const hasText = content.trim().length > 0
@@ -22,6 +28,8 @@ export function UserMessage({ content, attachments = [] }: UserMessageProps) {
   const copyMessageLabel = isCopied
     ? t("chat.copiedLabel")
     : t("chat.copyMessage")
+  const formattedTimestamp =
+    timestamp !== "" ? formatMessageTime(timestamp) : ""
 
   return (
     <div className="group flex w-full flex-col items-end gap-1.5">
@@ -80,6 +88,12 @@ export function UserMessage({ content, attachments = [] }: UserMessageProps) {
             )}
           </Button>
         </div>
+      )}
+
+      {formattedTimestamp && (
+        <span className="px-1 text-[12px] text-zinc-400">
+          {formattedTimestamp}
+        </span>
       )}
     </div>
   )

--- a/web/frontend/src/features/chat/history.ts
+++ b/web/frontend/src/features/chat/history.ts
@@ -43,8 +43,6 @@ export async function loadSessionMessages(
   sessionId: string,
 ): Promise<ChatMessage[]> {
   const detail = await getSessionHistory(sessionId)
-  const fallbackTime = detail.updated
-
   return detail.messages.map((message, index) => ({
     id: `hist-${index}-${Date.now()}`,
     role: message.role,
@@ -58,7 +56,7 @@ export async function loadSessionMessages(
       media: message.media,
       attachments: message.attachments,
     }),
-    timestamp: fallbackTime,
+    timestamp: message.created_at ?? detail.updated,
   }))
 }
 

--- a/web/frontend/src/features/chat/history.ts
+++ b/web/frontend/src/features/chat/history.ts
@@ -43,8 +43,6 @@ export async function loadSessionMessages(
   sessionId: string,
 ): Promise<ChatMessage[]> {
   const detail = await getSessionHistory(sessionId)
-  const fallbackTime = detail.updated
-
   return detail.messages.map((message, index) => ({
     id: `hist-${index}-${Date.now()}`,
     role: message.role,
@@ -59,7 +57,7 @@ export async function loadSessionMessages(
       media: message.media,
       attachments: message.attachments,
     }),
-    timestamp: fallbackTime,
+    timestamp: message.created_at ?? detail.updated,
   }))
 }
 


### PR DESCRIPTION
## Background

Session API (`GET /api/sessions/{id}`) returns messages without individual timestamps. The frontend has to use the session-level `updated` time for all messages, which is inaccurate when messages span different times.

## Changes

<img width="882" height="519" alt="image" src="https://github.com/user-attachments/assets/5d10ce52-9edd-46a6-a562-cc90e50d7ce1" />

### Backend

- **`pkg/providers/protocoltypes/types.go`** — Added `CreatedAt time.Time` field to `Message` struct with `json:"created_at,omitempty"` for backward compatibility
- **`pkg/memory/jsonl.go`** — Set `CreatedAt = time.Now()` in `addMsg` when the field is zero (after transient message check), so every stored message gets a timestamp
- **`web/backend/api/session.go`** — Expose `created_at` in `sessionChatMessage` API response; pass through from `providers.Message` to all transcript message types (user, assistant, thought, tool_calls, visible tool messages); fallback to session `updated` time for legacy messages with zero `CreatedAt`
- **`pkg/memory/jsonl_test.go`** — Added `TestAddMessage_SetsCreatedAt` verifying timestamps are set on write

### Frontend

- **`src/api/sessions.ts`** — Added `created_at?: string` to `SessionDetail.messages` type
- **`src/features/chat/history.ts`** — Use `message.created_at` when available (`message.created_at ?? detail.updated`)
- **`src/components/chat/user-message.tsx`** — Added `timestamp` prop and displays formatted time below message bubble
- **`src/components/chat/assistant-message.tsx`** — Show timestamp in collapsed block header (thought, tool_calls) — previously only shown for normal assistant messages
- **`src/components/chat/chat-page.tsx`** — Pass `timestamp` to `UserMessage`

## Behavior Impact

- New messages written after this change will have accurate per-message `created_at` timestamps in API responses
- Legacy messages (existing JSONL lines without `created_at`) will use the session `updated` time as fallback — no more `0001-01-01T00:00:00Z`
- All message types now display timestamps: user, assistant, thought, tool_calls
- No change to LLM provider communication (`Message` is never directly serialized to provider APIs)

## Risks and Rollback

- **Risk:** Legacy JSONL lines lack the field — handled by `omitempty`, `IsZero()` guard, and backend fallback to `session.updated`
- **Rollback:** Revert the commits, old behavior is fully preserved

## Verification

- `go test ./pkg/memory/` — 44/44 PASS
- `go test ./web/backend/api/` — all PASS
- `go build ./pkg/providers/protocoltypes/ ./pkg/memory/ ./web/backend/api/` — all pass
- Frontend build — `pnpm build:backend` passes

## Notes

Fixes #2787