### PR TITLE
fix: skip canonical ID parsing for @-prefixed allow_from entries

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -44,26 +44,30 @@ func MatchAllowed(sender bus.SenderInfo, allowed string) bool {
 		return false
 	}
 
-	// Try canonical match first: "platform:id" format
-	if platform, id, ok := ParseCanonicalID(allowed); ok {
-		// Only treat as canonical if the platform portion looks like a known platform name
-		// (not a pure-numeric string, which could be a compound ID)
-		if !isNumeric(platform) {
-			candidate := BuildCanonicalID(platform, id)
-			if candidate != "" && sender.CanonicalID != "" {
-				return strings.EqualFold(sender.CanonicalID, candidate)
-			}
-			// If sender has no canonical ID, try matching platform + platformID
-			return strings.EqualFold(platform, sender.Platform) &&
-				sender.PlatformID == id
-		}
-	}
-
 	// Keep track of explicit username format
 	isAtUsername := strings.HasPrefix(allowed, "@")
 
 	// Strip leading "@" for username matching
 	trimmed := strings.TrimPrefix(allowed, "@")
+
+	// Try canonical match first: "platform:id" format.
+	// Skip when the entry starts with "@" — the "@" prefix signals a
+	// username or Matrix MXID (e.g. "@alice:matrix.org"), not a platform:id pair.
+	if !isAtUsername {
+		if platform, id, ok := ParseCanonicalID(allowed); ok {
+			// Only treat as canonical if the platform portion looks like a known platform name
+			// (not a pure-numeric string, which could be a compound ID)
+			if !isNumeric(platform) {
+				candidate := BuildCanonicalID(platform, id)
+				if candidate != "" && sender.CanonicalID != "" {
+					return strings.EqualFold(sender.CanonicalID, candidate)
+				}
+				// If sender has no canonical ID, try matching platform + platformID
+				return strings.EqualFold(platform, sender.Platform) &&
+					sender.PlatformID == id
+			}
+		}
+	}
 
 	// Split compound "id|username" format
 	allowedID := trimmed
