### PR TITLE
Fix JSONL store metadata drift after crash

### DIFF
--- a/docs/design/jsonl-crash-consistency-fix-plan.zh.md
+++ b/docs/design/jsonl-crash-consistency-fix-plan.zh.md
@@ -1,0 +1,80 @@
+# JSONL Store 崩溃一致性修复方案
+
+## 1. 问题定义
+
+`pkg/memory/jsonl.go` 的 `addMsg` 先追加 `.jsonl` 数据行，再更新 `.meta.json`。
+
+当进程在两步之间崩溃时，会出现：
+
+- `.jsonl` 已包含新消息
+- `meta.Count` 仍是旧值
+- `GetHistory` 能读到新消息，但不会修复 `meta.Count`
+- `readMessages` 只按 `meta.Skip` 读取，不校验元数据是否与真实文件一致
+
+这会导致 metadata 长期漂移，并在后续截断、压缩、重启恢复中放大为静默丢消息风险。
+
+## 2. 本次目标
+
+- 在不引入 WAL 的前提下，消除 `Count/Skip` 长期漂移
+- 把“崩溃后永久不一致”收敛为“首次访问自动自愈”
+- 保持现有 JSONL 存储格式兼容，不做破坏性迁移
+- 用单元测试覆盖启动恢复、读取恢复、越界 `Skip` 恢复
+
+## 3. 已实施改动
+
+- `NewJSONLStore` 增加启动期 metadata repair：
+  - 扫描现有 `.meta.json`
+  - 对比真实 JSONL 行数与 `meta.Count`
+  - 当 `Skip > Count` 或 `Count` 漂移时自动回写修复
+- 增加统一修复入口 `repairSessionMetaLocked`
+  - 使用真实 JSONL 原始非空行数作为 `Count`
+  - 将越界 `Skip` 收敛到 `rawCount`
+  - 修复缺失的 `Key`
+  - 对缺失时间戳的非空会话补齐 `CreatedAt/UpdatedAt`
+- 在以下访问路径中接入修复：
+  - `GetSessionMeta`
+  - `GetHistory`
+  - `TruncateHistory`
+  - `Compact`
+
+## 4. 设计取舍
+
+- 选择“按需修复 + 启动预修复”，而不是本次直接上 WAL。
+  - 优点：兼容现有数据格式，改动面小，风险可控
+  - 缺点：追加写和 meta 更新仍不是严格原子
+- `Count` 继续定义为 JSONL 原始非空行数，而不是过滤后的 retained message 数。
+  - 这是为了与现有 `Skip` 语义、`TruncateHistory` 的 raw-line 计算保持一致
+- 对损坏尾行保持容忍：
+  - `readMessages` 继续跳过坏行
+  - repair 仅修复 metadata，不自动重写 JSONL 文件
+
+## 5. 验证策略
+
+新增测试覆盖：
+
+- `TestGetHistory_RepairsStaleMetaCount`
+  - 验证读取路径能修复“JSONL 比 meta 多一行”的崩溃后状态
+- `TestNewJSONLStore_RepairsExistingMetaOnStartup`
+  - 验证重启后 store 初始化阶段会修复旧 metadata
+- `TestGetHistory_RepairsSkipPastEOF`
+  - 验证 `Skip` 越界时不会长期维持错误状态
+
+已有测试继续覆盖：
+
+- `TestTruncateHistory_StaleMetaCount`
+- `TestCrashRecovery_PartialLine`
+
+## 6. 残余风险
+
+- 当前方案只能修复元数据漂移，不能提供严格的跨文件原子提交
+- 如果 `.meta.json` 写成功而 `.jsonl` 后续重写失败，仍会出现“metadata 比数据更前”的窗口
+- 启动期 repair 依赖扫描 JSONL，超大历史会话会带来额外启动成本
+
+## 7. 下一阶段建议
+
+按优先级建议后续继续推进：
+
+1. 引入 WAL 或单文件事务日志，保证 append 与 meta update 可恢复地提交
+2. 为 repair 增加可观测性指标和日志计数，便于发现线上频繁自愈
+3. 评估在 `Compact`/`SetHistory` 路径中加入更强的崩溃恢复标记
+4. 若会话规模继续增长，考虑把 `Count/Skip` 与 active count 分离建模

