### PR TITLE
fix: add CSRF protection, path traversal validation, and security headers

### DIFF
--- a/web/backend/api/skills.go
+++ b/web/backend/api/skills.go
@@ -502,7 +502,15 @@ func (h *Handler) handleDeleteSkill(w http.ResponseWriter, r *http.Request) {
 			matchedNonWorkspace = true
 			continue
 		}
-		if err := os.RemoveAll(filepath.Dir(skill.Path)); err != nil {
+
+		dirPath := filepath.Clean(filepath.Dir(skill.Path))
+		workspaceDir := filepath.Clean(cfg.WorkspacePath())
+		if !isWithinDir(dirPath, workspaceDir) {
+			http.Error(w, "path escapes workspace directory", http.StatusBadRequest)
+			return
+		}
+
+		if err := os.RemoveAll(dirPath); err != nil {
 			http.Error(w, fmt.Sprintf("Failed to delete skill: %v", err), http.StatusInternalServerError)
 			return
 		}
@@ -516,6 +524,28 @@ func (h *Handler) handleDeleteSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Error(w, "Skill not found", http.StatusNotFound)
+}
+
+// isWithinDir checks whether dirPath is within parentDir, accounting for
+// symlinks. It returns true only if dirPath equals parentDir or is a proper
+// subdirectory of parentDir.
+func isWithinDir(dirPath, parentDir string) bool {
+	if !strings.HasPrefix(dirPath, parentDir+string(os.PathSeparator)) && dirPath != parentDir {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(dirPath)
+	if err != nil {
+		// If we cannot resolve symlinks, trust the cleaned path check above.
+		return true
+	}
+	resolvedParent, err := filepath.EvalSymlinks(parentDir)
+	if err != nil {
+		return true
+	}
+	if !strings.HasPrefix(resolved, resolvedParent+string(os.PathSeparator)) && resolved != resolvedParent {
+		return false
+	}
+	return true
 }
 
 func newSkillsLoader(workspace string) *skills.SkillsLoader {

--- a/web/backend/api/skills_test.go
+++ b/web/backend/api/skills_test.go
@@ -1861,3 +1861,73 @@ func buildSkillZip(t *testing.T, files map[string]string) []byte {
 	}
 	return buf.Bytes()
 }
+
+func TestHandleDeleteSkillRejectsPathTraversal(t *testing.T) {
+	configPath, cleanup := setupOAuthTestEnv(t)
+	defer cleanup()
+
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	cfg.Agents.Defaults.Workspace = workspace
+	if err := config.SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	// Create a skill directory outside the workspace to simulate path traversal.
+	outsideDir := filepath.Join(t.TempDir(), "outside-skill")
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(outside) error = %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(outsideDir, "SKILL.md"),
+		[]byte("---\nname: traversal-skill\ndescription: outside workspace\n---\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("WriteFile(outside) error = %v", err)
+	}
+
+	// Verify the skill would be loaded with a path outside workspace.
+	// The isWithinDir check should reject it even if it appears as workspace source.
+	// We test isWithinDir directly since the skill loader won't naturally produce
+	// a workspace skill outside the workspace directory.
+	dirPath := filepath.Clean(outsideDir)
+	workspaceDir := filepath.Clean(workspace)
+	if isWithinDir(dirPath, workspaceDir) {
+		t.Fatalf("isWithinDir(%q, %q) = true, want false for path outside workspace", dirPath, workspaceDir)
+	}
+
+	// Also verify that a legitimate workspace skill passes the check.
+	skillDir := filepath.Join(workspace, "skills", "legit-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(legit) error = %v", err)
+	}
+	legitDirPath := filepath.Clean(skillDir)
+	if !isWithinDir(legitDirPath, workspaceDir) {
+		t.Fatalf("isWithinDir(%q, %q) = false, want true for path inside workspace", legitDirPath, workspaceDir)
+	}
+}
+
+func TestIsWithinDir(t *testing.T) {
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "workspace")
+	child := filepath.Join(parent, "skills", "my-skill")
+
+	if !isWithinDir(child, parent) {
+		t.Fatalf("isWithinDir(%q, %q) = false, want true", child, parent)
+	}
+	if !isWithinDir(parent, parent) {
+		t.Fatalf("isWithinDir(%q, %q) = false, want true for exact match", parent, parent)
+	}
+	outside := filepath.Join(tmp, "other")
+	if isWithinDir(outside, parent) {
+		t.Fatalf("isWithinDir(%q, %q) = true, want false for path outside", outside, parent)
+	}
+	// Path that shares a prefix but is not a subdirectory (e.g. /workspace-other).
+	sibling := tmp + "-other"
+	if isWithinDir(sibling, parent) {
+		t.Fatalf("isWithinDir(%q, %q) = true, want false for sibling prefix", sibling, parent)
+	}
+}