@@ -81,6 +85,18 @@ func MatchAllowed(sender bus.SenderInfo, allowed string) bool {
 	// Match against Username only when explicitly requested via "@username"
 	if isAtUsername && sender.Username != "" && sender.Username == trimmed {
 		return true
+	}
+
+	// Match the full "@"-prefixed entry against PlatformID or Username.
+	// Needed for Matrix MXIDs where both the config entry and the
+	// sender identifiers include the "@" prefix (e.g. "@alice:matrix.org").
+	if isAtUsername {
+		if sender.PlatformID != "" && sender.PlatformID == allowed {
+			return true
+		}
+		if sender.Username != "" && sender.Username == allowed {
+			return true
+		}
 	}
 
 	// Match compound sender format against allowed parts

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -223,6 +223,53 @@ func TestMatchAllowed(t *testing.T) {
 			allowed: "  123456  ",
 			want:    true,
 		},
+		// Matrix MXID matching (issue #2815)
+		// Matrix user IDs look like "@alice:matrix.org" — the colon must
+		// not be misinterpreted as a canonical "platform:id" separator.
+		{
+			name: "matrix MXID with @ prefix matches PlatformID",
+			sender: bus.SenderInfo{
+				Platform:    "matrix",
+				PlatformID:  "@alice:matrix.org",
+				CanonicalID: BuildCanonicalID("matrix", "@alice:matrix.org"),
+				Username:    "@alice:matrix.org",
+			},
+			allowed: "@alice:matrix.org",
+			want:    true,
+		},
+		{
+			name: "matrix MXID without @ prefix matches PlatformID",
+			sender: bus.SenderInfo{
+				Platform:    "matrix",
+				PlatformID:  "@alice:matrix.org",
+				CanonicalID: BuildCanonicalID("matrix", "@alice:matrix.org"),
+				Username:    "@alice:matrix.org",
+			},
+			allowed: "alice:matrix.org",
+			want:    false, // ambiguous — could be a canonical "platform:id" entry
+		},
+		{
+			name: "matrix canonical format matches",
+			sender: bus.SenderInfo{
+				Platform:    "matrix",
+				PlatformID:  "@alice:matrix.org",
+				CanonicalID: BuildCanonicalID("matrix", "@alice:matrix.org"),
+				Username:    "@alice:matrix.org",
+			},
+			allowed: "matrix:@alice:matrix.org",
+			want:    true,
+		},
+		{
+			name: "matrix MXID rejects unlisted sender",
+			sender: bus.SenderInfo{
+				Platform:    "matrix",
+				PlatformID:  "@eve:evil.org",
+				CanonicalID: BuildCanonicalID("matrix", "@eve:evil.org"),
+				Username:    "@eve:evil.org",
+			},
+			allowed: "@alice:matrix.org",
+			want:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## :memo: Description

The `allow_from` filter on the Matrix channel is completely broken - any non-empty allowlist blocks all messages, regardless of whether the sender is listed or not.

Root cause: Matrix user IDs (MXIDs) contain colons, e.g. `@alice:matrix.org`. The `MatchAllowed` function in `pkg/identity` sees that colon and tries to parse the entry as a canonical `platform:id` pair. It splits `@alice:matrix.org` into `platform="@alice"`, `id="matrix.org"`, builds a candidate that obviously doesn't match `sender.CanonicalID`, and returns false.

The fix is straightforward: when the allowlist entry starts with `@`, skip the canonical parsing entirely. The `@` prefix is already treated as a username signal elsewhere in the function - it just wasn't checked early enough.

Tested with four new cases covering the formats mentioned in the issue (`@user:server`, canonical `matrix:@user:server`, and rejection of unlisted senders).

## :speaking_head: Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] - [ ] New feature (non-breaking change which adds functionality)
- [ ] - [ ] Documentation update
- [ ] - [ ] Code refactoring (no functional changes, no api changes)
## :robot: AI Code Generation

- [ ] Fully AI-generated (100% AI, 0% Human)
- [x] - [ ] Mostly AI-generated (AI draft, Human verified/modified)
- [ ] - [x] Mostly Human-written (Human lead, AI assisted or none)
## :link: Related Issue

Fixes #2815 
## :books: Technical Context (Skip for Docs)

- **Reference URL:** https://github.com/sipeed/picoclaw/issues/2815
- - **Reasoning:** `ParseCanonicalID("@alice:matrix.org")` yields `platform="@alice"`, `id="matrix.org"` - since `"@alice"` isn't numeric, it enters the canonical comparison branch and builds a candidate that never matches `sender.CanonicalID = "matrix:@alice:matrix.org"`. Moving the `isAtUsername` guard before the canonical block prevents this misparse. Telegram and other channels are unaffected since their IDs are numeric and never hit this path.
## :test_tube: Test Environment

- **Hardware:** PC
- - **OS:** Linux (Docker), also verified logic on Windows
- - **Model/Provider:** N/A (not model-specific)
- - **Channels:** Matrix
## :camera: Evidence (Optional)

<details>
<summary>Click to view test output</summary>

Added to `TestMatchAllowed` in `pkg/identity/identity_test.go`:
- `matrix MXID with @ prefix matches PlatformID` - `@alice:matrix.org` 
- - `matrix MXID without @ prefix` - `alice:matrix.org` correctly treated as ambiguous 
- - `matrix canonical format` - `matrix:@alice:matrix.org` 
- - `matrix MXID rejects unlisted sender` - `@eve:evil.org` blocked 
</details>

## :ballot_box_with_check: Checklist

- [x] My code/docs follow the style of this project.
- [ ] - [x] I have performed a self-review of my own changes.
- [ ] - [x] I have updated the documentation accordingly.