### PR TITLE
fix(tools): hidden tools promoted in the parent registry rather than the subagent's registry

### DIFF
--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -30,6 +30,10 @@ type mediaStoreAware interface {
 	SetMediaStore(store media.MediaStore)
 }
 
+type registryCloneAware interface {
+	CloneForRegistry(registry *ToolRegistry) Tool
+}
+
 func NewToolRegistry() *ToolRegistry {
 	return &ToolRegistry{
 		tools: make(map[string]*ToolEntry),
@@ -413,11 +417,8 @@ func (r *ToolRegistry) Clone() *ToolRegistry {
 	}
 	for name, entry := range r.tools {
 		tool := entry.Tool
-		switch t := entry.Tool.(type) {
-		case *RegexSearchTool:
-			tool = NewRegexSearchTool(clone, t.ttl, t.maxSearchResults)
-		case *BM25SearchTool:
-			tool = NewBM25SearchTool(clone, t.ttl, t.maxSearchResults)
+		if aware, ok := entry.Tool.(registryCloneAware); ok {
+			tool = aware.CloneForRegistry(clone)
 		}
 		clone.tools[name] = &ToolEntry{
 			Tool:   tool,

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -412,8 +412,15 @@ func (r *ToolRegistry) Clone() *ToolRegistry {
 		mediaStore: r.mediaStore,
 	}
 	for name, entry := range r.tools {
+		tool := entry.Tool
+		switch t := entry.Tool.(type) {
+		case *RegexSearchTool:
+			tool = NewRegexSearchTool(clone, t.ttl, t.maxSearchResults)
+		case *BM25SearchTool:
+			tool = NewBM25SearchTool(clone, t.ttl, t.maxSearchResults)
+		}
 		clone.tools[name] = &ToolEntry{
-			Tool:   entry.Tool,
+			Tool:   tool,
 			IsCore: entry.IsCore,
 			TTL:    entry.TTL,
 		}

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -515,6 +515,32 @@ func TestToolRegistry_Clone_PreservesTTLValue(t *testing.T) {
 	}
 }
 
+func TestToolRegistry_Clone_RebindsDiscoveryToolsToClone(t *testing.T) {
+	parent := NewToolRegistry()
+	parent.RegisterHidden(newMockTool("mcp_research", "deep research report tool"))
+	parent.Register(NewBM25SearchTool(parent, 3, 5))
+
+	clone := parent.Clone()
+
+	searchTool, ok := clone.Get("tool_search_tool_bm25")
+	if !ok {
+		t.Fatal("expected cloned registry to expose BM25 search tool")
+	}
+	result := searchTool.Execute(context.Background(), map[string]any{
+		"query": "deep research",
+	})
+	if result == nil || result.IsError {
+		t.Fatalf("search result error: %+v", result)
+	}
+
+	if _, ok := clone.Get("mcp_research"); !ok {
+		t.Fatal("expected search in clone to promote hidden tool in clone")
+	}
+	if _, ok := parent.Get("mcp_research"); ok {
+		t.Fatal("expected search in clone not to promote hidden tool in parent")
+	}
+}
+
 func TestToolRegistry_ConcurrentAccess(t *testing.T) {
 	r := NewToolRegistry()
 	var wg sync.WaitGroup

--- a/pkg/tools/search_tool.go
+++ b/pkg/tools/search_tool.go
@@ -26,6 +26,13 @@ func NewRegexSearchTool(r *ToolRegistry, ttl int, maxSearchResults int) *RegexSe
 	return &RegexSearchTool{registry: r, ttl: ttl, maxSearchResults: maxSearchResults}
 }
 
+func (t *RegexSearchTool) CloneForRegistry(registry *ToolRegistry) Tool {
+	if t == nil {
+		return NewRegexSearchTool(registry, 0, 0)
+	}
+	return NewRegexSearchTool(registry, t.ttl, t.maxSearchResults)
+}
+
 func (t *RegexSearchTool) Name() string {
 	return "tool_search_tool_regex"
 }
@@ -93,6 +100,13 @@ type BM25SearchTool struct {
 
 func NewBM25SearchTool(r *ToolRegistry, ttl int, maxSearchResults int) *BM25SearchTool {
 	return &BM25SearchTool{registry: r, ttl: ttl, maxSearchResults: maxSearchResults}
+}
+
+func (t *BM25SearchTool) CloneForRegistry(registry *ToolRegistry) Tool {
+	if t == nil {
+		return NewBM25SearchTool(registry, 0, 0)
+	}
+	return NewBM25SearchTool(registry, t.ttl, t.maxSearchResults)
 }
 
 func (t *BM25SearchTool) Name() string {


### PR DESCRIPTION
## Summary

Fix deferred tool discovery inside cloned tool registries, especially subagent turns.

`ToolRegistry.Clone()` previously shallow-copied every tool entry. Discovery tools such as `BM25SearchTool` and `RegexSearchTool` store a pointer to the registry they search and promote tools in. After cloning a registry for a subagent, the cloned search tool still pointed at the parent registry.

That meant a subagent could call `tool_search_tool_bm25`, get a successful "promoted tools" result, but the hidden tools were promoted in the parent registry rather than the subagent's cloned registry. The next subagent LLM iteration still could not call the discovered tools.

## Changes

- Recreate BM25 and regex discovery tools during `ToolRegistry.Clone()` so they point at the cloned registry.
- Add a regression test that verifies searching in a clone promotes hidden tools only in that clone, not in the parent registry.

## Validation

- `go test ./pkg/tools -run 'TestToolRegistry_Clone_RebindsDiscoveryToolsToClone|TestToolRegistry_Clone' -count=1`
- `go test ./pkg/tools ./pkg/agent`
