### PR TITLE
chore(build): bump Go toolchain to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sipeed/picoclaw
 
-go 1.25.9
+go 1.25.10
 
 require (
 	fyne.io/systray v1.12.0


### PR DESCRIPTION
## Summary
- bump the Go toolchain version in `go.mod` from `1.25.9` to `1.25.10`

## Why
Several open PRs are currently failing the shared `Security Check` workflow because `govulncheck` reports standard-library vulnerabilities in Go `1.25.9`, including:
- `GO-2026-4976`
- `GO-2026-4971`
- `GO-2026-4918`

These are workflow/toolchain-level failures rather than branch-specific code regressions. Moving the repository baseline to `1.25.10` aligns the CI environment with the fixed standard library version and should clear those failures for unrelated PRs after rebase.

## Verification
- `go test ./pkg/state ./pkg/commands ./pkg/channels/telegram -count=1`