### PR TITLE
chore: update slack-go to v0.23.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/pion/webrtc/v3 v3.3.6
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/rs/zerolog v1.35.1
-	github.com/slack-go/slack v0.17.3
+	github.com/slack-go/slack v0.23.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfv
 github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
-github.com/slack-go/slack v0.17.3 h1:zV5qO3Q+WJAQ/XwbGfNFrRMaJ5T/naqaonyPV/1TP4g=
-github.com/slack-go/slack v0.17.3/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVrhl8/Prk=
+github.com/slack-go/slack v0.23.1 h1:ZS5B96wxxYQRwvJ3/vJFtqtUZi3tXhsZCyT44Nv7M80=
+github.com/slack-go/slack v0.23.1/go.mod h1:H0yR/YBuRJ39RkE+JpV/d/oEsbanzTRowR82bCN0cEs=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/pkg/channels/slack/slack.go
+++ b/pkg/channels/slack/slack.go
@@ -191,7 +191,7 @@ func (c *SlackChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaMessa
 			title = filename
 		}
 
-		_, err = c.api.UploadFileV2Context(ctx, slack.UploadFileV2Parameters{
+		_, err = c.api.UploadFileContext(ctx, slack.UploadFileParameters{
 			Channel:         channelID,
 			ThreadTimestamp: threadTS,
 			File:            localPath,
@@ -207,7 +207,7 @@ func (c *SlackChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaMessa
 		}
 	}
 
-	// UploadFileV2 does not expose the posted message timestamp in its
+	// UploadFile does not expose the posted message timestamp in its
 	// response; returning nil avoids conflating file IDs with message IDs.
 	return nil, nil
 }


### PR DESCRIPTION
## Description

Updates `github.com/slack-go/slack` from `v0.17.3` to `v0.23.1`.

The Slack media upload path now calls `UploadFileContext` with `slack.UploadFileParameters`, matching the updated client API while preserving the existing channel, thread, file path, title, filename, and comment behavior.

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor / maintenance

## AI Code Generation

- [x] Mostly Human-written

## Related Issue

None.

## Technical Context

The updated Slack client exposes the context-aware file upload API through `UploadFileContext(ctx, slack.UploadFileParameters)`. This keeps the existing context-aware upload behavior while moving the project to the newer module version.

## Test Environment

- Hardware: local development machine
- OS: macOS
- Model/provider: not applicable
- Channels tested: Slack package tests

## Evidence

- `go test ./pkg/channels/slack` passed.
- `go test ./...` was attempted, but local validation is blocked by the missing system header `olm/olm.h` required by `maunium.net/go/mautrix/crypto/libolm`. The Slack package tests passed.

## Checklist

- [x] I have read and understood the code changes.
- [x] I have performed a self-review.
- [x] I have run the relevant local test.
- [x] I have documented the blocked full test run.
- [x] I have checked that no secrets or private configuration are included.
- [x] This PR is focused on one logical change.
