### PR TITLE
fix: resolve relative paths correctly in exec tool safety guard

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -1094,9 +1094,15 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 				}
 			}
 
-			p, err := filepath.Abs(raw)
-			if err != nil {
-				continue
+			// Resolve the path correctly based on cwd:
+			// - Absolute paths: use as-is (cleaned)
+			// - Relative paths: join with cwd to resolve correctly
+			var p string
+			if filepath.IsAbs(raw) {
+				p = filepath.Clean(raw)
+			} else {
+				p = filepath.Join(cwdPath, raw)
+				p = filepath.Clean(p)
 			}
 
 			if safePaths[p] {


### PR DESCRIPTION
## 📝 Description

Fix issue #2749: Bash evaluates relative path as absolute path

When the exec tool (bash) restricts access to the workspace, relative paths in commands were incorrectly resolved using the process's current working directory instead of the command's intended working directory. This caused legitimate relative paths (e.g., `skills/file.md`) to be evaluated as absolute paths from the process root, triggering false-positive safety blocks.

The fix modifies the `guardCommand` method in `pkg/tools/shell.go` to correctly resolve paths:
- For absolute paths: use as-is (cleaned)
- For relative paths: join with the command's working directory (`cwd`) before cleaning and validation

This ensures that relative paths are resolved relative to the intended working directory, not the process's global cwd.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully tool-generated
- [ ] 🛠️ Mixed (tool-assisted)
- [x] 👨‍💻 Human-written

## 🔗 Related Issue

Fixes #2749

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**
  The `absolutePathPattern` regex matches paths in commands. The guard validates each matched path to ensure it stays within the workspace boundary. Previously, `filepath.Abs(raw)` was used for all matched paths, which is incorrect for relative paths because it uses the process's current working directory. The fix distinguishes absolute and relative paths, resolving them correctly against the command's cwd.

## 🧪 Test Environment
- **Hardware:** x86_64
- **OS:** Linux (Ubuntu 24.04)
- **Model/Provider:** Not applicable (tooling fix)
- **Channels:** All (exec tool is channel-agnostic)

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Manual verification: With workspace restriction enabled, running `exec` with a relative path like `cat skills/test.md` now correctly resolves to the workspace subdirectory and is allowed, while attempts to traverse outside (`cat ../../etc/passwd`) remain blocked.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
