### PR TITLE
Fix fallback chain handling for expired contexts

### DIFF
--- a/pkg/providers/fallback.go
+++ b/pkg/providers/fallback.go
@@ -205,14 +205,14 @@ func (fc *FallbackChain) Execute(
 		}
 
 		// Context termination: abort immediately, no fallback.
-		if err := fallbackContextErr(ctx); err != nil {
+		if ctxErr := fallbackContextErr(ctx); ctxErr != nil {
 			result.Attempts = append(result.Attempts, FallbackAttempt{
 				Provider: candidate.Provider,
 				Model:    candidate.Model,
-				Error:    err,
+				Error:    ctxErr,
 				Duration: elapsed,
 			})
-			return nil, err
+			return nil, ctxErr
 		}
 
 		// Classify the error.
@@ -323,14 +323,14 @@ func (fc *FallbackChain) ExecuteImage(
 			return result, nil
 		}
 
-		if err := fallbackContextErr(ctx); err != nil {
+		if ctxErr := fallbackContextErr(ctx); ctxErr != nil {
 			result.Attempts = append(result.Attempts, FallbackAttempt{
 				Provider: candidate.Provider,
 				Model:    candidate.Model,
-				Error:    err,
+				Error:    ctxErr,
 				Duration: elapsed,
 			})
-			return nil, err
+			return nil, ctxErr
 		}
 
 		// Image dimension/size errors are non-retriable.

--- a/pkg/providers/fallback.go
+++ b/pkg/providers/fallback.go
@@ -7,6 +7,16 @@ import (
 	"time"
 )
 
+func fallbackContextErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("fallback: context ended: %w", err)
+	}
+	return nil
+}
+
 // FallbackChain orchestrates model fallback across multiple candidates.
 type FallbackChain struct {
 	cooldown *CooldownTracker
@@ -109,7 +119,7 @@ func ResolveCandidatesWithLookup(
 //
 // Behavior:
 //   - Candidates in cooldown are skipped (logged as skipped attempt).
-//   - context.Canceled aborts immediately (user abort, no fallback).
+//   - Any context termination aborts immediately (cancel or deadline, no fallback).
 //   - Non-retriable errors (format) abort immediately.
 //   - Retriable errors trigger fallback to next candidate.
 //   - Success marks provider as good (resets cooldown).
@@ -129,8 +139,8 @@ func (fc *FallbackChain) Execute(
 
 	for i, candidate := range candidates {
 		// Check context before each attempt.
-		if ctx.Err() == context.Canceled {
-			return nil, context.Canceled
+		if err := fallbackContextErr(ctx); err != nil {
+			return nil, err
 		}
 
 		// Check cooldown per stable candidate identity, not just provider/model.
@@ -194,15 +204,15 @@ func (fc *FallbackChain) Execute(
 			return result, nil
 		}
 
-		// Context cancellation: abort immediately, no fallback.
-		if ctx.Err() == context.Canceled {
+		// Context termination: abort immediately, no fallback.
+		if err := fallbackContextErr(ctx); err != nil {
 			result.Attempts = append(result.Attempts, FallbackAttempt{
 				Provider: candidate.Provider,
 				Model:    candidate.Model,
 				Error:    err,
 				Duration: elapsed,
 			})
-			return nil, context.Canceled
+			return nil, err
 		}
 
 		// Classify the error.
@@ -269,8 +279,8 @@ func (fc *FallbackChain) ExecuteImage(
 	}
 
 	for i, candidate := range candidates {
-		if ctx.Err() == context.Canceled {
-			return nil, context.Canceled
+		if err := fallbackContextErr(ctx); err != nil {
+			return nil, err
 		}
 
 		// Enforce per-candidate rate limit before calling the provider.
@@ -313,14 +323,14 @@ func (fc *FallbackChain) ExecuteImage(
 			return result, nil
 		}
 
-		if ctx.Err() == context.Canceled {
+		if err := fallbackContextErr(ctx); err != nil {
 			result.Attempts = append(result.Attempts, FallbackAttempt{
 				Provider: candidate.Provider,
 				Model:    candidate.Model,
 				Error:    err,
 				Duration: elapsed,
 			})
-			return nil, context.Canceled
+			return nil, err
 		}
 
 		// Image dimension/size errors are non-retriable.

--- a/pkg/providers/fallback_test.go
+++ b/pkg/providers/fallback_test.go
@@ -116,8 +116,61 @@ func TestFallback_ContextCanceled(t *testing.T) {
 	}
 
 	_, err := fc.Execute(ctx, candidates, run)
-	if err != context.Canceled {
+	if err == nil || !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestFallback_ContextDeadlineExceededBeforeAttempt(t *testing.T) {
+	ct := NewCooldownTracker()
+	fc := NewFallbackChain(ct, nil)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	candidates := []FallbackCandidate{
+		makeCandidate("openai", "gpt-4"),
+		makeCandidate("anthropic", "claude"),
+	}
+
+	_, err := fc.Execute(ctx, candidates, func(ctx context.Context, provider, model string) (*LLMResponse, error) {
+		t.Fatal("run should not be called when context has already expired")
+		return nil, nil
+	})
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded error, got %v", err)
+	}
+}
+
+func TestFallback_ContextDeadlineExceededDoesNotTryNextCandidate(t *testing.T) {
+	ct := NewCooldownTracker()
+	fc := NewFallbackChain(ct, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	candidates := []FallbackCandidate{
+		makeCandidate("openai", "gpt-4"),
+		makeCandidate("anthropic", "claude"),
+	}
+
+	attempt := 0
+	run := func(ctx context.Context, provider, model string) (*LLMResponse, error) {
+		attempt++
+		if attempt == 1 {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		t.Fatal("should not reach second candidate after deadline exceeded")
+		return nil, nil
+	}
+
+	_, err := fc.Execute(ctx, candidates, run)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded error, got %v", err)
+	}
+	if attempt != 1 {
+		t.Fatalf("attempt = %d, want 1", attempt)
 	}
 }
 
@@ -517,6 +570,55 @@ func TestImageFallback_RetryOnOtherErrors(t *testing.T) {
 	}
 	if result.Provider != "anthropic" {
 		t.Errorf("provider = %q, want anthropic", result.Provider)
+	}
+}
+
+func TestImageFallback_ContextDeadlineExceededBeforeAttempt(t *testing.T) {
+	ct := NewCooldownTracker()
+	fc := NewFallbackChain(ct, nil)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	candidates := []FallbackCandidate{makeCandidate("openai", "gpt-4o")}
+	_, err := fc.ExecuteImage(ctx, candidates, func(ctx context.Context, provider, model string) (*LLMResponse, error) {
+		t.Fatal("run should not be called when image context has already expired")
+		return nil, nil
+	})
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded error, got %v", err)
+	}
+}
+
+func TestImageFallback_ContextDeadlineExceededDoesNotTryNextCandidate(t *testing.T) {
+	ct := NewCooldownTracker()
+	fc := NewFallbackChain(ct, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	candidates := []FallbackCandidate{
+		makeCandidate("openai", "gpt-4o"),
+		makeCandidate("anthropic", "claude-sonnet"),
+	}
+
+	attempt := 0
+	run := func(ctx context.Context, provider, model string) (*LLMResponse, error) {
+		attempt++
+		if attempt == 1 {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		t.Fatal("should not reach second image candidate after deadline exceeded")
+		return nil, nil
+	}
+
+	_, err := fc.ExecuteImage(ctx, candidates, run)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded error, got %v", err)
+	}
+	if attempt != 1 {
+		t.Fatalf("attempt = %d, want 1", attempt)
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

Fix fallback-chain context handling so expired request contexts stop the chain immediately instead of pointlessly trying later candidates.

Before this change, `pkg/providers/fallback.go` only short-circuited on `context.Canceled`. When a request hit a deadline, `ctx.Err()` became `context.DeadlineExceeded`, but the fallback chain kept moving through the remaining candidates. Those attempts could not succeed because the context was already done, so they only added latency and noise.

This PR updates both existing fallback execution paths:

- `Execute`
- `ExecuteImage`

The change introduces a small shared helper that treats any non-nil `ctx.Err()` as terminal and returns a wrapped error that still preserves `errors.Is(..., context.Canceled)` and `errors.Is(..., context.DeadlineExceeded)`.

It also adds regression coverage for:

- canceled contexts
- deadline exceeded before the first attempt
- deadline exceeded during the first attempt
- ensuring no second candidate is attempted after the context has already ended

for both text and image fallback flows.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

No tracked GitHub issue. This addresses item 2 ("Fallback Chain context handling defect") from the local improvement report.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
  - Local report: `improvement-report.md`
  - Relevant code: `pkg/providers/fallback.go`
- **Reasoning:**
  - A finished context is terminal for provider calls.
  - Continuing fallback after `context.DeadlineExceeded` cannot recover the request, because every later candidate receives the same expired context.
  - Stopping immediately avoids wasted work, avoids misleading extra failure records, and aligns deadline behavior with existing cancel behavior.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Linux
- **Model/Provider:** N/A
- **Channels:** N/A


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Targeted verification completed:

```bash
env CGO_ENABLED=0 GOCACHE=/tmp/picoclaw-gocache GOMODCACHE=/tmp/picoclaw-gomodcache GOPATH=/tmp/picoclaw-gopath go test ./pkg/providers
```

Notes:

- Regression tests for the fallback package were added and reviewed.
- Full-repo `go test ./...` / `go build ./...` could not be fully confirmed inside the current sandbox because unrelated provider tests in this environment hit local socket restrictions, and full-repo builds also depend on the project's normal CI build-tag setup.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
