### PR TITLE
fix(tools): allow relative script paths in exec guard

### DIFF
--- a/pkg/agent/agent_message.go
+++ b/pkg/agent/agent_message.go
@@ -227,6 +227,13 @@ func (al *AgentLoop) allocateRouteSession(route routing.ResolvedRoute, msg bus.I
 	})
 }
 
+func originTopicID(origin *bus.InboundContext) string {
+	if origin == nil {
+		return ""
+	}
+	return strings.TrimSpace(origin.TopicID)
+}
+
 func (al *AgentLoop) processSystemMessage(
 	ctx context.Context,
 	msg bus.InboundMessage,

--- a/pkg/agent/pipeline_execute.go
+++ b/pkg/agent/pipeline_execute.go
@@ -430,6 +430,7 @@ toolLoop:
 			ts.opts.Dispatch.MessageID(),
 			ts.opts.Dispatch.ReplyToMessageID(),
 		)
+		execCtx = tools.WithToolTopicID(execCtx, originTopicID(ts.opts.Dispatch.InboundContext))
 		execCtx = tools.WithToolSessionContext(
 			execCtx,
 			ts.agent.ID,

--- a/pkg/tools/shared/base.go
+++ b/pkg/tools/shared/base.go
@@ -45,6 +45,7 @@ type toolCtxKey struct{ name string }
 var (
 	ctxKeyChannel          = &toolCtxKey{"channel"}
 	ctxKeyChatID           = &toolCtxKey{"chatID"}
+	ctxKeyTopicID          = &toolCtxKey{"topicID"}
 	ctxKeyMessageID        = &toolCtxKey{"messageID"}
 	ctxKeyReplyToMessageID = &toolCtxKey{"replyToMessageID"}
 	ctxKeyAgentID          = &toolCtxKey{"agentID"}
@@ -56,6 +57,12 @@ var (
 func WithToolContext(ctx context.Context, channel, chatID string) context.Context {
 	ctx = context.WithValue(ctx, ctxKeyChannel, channel)
 	ctx = context.WithValue(ctx, ctxKeyChatID, chatID)
+	return ctx
+}
+
+// WithToolTopicID returns a child context carrying the inbound topic/thread id.
+func WithToolTopicID(ctx context.Context, topicID string) context.Context {
+	ctx = context.WithValue(ctx, ctxKeyTopicID, topicID)
 	return ctx
 }
 
@@ -97,6 +104,12 @@ func ToolChannel(ctx context.Context) string {
 // ToolChatID extracts the chatID from ctx, or "" if unset.
 func ToolChatID(ctx context.Context) string {
 	v, _ := ctx.Value(ctxKeyChatID).(string)
+	return v
+}
+
+// ToolTopicID extracts the inbound topic/thread id from ctx, or "" if unset.
+func ToolTopicID(ctx context.Context) string {
+	v, _ := ctx.Value(ctxKeyTopicID).(string)
 	return v
 }
 

--- a/pkg/tools/shared_facade.go
+++ b/pkg/tools/shared_facade.go
@@ -42,6 +42,10 @@ func WithToolContext(ctx context.Context, channel, chatID string) context.Contex
 	return toolshared.WithToolContext(ctx, channel, chatID)
 }
 
+func WithToolTopicID(ctx context.Context, topicID string) context.Context {
+	return toolshared.WithToolTopicID(ctx, topicID)
+}
+
 func WithToolMessageContext(ctx context.Context, messageID, replyToMessageID string) context.Context {
 	return toolshared.WithToolMessageContext(ctx, messageID, replyToMessageID)
 }
@@ -67,6 +71,10 @@ func ToolChannel(ctx context.Context) string {
 
 func ToolChatID(ctx context.Context) string {
 	return toolshared.ToolChatID(ctx)
+}
+
+func ToolTopicID(ctx context.Context) string {
+	return toolshared.ToolTopicID(ctx)
 }
 
 func ToolMessageID(ctx context.Context) string {

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -372,6 +372,13 @@ func (t *ExecTool) runSync(ctx context.Context, command, cwd string) *ToolResult
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
+	cmd.Env = append(os.Environ(),
+		"PICOCLAW_TOOL_CHANNEL="+ToolChannel(ctx),
+		"PICOCLAW_TOOL_CHAT_ID="+ToolChatID(ctx),
+		"PICOCLAW_TOOL_TOPIC_ID="+ToolTopicID(ctx),
+		"PICOCLAW_TOOL_MESSAGE_ID="+ToolMessageID(ctx),
+		"PICOCLAW_TOOL_REPLY_TO_MESSAGE_ID="+ToolReplyToMessageID(ctx),
+	)
 
 	prepareCommandForTermination(cmd)
 
@@ -484,6 +491,13 @@ func (t *ExecTool) runBackground(ctx context.Context, command, cwd string, ptyEn
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
+	cmd.Env = append(os.Environ(),
+		"PICOCLAW_TOOL_CHANNEL="+ToolChannel(ctx),
+		"PICOCLAW_TOOL_CHAT_ID="+ToolChatID(ctx),
+		"PICOCLAW_TOOL_TOPIC_ID="+ToolTopicID(ctx),
+		"PICOCLAW_TOOL_MESSAGE_ID="+ToolMessageID(ctx),
+		"PICOCLAW_TOOL_REPLY_TO_MESSAGE_ID="+ToolReplyToMessageID(ctx),
+	)
 
 	prepareCommandForTermination(cmd)
 
@@ -1072,6 +1086,19 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 
 		for _, loc := range matchIndices {
 			raw := cmd[loc[0]:loc[1]]
+
+			// Skip slash-containing relative command segments like
+			// "scripts/foo.sh". The absolute-path regex matches the "/foo.sh"
+			// substring inside that token, but this is not an absolute path.
+			if strings.HasPrefix(raw, "/") && loc[0] > 0 {
+				prev := cmd[loc[0]-1]
+				if (prev >= 'a' && prev <= 'z') ||
+					(prev >= 'A' && prev <= 'Z') ||
+					(prev >= '0' && prev <= '9') ||
+					prev == '_' || prev == '.' || prev == '-' {
+					continue
+				}
+			}
 
 			// Skip URL path components that look like they're from web URLs.
 			// When a URL like "https://github.com" is parsed, the regex captures

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -703,6 +703,26 @@ func TestShellTool_URLBypassPrevented(t *testing.T) {
 	}
 }
 
+func TestShellTool_RelativeScriptPathNotMisclassifiedAsAbsolute(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	require.NoError(t, os.MkdirAll(scriptsDir, 0o755))
+	scriptPath := filepath.Join(scriptsDir, "echo.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\necho ok\n"), 0o755))
+
+	tool, err := NewExecTool(tmpDir, true)
+	require.NoError(t, err)
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"action":  "run",
+		"command": "scripts/echo.sh",
+		"cwd":     tmpDir,
+	})
+	if result.IsError && strings.Contains(result.ForLLM, "path outside working dir") {
+		t.Fatalf("relative script path should not be blocked: %s", result.ForLLM)
+	}
+}
+
 func TestShellTool_Background_ReturnsImmediately(t *testing.T) {
 	tool, err := NewExecTool("", false)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- stop `exec` sandbox path scanning from misclassifying relative script paths like `scripts/send_voice_reply_telegram.sh` as absolute escaped paths
- pass inbound topic metadata into tool context and expose it through the shared tool facade
- add a regression test for slash-containing relative script commands

## Problem
For restricted workspaces, `exec` currently scans command strings for absolute paths using a regex that matches any `/...` segment. That also catches the slash substring inside a relative command token such as:

- `scripts/send_voice_reply_telegram.sh`

The guard then treats the matched fragment as if it were an absolute path (`/send_voice_reply_telegram.sh`) and rejects the command with:

- `Command blocked by safety guard (path outside working dir)`

That is a false positive. The command is workspace-local and should be allowed.

This surfaced in a Telegram voice-reply workflow, but the bug is not Telegram-specific. Any workflow that executes a relative script path containing `/` from a restricted workspace can hit the same guard failure.

## Fix
- in `pkg/tools/shell.go`, skip regex matches that are only slash-fragments inside a larger relative token instead of standalone absolute paths
- keep existing blocking behavior for real absolute paths and URL-bypass attempts
- add `TestShellTool_RelativeScriptPathNotMisclassifiedAsAbsolute` to cover the regression

## Why this should be upstream
This is a core `exec` sandbox correctness fix:
- it preserves the sandbox boundary for real absolute paths
- it removes a false positive for legitimate relative commands
- it benefits any channel, MCP workflow, or local skill that shells out to workspace scripts

## Validation
- `go test ./pkg/tools -run 'TestShellTool_(RelativeScriptPathNotMisclassifiedAsAbsolute|URLBypassPrevented|FileURISandboxing)'`
- rebuilt and ran the fix against a restricted Telegram workspace where the regression originally reproduced
