### PR TITLE
fix(feishu): use dynamic channel name instead of hardcoded "feishu"

### DIFF
--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -60,7 +60,7 @@ type cachedMessage struct {
 }
 
 func NewFeishuChannel(bc *config.Channel, cfg *config.FeishuSettings, bus *bus.MessageBus) (*FeishuChannel, error) {
-	base := channels.NewBaseChannel("feishu", cfg, bus, bc.AllowFrom,
+	base := channels.NewBaseChannel(bc.Name(), cfg, bus, bc.AllowFrom,
 		channels.WithGroupTrigger(bc.GroupTrigger),
 		channels.WithReasoningChannelID(bc.ReasoningChannelID),
 	)


### PR DESCRIPTION
## Summary
- Replace hardcoded `"feishu"` string with `bc.Name()` in `NewBaseChannel` call, so multi-instance feishu channels get correct distinct names

## Test plan
- [ ] Verify feishu channel initializes with the name from config
- [ ] Verify multi-instance feishu channels each get their own name