### PR TITLE
fix(config): make load_image configurable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -997,6 +997,7 @@ type ToolsConfig struct {
 	I2C             ToolConfig         `json:"i2c"               yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_I2C_"`
 	InstallSkill    ToolConfig         `json:"install_skill"     yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_INSTALL_SKILL_"`
 	ListDir         ToolConfig         `json:"list_dir"          yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_LIST_DIR_"`
+	LoadImage       ToolConfig         `json:"load_image"        yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_LOAD_IMAGE_"`
 	Message         ToolConfig         `json:"message"           yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_MESSAGE_"`
 	ReadFile        ReadFileToolConfig `json:"read_file"         yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_READ_FILE_"`
 	Serial          ToolConfig         `json:"serial"            yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_SERIAL_"`
@@ -1727,6 +1728,8 @@ func (t *ToolsConfig) IsToolEnabled(name string) bool {
 		return t.InstallSkill.Enabled
 	case "list_dir":
 		return t.ListDir.Enabled
+	case "load_image":
+		return t.LoadImage.Enabled
 	case "message":
 		return t.Message.Enabled
 	case "read_file":

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1247,6 +1247,36 @@ func TestDefaultConfig_FilterMinLength(t *testing.T) {
 	}
 }
 
+func TestDefaultConfig_LoadImageEnabled(t *testing.T) {
+	cfg := DefaultConfig()
+	if !cfg.Tools.LoadImage.Enabled {
+		t.Fatal("DefaultConfig().Tools.LoadImage.Enabled should be true")
+	}
+	if !cfg.Tools.IsToolEnabled("load_image") {
+		t.Fatal("DefaultConfig().Tools.IsToolEnabled(load_image) should be true")
+	}
+}
+
+func TestLoadConfig_LoadImageCanBeDisabled(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	raw := "{\n  \"version\": 2,\n  \"tools\": {\n    \"load_image\": {\n      \"enabled\": false\n    }\n  }\n}\n"
+	if err := os.WriteFile(configPath, []byte(raw), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error: %v", err)
+	}
+	if cfg.Tools.LoadImage.Enabled {
+		t.Fatal("LoadConfig().Tools.LoadImage.Enabled should be false")
+	}
+	if cfg.Tools.IsToolEnabled("load_image") {
+		t.Fatal("LoadConfig().Tools.IsToolEnabled(load_image) should be false")
+	}
+}
+
 func TestToolsConfig_GetFilterMinLength(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -444,6 +444,9 @@ func DefaultConfig() *Config {
 			ListDir: ToolConfig{
 				Enabled: true,
 			},
+			LoadImage: ToolConfig{
+				Enabled: true,
+			},
 			Message: ToolConfig{
 				Enabled: true,
 			},


### PR DESCRIPTION
## 📝 Description

This PR fixes the `load_image` tool configuration path.

`load_image` was conditionally registered in `agent_init.go`, but `ToolsConfig.IsToolEnabled("load_image")` had no dedicated branch and fell through to the default `true` case. In addition, `ToolsConfig` had no `load_image` field, so there was no way to control the tool from `config.json`.

This change:
- adds `tools.load_image` to `ToolsConfig`
- wires `IsToolEnabled("load_image")` to that config field
- preserves the current default behavior by setting `load_image` to enabled in `DefaultConfig()`
- adds tests covering both the default-enabled case and the explicit disabled case

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes [#2878](https://github.com/sipeed/picoclaw/issues/2878)

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/2878
- **Reasoning:** The runtime already checked `IsToolEnabled("load_image")`, but the config layer did not define a `load_image` tool entry or a corresponding switch branch. Because of that mismatch, the guard always evaluated to `true`, and `load_image` could not be disabled via configuration.

## 🧪 Test Environment
- **Hardware:** PC (local development machine)
- **OS:** macOS
- **Model/Provider:** OpenAI GPT-5 / Codex
- **Channels:** N/A (config-level tests only)

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```text
go test ./pkg/config -run 'TestDefaultConfig_LoadImageEnabled|TestLoadConfig_LoadImageCanBeDisabled' -count=1
ok  	github.com/sipeed/picoclaw/pkg/config	0.721s

go test ./pkg/config -count=1
ok  	github.com/sipeed/picoclaw/pkg/config	2.689s
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
