### PR TITLE
Docs: Add Yocto/OpenEmbedded layer (meta-picoclaw)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ PicoClaw can be deployed on virtually any Linux device!
 <https://private-user-images.githubusercontent.com/83055338/547056448-e7b031ff-d6f5-4468-bcca-5726b6fecb5c.mp4>
 
 🌟 More Deployment Cases Await!
-
+### Community Integrations
+* [meta-picoclaw](https://github.com/skrimby1/meta-picoclaw) - Yocto/OpenEmbedded layer for building PicoClaw into custom Linux distributions.
 ## 📦 Install
 
 ### Download from picoclaw.io (Recommended)


### PR DESCRIPTION
Hi Sipeed team! I've developed a dedicated Yocto layer (meta-picoclaw) to simplify deploying PicoClaw on professional embedded Linux builds. Since PicoClaw is perfect for low-resource hardware, this layer helps engineers bake it directly into their custom images. Added a link to the Community section.

Check it out here: 
[meta-picoclaw](https://github.com/skrimby1/meta-picoclaw)
