### PR TITLE
build(go): bump Go to 1.25.10 to fix stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sipeed/picoclaw
 
-go 1.25.9
+go 1.25.10
 
 require (
 	fyne.io/systray v1.12.0


### PR DESCRIPTION
## 📝 Description

This PR updates the Go version from `1.25.9` to `1.25.10` to address three critical security vulnerabilities found in the standard library (`net`, `net/http`, and `net/http/httputil`).

## 🗣️ Type of Change

* [x] 🐞 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature (non-breaking change which adds functionality)
* [ ] 📖 Documentation update
* [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation

* [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
* [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
* [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes security vulnerabilities: GO-2026-4976, GO-2026-4971, GO-2026-4918.

## 📚 Technical Context (Skip for Docs)

* **Reference URL:** [https://pkg.go.dev/vuln/GO-2026-4976](https://pkg.go.dev/vuln/GO-2026-4976)
* **Reasoning:** Running `govulncheck` identified multiple vulnerabilities in the Go standard library affecting `ReverseProxy`, `net.Dial` on Windows, and HTTP/2 transport. These are resolved by upgrading to the latest patch release (1.25.10).

## 🧪 Test Environment

* **Hardware:** PC
* **OS:** 
* **Model/Provider:** N/A
* **Channels:** N/A

## 📸 Evidence (Optional)

```text
Vulnerability #1: GO-2026-4976 (Fixed in go1.25.10)
Vulnerability #2: GO-2026-4971 (Fixed in go1.25.10)
Vulnerability #3: GO-2026-4918 (Fixed in go1.25.10)

```

## ☑️ Checklist

* [x] My code/docs follow the style of this project.
* [x] I have performed a self-review of my own changes.
* [x] I have updated the documentation accordingly.