### PR TITLE
fix(agent): always publish final reply after interim message

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -254,11 +254,25 @@ func (al *AgentLoop) Run(ctx context.Context) error {
 					}
 					continued, continueErr := al.drainQueuedSteeringContinuations(ctx, target)
 					if continueErr != nil {
-						al.maybePublishError(ctx, m.Channel, m.ChatID, sessionKey, continueErr)
+						al.maybePublishErrorWithPolicy(
+							ctx,
+							m.Channel,
+							m.ChatID,
+							sessionKey,
+							continueErr,
+							finalResponseAlwaysPublish,
+						)
 						return
 					}
 					if continued != "" {
-						al.PublishResponseIfNeeded(ctx, target.Channel, target.ChatID, target.SessionKey, continued)
+						al.publishResponseIfNeededWithPolicy(
+							ctx,
+							target.Channel,
+							target.ChatID,
+							target.SessionKey,
+							continued,
+							finalResponseAlwaysPublish,
+						)
 					}
 					return
 				}

--- a/pkg/agent/agent_outbound.go
+++ b/pkg/agent/agent_outbound.go
@@ -55,23 +55,6 @@ func (al *AgentLoop) maybePublishErrorWithPolicy(
 	return true
 }
 
-func (al *AgentLoop) publishResponseOrError(
-	ctx context.Context,
-	channel, chatID, sessionKey string,
-	response string,
-	err error,
-) {
-	al.publishResponseOrErrorWithPolicy(
-		ctx,
-		channel,
-		chatID,
-		sessionKey,
-		response,
-		err,
-		finalResponseSuppressIfMessageToolSent,
-	)
-}
-
 func (al *AgentLoop) publishResponseOrErrorWithPolicy(
 	ctx context.Context,
 	channel, chatID, sessionKey string,

--- a/pkg/agent/agent_outbound.go
+++ b/pkg/agent/agent_outbound.go
@@ -17,11 +17,41 @@ import (
 	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
+type finalResponseDeliveryPolicy uint8
+
+const (
+	finalResponseSuppressIfMessageToolSent finalResponseDeliveryPolicy = iota
+	finalResponseAlwaysPublish
+)
+
 func (al *AgentLoop) maybePublishError(ctx context.Context, channel, chatID, sessionKey string, err error) bool {
+	return al.maybePublishErrorWithPolicy(
+		ctx,
+		channel,
+		chatID,
+		sessionKey,
+		err,
+		finalResponseSuppressIfMessageToolSent,
+	)
+}
+
+func (al *AgentLoop) maybePublishErrorWithPolicy(
+	ctx context.Context,
+	channel, chatID, sessionKey string,
+	err error,
+	policy finalResponseDeliveryPolicy,
+) bool {
 	if errors.Is(err, context.Canceled) {
 		return false
 	}
-	al.PublishResponseIfNeeded(ctx, channel, chatID, sessionKey, fmt.Sprintf("Error processing message: %v", err))
+	al.publishResponseIfNeededWithPolicy(
+		ctx,
+		channel,
+		chatID,
+		sessionKey,
+		fmt.Sprintf("Error processing message: %v", err),
+		policy,
+	)
 	return true
 }
 
@@ -31,26 +61,61 @@ func (al *AgentLoop) publishResponseOrError(
 	response string,
 	err error,
 ) {
+	al.publishResponseOrErrorWithPolicy(
+		ctx,
+		channel,
+		chatID,
+		sessionKey,
+		response,
+		err,
+		finalResponseSuppressIfMessageToolSent,
+	)
+}
+
+func (al *AgentLoop) publishResponseOrErrorWithPolicy(
+	ctx context.Context,
+	channel, chatID, sessionKey string,
+	response string,
+	err error,
+	policy finalResponseDeliveryPolicy,
+) {
 	if err != nil {
-		if !al.maybePublishError(ctx, channel, chatID, sessionKey, err) {
+		if !al.maybePublishErrorWithPolicy(ctx, channel, chatID, sessionKey, err, policy) {
 			return
 		}
 		response = ""
 	}
-	al.PublishResponseIfNeeded(ctx, channel, chatID, sessionKey, response)
+	al.publishResponseIfNeededWithPolicy(ctx, channel, chatID, sessionKey, response, policy)
 }
 
 func (al *AgentLoop) PublishResponseIfNeeded(ctx context.Context, channel, chatID, sessionKey, response string) {
+	al.publishResponseIfNeededWithPolicy(
+		ctx,
+		channel,
+		chatID,
+		sessionKey,
+		response,
+		finalResponseSuppressIfMessageToolSent,
+	)
+}
+
+func (al *AgentLoop) publishResponseIfNeededWithPolicy(
+	ctx context.Context,
+	channel, chatID, sessionKey, response string,
+	policy finalResponseDeliveryPolicy,
+) {
 	if response == "" {
 		return
 	}
 
 	alreadySentToSameChat := false
-	defaultAgent := al.GetRegistry().GetDefaultAgent()
-	if defaultAgent != nil {
-		if tool, ok := defaultAgent.Tools.Get("message"); ok {
-			if mt, ok := tool.(*tools.MessageTool); ok {
-				alreadySentToSameChat = mt.HasSentTo(sessionKey, channel, chatID)
+	if policy == finalResponseSuppressIfMessageToolSent {
+		defaultAgent := al.GetRegistry().GetDefaultAgent()
+		if defaultAgent != nil {
+			if tool, ok := defaultAgent.Tools.Get("message"); ok {
+				if mt, ok := tool.(*tools.MessageTool); ok {
+					alreadySentToSameChat = mt.HasSentTo(sessionKey, channel, chatID)
+				}
 			}
 		}
 	}

--- a/pkg/agent/agent_steering.go
+++ b/pkg/agent/agent_steering.go
@@ -15,7 +15,15 @@ func (al *AgentLoop) processMessageSync(ctx context.Context, msg bus.InboundMess
 	}
 
 	response, err := al.processMessage(ctx, msg)
-	al.publishResponseOrError(ctx, msg.Channel, msg.ChatID, msg.SessionKey, response, err)
+	al.publishResponseOrErrorWithPolicy(
+		ctx,
+		msg.Channel,
+		msg.ChatID,
+		msg.SessionKey,
+		response,
+		err,
+		finalResponseAlwaysPublish,
+	)
 }
 
 func (al *AgentLoop) runTurnWithSteering(ctx context.Context, initialMsg bus.InboundMessage) {
@@ -58,7 +66,14 @@ func (al *AgentLoop) runTurnWithSteering(ctx context.Context, initialMsg bus.Inb
 
 	// Publish final response
 	if finalResponse != "" {
-		al.PublishResponseIfNeeded(ctx, target.Channel, target.ChatID, target.SessionKey, finalResponse)
+		al.publishResponseIfNeededWithPolicy(
+			ctx,
+			target.Channel,
+			target.ChatID,
+			target.SessionKey,
+			finalResponse,
+			finalResponseAlwaysPublish,
+		)
 	}
 }
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -162,6 +162,105 @@ func newTestAgentLoop(
 	return al, cfg, msgBus, provider, func() { os.RemoveAll(tmpDir) }
 }
 
+func TestPublishResponseIfNeededWithPolicy_AlwaysPublishesFinalAfterMessageTool(t *testing.T) {
+	al, _, msgBus, _, cleanup := newTestAgentLoop(t)
+	defer cleanup()
+
+	agent := al.registry.GetDefaultAgent()
+	if agent == nil {
+		t.Fatal("expected default agent")
+	}
+	rawTool, ok := agent.Tools.Get("message")
+	if !ok {
+		mt := tools.NewMessageTool()
+		agent.Tools.Register(mt)
+		rawTool = mt
+	}
+	mt, ok := rawTool.(*tools.MessageTool)
+	if !ok {
+		t.Fatalf("message tool type = %T", rawTool)
+	}
+	mt.SetSendCallback(func(ctx context.Context, channel, chatID, content, replyToMessageID string) error {
+		return nil
+	})
+
+	ctx := tools.WithToolSessionContext(context.Background(), routing.DefaultAgentID, "session-msg-1", nil)
+	res := mt.Execute(ctx, map[string]any{
+		"content": "working on it",
+		"channel": "telegram",
+		"chat_id": "-100123",
+	})
+	if res == nil || res.IsError {
+		t.Fatalf("message tool execute failed: %+v", res)
+	}
+
+	al.publishResponseIfNeededWithPolicy(
+		context.Background(),
+		"telegram",
+		"-100123",
+		"session-msg-1",
+		"final result",
+		finalResponseAlwaysPublish,
+	)
+
+	select {
+	case outbound := <-msgBus.OutboundChan():
+		if outbound.Content != "final result" {
+			t.Fatalf("outbound content = %q, want final result", outbound.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected outbound response")
+	}
+}
+
+func TestPublishResponseIfNeededWithPolicy_SuppressesWhenMessageToolAlreadySent(t *testing.T) {
+	al, _, msgBus, _, cleanup := newTestAgentLoop(t)
+	defer cleanup()
+
+	agent := al.registry.GetDefaultAgent()
+	if agent == nil {
+		t.Fatal("expected default agent")
+	}
+	rawTool, ok := agent.Tools.Get("message")
+	if !ok {
+		mt := tools.NewMessageTool()
+		agent.Tools.Register(mt)
+		rawTool = mt
+	}
+	mt, ok := rawTool.(*tools.MessageTool)
+	if !ok {
+		t.Fatalf("message tool type = %T", rawTool)
+	}
+	mt.SetSendCallback(func(ctx context.Context, channel, chatID, content, replyToMessageID string) error {
+		return nil
+	})
+
+	ctx := tools.WithToolSessionContext(context.Background(), routing.DefaultAgentID, "session-msg-2", nil)
+	res := mt.Execute(ctx, map[string]any{
+		"content": "working on it",
+		"channel": "telegram",
+		"chat_id": "-100123",
+	})
+	if res == nil || res.IsError {
+		t.Fatalf("message tool execute failed: %+v", res)
+	}
+
+	al.publishResponseIfNeededWithPolicy(
+		context.Background(),
+		"telegram",
+		"-100123",
+		"session-msg-2",
+		"final result",
+		finalResponseSuppressIfMessageToolSent,
+	)
+
+	select {
+	case outbound := <-msgBus.OutboundChan():
+		t.Fatalf("unexpected outbound response: %+v", outbound)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
 func TestNewAgentLoop_RegistersWebSearchTool(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Agents.Defaults.Workspace = t.TempDir()


### PR DESCRIPTION
## Summary

Keep normal interactive final replies from being suppressed just because the same turn used the `message` tool earlier for a progress update.

## Problem

PicoClaw currently suppresses a normal final outbound response whenever the `message` tool has already sent content to the same chat in the same session/turn.

That is useful for some scheduled/background paths, but it breaks a common interactive pattern:

1. the agent sends an interim status update with the `message` tool
2. the turn continues and completes normally
3. the runtime generates a final reply
4. the final reply is dropped as a duplicate because the earlier progress message already marked the chat as "sent"

From the user's perspective this looks like:
- the work was done
- the result existed
- but the assistant never replied with the actual final answer

## Fix

Introduce a small internal final-response delivery policy for agent outbound publishing:

- `finalResponseSuppressIfMessageToolSent`
- `finalResponseAlwaysPublish`

Use `finalResponseAlwaysPublish` for interactive user-turn final replies, including:
- synchronous `processMessageSync`
- steering-driven final replies
- pending-stop continuation final replies

Keep the legacy suppression behavior as the default wrapper used by existing non-interactive callers.

## API shape

This intentionally does **not** change the public/default `PublishResponseIfNeeded(...)` behavior or signature.

Instead:
- `PublishResponseIfNeeded(...)` remains the stable default entrypoint with the legacy suppression semantics
- policy-aware behavior lives in internal helpers used by the agent runtime for interactive turns

That keeps the new behavior narrowly scoped to the interactive turn lifecycle, instead of forcing every caller onto a wider API surface.

## Why this shape

This keeps the existing duplicate-suppression behavior where it still makes sense, while making the interactive turn lifecycle explicit instead of relying on a single global heuristic.

It is intentionally separate from async subagent result routing changes:
- this PR is about final reply suppression inside a still-active interactive turn
- PR #2830 is about async background result delivery semantics (`spawn`/`user_only` vs `parent_only`)

They are adjacent, but they solve different layers.

## Tests

Ran focused tests:

```bash
go test ./pkg/agent -run 'TestPublishResponseIfNeededWithPolicy_|TestProcessMessage_MessageTool|TestNewAgentLoop' -count=1
go test ./pkg/tools -run 'TestCronTool_ExecuteJobSkipsWhenMessageToolAlreadySent|TestCronTool_ExecuteJobSkipsNoReplySentinel|TestCronTool_ExecuteJobSkipsEmptyAgentResponse' -count=1
golangci-lint run ./pkg/agent ./pkg/tools
```
