### PR TITLE
fix: resolve symlinks in cwdPath on macOS to fix path validation

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -1113,6 +1113,14 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 		if err != nil {
 			return ""
 		}
+		// On macOS, resolve symlinks in cwdPath to handle /var -> /private/var.
+		// This ensures consistent path comparison when commands reference paths
+		// through symlinks (e.g., temp directories on macOS).
+		if runtime.GOOS == "darwin" {
+			if resolved, err := filepath.EvalSymlinks(cwdPath); err == nil {
+				cwdPath = resolved
+			}
+		}
 
 		// Web URL schemes whose path components (starting with //) should be exempt
 		// from workspace sandbox checks. file: is intentionally excluded so that


### PR DESCRIPTION
## 📝 Description

Fix path validation failure on macOS caused by symlink inconsistency. On macOS, `/var` is a symlink to `/private/var`. When using `t.TempDir()` in tests, the returned path is under `/var`, but commands referencing temp files get resolved to `/private/var` paths. This causes `filepath.Rel()` to incorrectly report paths as outside the working directory.

The fix resolves symlinks in `cwdPath` on macOS before comparing paths, ensuring consistent path validation.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- No related issue number -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** 
  - macOS uses `/var` as a symlink to `/private/var`
  - `filepath.Abs()` returns `/var/folders/...` for temp directories
  - `filepath.EvalSymlinks()` resolves to `/private/var/folders/...`
  - Without resolving cwdPath symlinks, `filepath.Rel(cwdPath, p)` returns `../../../../../../../var/...` which starts with `..`
  - This triggers false positive "path outside working dir" errors

## 🧪 Test Environment
- **Hardware:** MacBook Pro (Intel/Apple Silicon)
- **OS:** macOS (Darwin)
- **Model/Provider:** N/A
- **Channels:** N/A


## 📸 Evidence (Optional)
<details>
<summary>Click to view Test Results</summary>

Before fix:
```
=== RUN   TestShellTool_DevNullAllowed
    shell_test.go:432: command should not be blocked: find /var/folders/... -name '*.go' 2>/dev/null
        error: Command blocked by safety guard (path outside working dir)
--- FAIL: TestShellTool_DevNullAllowed (0.04s)
```

After fix:
```
=== RUN   TestShellTool_DevNullAllowed
--- PASS: TestShellTool_DevNullAllowed (0.04s)
=== RUN   TestShellTool_FileURISandboxing
--- PASS: TestShellTool_FileURISandboxing (0.01s)
PASS
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