--- a/web/backend/main.go
+++ b/web/backend/main.go
@@ -604,8 +604,12 @@ func main() {
 	// Apply middleware stack
 	handler := middleware.Recoverer(
 		middleware.Logger(
-			middleware.ReferrerPolicyNoReferrer(
-				middleware.JSONContentType(dashAuth),
+			middleware.SecurityHeaders(
+				middleware.ReferrerPolicyNoReferrer(
+					middleware.CSRF(
+						middleware.JSONContentType(dashAuth),
+					),
+				),
 			),
 		),
 	)

--- a/web/backend/middleware/middleware.go
+++ b/web/backend/middleware/middleware.go
@@ -79,3 +79,28 @@ func Recoverer(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
+
+// CSRF checks for the X-Requested-With header on mutating requests (POST, PUT,
+// DELETE). Browsers block cross-origin requests that include custom headers,
+// so this simple check mitigates CSRF attacks. AJAX calls from the frontend
+// must include the header explicitly.
+func CSRF(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodDelete {
+			if r.Header.Get("X-Requested-With") == "" {
+				http.Error(w, "CSRF check failed: missing X-Requested-With header", http.StatusForbidden)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// SecurityHeaders sets browser-hardening response headers on every response.
+func SecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/web/backend/middleware/middleware_test.go
+++ b/web/backend/middleware/middleware_test.go
@@ -1,0 +1,148 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCSRF_AllowsGetWithoutHeader(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CSRF(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET without X-Requested-With: status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestCSRF_BlocksPostWithoutHeader(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CSRF(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/config", nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("POST without X-Requested-With: status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestCSRF_BlocksPutWithoutHeader(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CSRF(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/config", nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("PUT without X-Requested-With: status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestCSRF_BlocksDeleteWithoutHeader(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CSRF(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/skills/test", nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("DELETE without X-Requested-With: status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestCSRF_AllowsPostWithHeader(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CSRF(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/config", nil)
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST with X-Requested-With: status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestCSRF_AllowsDeleteWithHeader(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CSRF(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/skills/test", nil)
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE with X-Requested-With: status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestSecurityHeaders_SetsNosniff(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := SecurityHeaders(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want %q", got, "nosniff")
+	}
+}
+
+func TestSecurityHeaders_SetsDenyFrameOptions(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := SecurityHeaders(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("X-Frame-Options = %q, want %q", got, "DENY")
+	}
+}
+
+func TestSecurityHeaders_DoesNotOverrideExistingHeaders(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	})
+	h := SecurityHeaders(inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want %q", got, "application/json")
+	}
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want %q", got, "nosniff")
+	}
+}

--- a/web/frontend/src/api/http.ts
+++ b/web/frontend/src/api/http.ts
@@ -19,14 +19,22 @@ function isLauncherAuthPath(): boolean {
 /**
  * Same-origin fetch that sends cookies; redirects to launcher login on 401 JSON responses.
  * Skips redirect while already on an auth page (login or setup) to avoid reload loops.
+ * Adds X-Requested-With header on mutating requests for CSRF protection.
  */
 export async function launcherFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<Response> {
+  const method = init?.method?.toUpperCase() || (typeof input === "string" || input instanceof URL ? "GET" : input instanceof Request ? input.method : "GET")
+  const isMutating = method === "POST" || method === "PUT" || method === "DELETE"
+  const headers = new Headers(init?.headers)
+  if (isMutating) {
+    headers.set("X-Requested-With", "XMLHttpRequest")
+  }
   const res = await fetch(input, {
     credentials: "same-origin",
     ...init,
+    headers,
   })
   if (res.status === 401) {
     const ct = res.headers.get("content-type") || ""

--- a/web/frontend/src/api/launcher-auth.ts
+++ b/web/frontend/src/api/launcher-auth.ts
@@ -11,7 +11,10 @@ export async function postLauncherDashboardLogin(
 ): Promise<LoginResult> {
   const res = await fetch("/api/auth/login", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "X-Requested-With": "XMLHttpRequest",
+    },
     credentials: "same-origin",
     body: JSON.stringify({ password: password.trim() }),
   })
@@ -44,7 +47,10 @@ export async function getLauncherAuthStatus(): Promise<LauncherAuthStatus> {
 export async function postLauncherDashboardLogout(): Promise<boolean> {
   const res = await fetch("/api/auth/logout", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "X-Requested-With": "XMLHttpRequest",
+    },
     credentials: "same-origin",
     body: "{}",
   })
@@ -59,7 +65,10 @@ export async function postLauncherDashboardSetup(
 ): Promise<SetupResult> {
   const res = await fetch("/api/auth/setup", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "X-Requested-With": "XMLHttpRequest",
+    },
     credentials: "same-origin",
     body: JSON.stringify({
       password: password.trim(),

--- a/web/frontend/src/components/config/config-sections.tsx
+++ b/web/frontend/src/components/config/config-sections.tsx
@@ -739,7 +739,10 @@ export function ExecSection({ form, onFieldChange }: ExecSectionProps) {
     try {
       const res = await fetch("/api/config/test-command-patterns", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "X-Requested-With": "XMLHttpRequest",
+        },
         body: JSON.stringify({
           allow_patterns: allowPatterns,
           deny_patterns: denyPatterns,


### PR DESCRIPTION
fix: add CSRF protection, path traversal validation, and security headers to web backend

Security fixes for the web UI launcher backend:

1. handleDeleteSkill path boundary validation:
   - Add filepath.Clean + isWithinDir prefix check against workspace dir
   - Resolve symlinks via filepath.EvalSymlinks before final check
   - Return 400 if deletion target escapes workspace directory

2. CSRF middleware:
   - Check X-Requested-With header on POST/PUT/DELETE requests
   - Return 403 for requests missing the header
   - Frontend automatically adds X-Requested-With: XMLHttpRequest on mutating requests

3. Security response headers:
   - X-Content-Type-Options: nosniff (prevent MIME sniffing)
   - X-Frame-Options: DENY (prevent clickjacking)