--- a/pkg/memory/jsonl.go
+++ b/pkg/memory/jsonl.go
@@ -694,8 +694,8 @@ func (s *JSONLStore) GetHistory(
 	if err != nil {
 		return nil, err
 	}
-	if _, err := s.repairSessionMetaLocked(sessionKey, &meta); err != nil {
-		return nil, err
+	if _, repairErr := s.repairSessionMetaLocked(sessionKey, &meta); repairErr != nil {
+		return nil, repairErr
 	}
 
 	// Pass meta.Skip so readMessages skips those lines without
@@ -754,8 +754,8 @@ func (s *JSONLStore) TruncateHistory(
 	if err != nil {
 		return err
 	}
-	if _, err := s.repairSessionMetaLocked(sessionKey, &meta); err != nil {
-		return err
+	if _, repairErr := s.repairSessionMetaLocked(sessionKey, &meta); repairErr != nil {
+		return repairErr
 	}
 
 	rawCount, retainedRawLines, scanErr := scanRetainedMessageLines(s.jsonlPath(sessionKey))
@@ -836,8 +836,8 @@ func (s *JSONLStore) Compact(
 	if err != nil {
 		return err
 	}
-	if _, err := s.repairSessionMetaLocked(sessionKey, &meta); err != nil {
-		return err
+	if _, repairErr := s.repairSessionMetaLocked(sessionKey, &meta); repairErr != nil {
+		return repairErr
 	}
 	if meta.Skip == 0 {
 		return nil

--- a/pkg/memory/jsonl.go
+++ b/pkg/memory/jsonl.go
@@ -71,7 +71,11 @@ func NewJSONLStore(dir string) (*JSONLStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("memory: create directory: %w", err)
 	}
-	return &JSONLStore{dir: dir}, nil
+	store := &JSONLStore{dir: dir}
+	if err := store.repairSessionMetadata(); err != nil {
+		return nil, err
+	}
+	return store, nil
 }
 
 // sessionLock returns a mutex for the given session key.
@@ -137,6 +141,34 @@ func (s *JSONLStore) writeMeta(key string, meta SessionMeta) error {
 	return fileutil.WriteFileAtomic(s.metaPath(key), data, 0o644)
 }
 
+func (s *JSONLStore) repairSessionMetadata() error {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return fmt.Errorf("memory: read session directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".meta.json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.dir, entry.Name()))
+		if err != nil {
+			return fmt.Errorf("memory: read meta during repair: %w", err)
+		}
+		var meta SessionMeta
+		if err := json.Unmarshal(data, &meta); err != nil {
+			return fmt.Errorf("memory: decode meta during repair: %w", err)
+		}
+		sessionKey := strings.TrimSpace(meta.Key)
+		if sessionKey == "" {
+			sessionKey = strings.TrimSuffix(entry.Name(), ".meta.json")
+		}
+		if _, err := s.repairSessionMetaLocked(sessionKey, &meta); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func cloneRawJSON(data json.RawMessage) json.RawMessage {
 	if len(data) == 0 {
 		return nil
@@ -189,6 +221,9 @@ func (s *JSONLStore) GetSessionMeta(_ context.Context, sessionKey string) (Sessi
 
 	meta, err := s.readMeta(sessionKey)
 	if err != nil {
+		return SessionMeta{}, err
+	}
+	if _, err := s.repairSessionMetaLocked(sessionKey, &meta); err != nil {
 		return SessionMeta{}, err
 	}
 	meta.Scope = cloneRawJSON(meta.Scope)
@@ -536,6 +571,46 @@ func scanRetainedMessageLines(path string) (int, []int, error) {
 	return rawCount, retained, nil
 }
 
+func (s *JSONLStore) repairSessionMetaLocked(sessionKey string, meta *SessionMeta) (bool, error) {
+	rawCount, _, err := scanRetainedMessageLines(s.jsonlPath(sessionKey))
+	if err != nil {
+		return false, err
+	}
+
+	changed := false
+	if strings.TrimSpace(meta.Key) == "" {
+		meta.Key = sessionKey
+		changed = true
+	}
+	if meta.Count != rawCount {
+		meta.Count = rawCount
+		changed = true
+	}
+	if meta.Skip > rawCount {
+		meta.Skip = rawCount
+		changed = true
+	}
+	if meta.Skip < 0 {
+		meta.Skip = 0
+		changed = true
+	}
+	if rawCount > 0 && meta.CreatedAt.IsZero() {
+		now := time.Now()
+		meta.CreatedAt = now
+		meta.UpdatedAt = now
+		changed = true
+	}
+	if changed {
+		if meta.UpdatedAt.IsZero() {
+			meta.UpdatedAt = time.Now()
+		}
+		if err := s.writeMeta(sessionKey, *meta); err != nil {
+			return false, err
+		}
+	}
+	return changed, nil
+}
+
 func (s *JSONLStore) AddMessage(
 	_ context.Context, sessionKey, role, content string,
 ) error {
@@ -619,6 +694,9 @@ func (s *JSONLStore) GetHistory(
 	if err != nil {
 		return nil, err
 	}
+	if _, err := s.repairSessionMetaLocked(sessionKey, &meta); err != nil {
+		return nil, err
+	}
 
 	// Pass meta.Skip so readMessages skips those lines without
 	// unmarshaling them — avoids wasted CPU on truncated messages.
@@ -674,6 +752,9 @@ func (s *JSONLStore) TruncateHistory(
 
 	meta, err := s.readMeta(sessionKey)
 	if err != nil {
+		return err
+	}
+	if _, err := s.repairSessionMetaLocked(sessionKey, &meta); err != nil {
 		return err
 	}
 
@@ -753,6 +834,9 @@ func (s *JSONLStore) Compact(
 
 	meta, err := s.readMeta(sessionKey)
 	if err != nil {
+		return err
+	}
+	if _, err := s.repairSessionMetaLocked(sessionKey, &meta); err != nil {
 		return err
 	}
 	if meta.Skip == 0 {

--- a/pkg/memory/jsonl_test.go
+++ b/pkg/memory/jsonl_test.go
@@ -822,6 +822,47 @@ func TestTruncateHistory_StaleMetaCount(t *testing.T) {
 	}
 }
 
+func TestGetHistory_RepairsStaleMetaCount(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		if err := store.AddMessage(ctx, "repair-count", "user", string(rune('a'+i))); err != nil {
+			t.Fatalf("AddMessage: %v", err)
+		}
+	}
+
+	f, err := os.OpenFile(store.jsonlPath("repair-count"), os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	if _, err := f.WriteString(`{"role":"assistant","content":"tail"}` + "\n"); err != nil {
+		t.Fatalf("write orphan: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close append file: %v", err)
+	}
+
+	history, err := store.GetHistory(ctx, "repair-count")
+	if err != nil {
+		t.Fatalf("GetHistory: %v", err)
+	}
+	if len(history) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(history))
+	}
+	if history[3].Content != "tail" {
+		t.Fatalf("last content = %q, want tail", history[3].Content)
+	}
+
+	meta, err := store.readMeta("repair-count")
+	if err != nil {
+		t.Fatalf("readMeta: %v", err)
+	}
+	if meta.Count != 4 {
+		t.Fatalf("meta.Count = %d, want 4", meta.Count)
+	}
+}
+
 func TestTruncateHistory_IgnoresTransientThoughtForKeepLast(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
@@ -907,6 +948,49 @@ func TestCrashRecovery_PartialLine(t *testing.T) {
 	}
 }
 
+func TestGetHistory_RepairsSkipPastEOF(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	sessionKey := "skip-past-eof"
+	now := time.Now()
+
+	rawJSONL := strings.Join([]string{
+		`{"role":"user","content":"a"}`,
+		`{"role":"assistant","content":"b"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(store.jsonlPath(sessionKey), []byte(rawJSONL), 0o644); err != nil {
+		t.Fatalf("WriteFile(jsonl): %v", err)
+	}
+	if err := store.writeMeta(sessionKey, SessionMeta{
+		Key:       sessionKey,
+		Count:     10,
+		Skip:      10,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+
+	history, err := store.GetHistory(ctx, sessionKey)
+	if err != nil {
+		t.Fatalf("GetHistory: %v", err)
+	}
+	if len(history) != 0 {
+		t.Fatalf("expected no active messages after repaired skip, got %d", len(history))
+	}
+
+	meta, err := store.readMeta(sessionKey)
+	if err != nil {
+		t.Fatalf("readMeta: %v", err)
+	}
+	if meta.Count != 2 {
+		t.Fatalf("meta.Count = %d, want 2", meta.Count)
+	}
+	if meta.Skip != 2 {
+		t.Fatalf("meta.Skip = %d, want 2", meta.Skip)
+	}
+}
+
 func TestPersistence_AcrossInstances(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
@@ -947,6 +1031,62 @@ func TestPersistence_AcrossInstances(t *testing.T) {
 	}
 	if summary != "a test session" {
 		t.Errorf("summary = %q", summary)
+	}
+}
+
+func TestNewJSONLStore_RepairsExistingMetaOnStartup(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	store1, err := NewJSONLStore(dir)
+	if err != nil {
+		t.Fatalf("NewJSONLStore: %v", err)
+	}
+	if err := store1.AddMessage(ctx, "startup-repair", "user", "one"); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	if err := store1.AddMessage(ctx, "startup-repair", "assistant", "two"); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	if err := store1.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	jsonlPath := filepath.Join(dir, "startup-repair.jsonl")
+	f, err := os.OpenFile(jsonlPath, os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	if _, err := f.WriteString(`{"role":"user","content":"three"}` + "\n"); err != nil {
+		t.Fatalf("write orphan: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close append file: %v", err)
+	}
+
+	store2, err := NewJSONLStore(dir)
+	if err != nil {
+		t.Fatalf("NewJSONLStore second: %v", err)
+	}
+	defer store2.Close()
+
+	meta, err := store2.GetSessionMeta(ctx, "startup-repair")
+	if err != nil {
+		t.Fatalf("GetSessionMeta: %v", err)
+	}
+	if meta.Count != 3 {
+		t.Fatalf("meta.Count = %d, want 3", meta.Count)
+	}
+
+	history, err := store2.GetHistory(ctx, "startup-repair")
+	if err != nil {
+		t.Fatalf("GetHistory: %v", err)
+	}
+	if len(history) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(history))
+	}
+	if history[2].Content != "three" {
+		t.Fatalf("last content = %q, want three", history[2].Content)
 	}
 }
 

--- a/pkg/memory/jsonl_test.go
+++ b/pkg/memory/jsonl_test.go
@@ -836,11 +836,13 @@ func TestGetHistory_RepairsStaleMetaCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open for append: %v", err)
 	}
-	if _, err := f.WriteString(`{"role":"assistant","content":"tail"}` + "\n"); err != nil {
-		t.Fatalf("write orphan: %v", err)
+	_, writeErr := f.WriteString(`{"role":"assistant","content":"tail"}` + "\n")
+	if writeErr != nil {
+		t.Fatalf("write orphan: %v", writeErr)
 	}
-	if err := f.Close(); err != nil {
-		t.Fatalf("close append file: %v", err)
+	closeErr := f.Close()
+	if closeErr != nil {
+		t.Fatalf("close append file: %v", closeErr)
 	}
 
 	history, err := store.GetHistory(ctx, "repair-count")
@@ -1042,14 +1044,17 @@ func TestNewJSONLStore_RepairsExistingMetaOnStartup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJSONLStore: %v", err)
 	}
-	if err := store1.AddMessage(ctx, "startup-repair", "user", "one"); err != nil {
-		t.Fatalf("AddMessage: %v", err)
+	addErr := store1.AddMessage(ctx, "startup-repair", "user", "one")
+	if addErr != nil {
+		t.Fatalf("AddMessage: %v", addErr)
 	}
-	if err := store1.AddMessage(ctx, "startup-repair", "assistant", "two"); err != nil {
-		t.Fatalf("AddMessage: %v", err)
+	addErr = store1.AddMessage(ctx, "startup-repair", "assistant", "two")
+	if addErr != nil {
+		t.Fatalf("AddMessage: %v", addErr)
 	}
-	if err := store1.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
+	closeErr := store1.Close()
+	if closeErr != nil {
+		t.Fatalf("Close: %v", closeErr)
 	}
 
 	jsonlPath := filepath.Join(dir, "startup-repair.jsonl")
@@ -1057,11 +1062,13 @@ func TestNewJSONLStore_RepairsExistingMetaOnStartup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open for append: %v", err)
 	}
-	if _, err := f.WriteString(`{"role":"user","content":"three"}` + "\n"); err != nil {
-		t.Fatalf("write orphan: %v", err)
+	_, writeErr := f.WriteString(`{"role":"user","content":"three"}` + "\n")
+	if writeErr != nil {
+		t.Fatalf("write orphan: %v", writeErr)
 	}
-	if err := f.Close(); err != nil {
-		t.Fatalf("close append file: %v", err)
+	closeErr = f.Close()
+	if closeErr != nil {
+		t.Fatalf("close append file: %v", closeErr)
 	}
 
 	store2, err := NewJSONLStore(dir)


### PR DESCRIPTION
## 📝 Description

This PR fixes a crash-consistency gap in the JSONL-backed memory store.

`pkg/memory/jsonl.go` appends new data to the session `.jsonl` file first and updates `.meta.json` afterwards. If the process crashes between those two writes, the JSONL file may already contain the new message while the metadata still reflects the old count or skip state. In practice this means:

- `GetHistory` can read the appended message from disk, but the metadata drift is left behind
- later operations such as `TruncateHistory` or `Compact` may keep working from stale metadata
- repeated crashes can accumulate incorrect `Count` / `Skip` values and eventually lead to incorrect truncation decisions or silent history loss

This change makes the metadata layer self-healing without changing the on-disk format:

- `NewJSONLStore` now performs a startup repair pass over existing `.meta.json` files
- `GetSessionMeta`, `GetHistory`, `TruncateHistory`, and `Compact` now reconcile metadata with the real JSONL file before proceeding
- stale `Count` values are repaired to match the real raw JSONL line count
- out-of-range `Skip` values are clamped back to the actual file size
- missing session keys and missing timestamps on non-empty sessions are repaired during reconciliation
- focused tests were added for stale count recovery, startup recovery, and `Skip` past EOF recovery
- a design note was added to document the fix scope, tradeoffs, and the follow-up WAL direction

This is intentionally a compatibility-preserving fix. It improves recovery behavior for the existing JSONL + metadata design and reduces the risk of permanent metadata drift, while leaving room for a future WAL-based implementation if stricter atomicity is needed.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

Addresses the 4th item in `improvement-report.md`: `JSONL Store 的崩溃一致性问题`.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** Repository-local analysis from `improvement-report.md` and the current `pkg/memory/jsonl.go` implementation
- **Reasoning:** The current write order in `addMsg` prioritizes not losing appended JSONL lines, but it leaves a crash window where `.meta.json` can permanently lag behind the real file contents. The lowest-risk fix within the current architecture is to automatically reconcile metadata on startup and on critical read/write paths, so the store converges back to a correct state without introducing a new storage format.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Linux
- **Model/Provider:** N/A
- **Channels:** N/A


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Validated locally with:

```bash
go test ./pkg/memory
go test ./pkg/memory ./pkg/fileutil
CGO_ENABLED=0 go build -tags goolm,stdjson ./cmd/picoclaw
```

Notes:

- `go test ./...` was also attempted during validation.
- The remaining failure on that command was environment-specific and unrelated to this PR: the machine did not have `olm/olm.h`, which is required by `maunium.net/go/mautrix/crypto/libolm`.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
