### PR TITLE
Fix JSONL session index hot-path cloning and TTL refresh semantics

### DIFF
--- a/pkg/memory/jsonl.go
+++ b/pkg/memory/jsonl.go
@@ -32,6 +32,8 @@ const (
 	// we set a generous limit. The scanner starts at 64 KB and grows
 	// only as needed up to this cap.
 	maxLineSize = 10 * 1024 * 1024 // 10 MB
+
+	sessionIndexRefreshInterval = 30 * time.Second
 )
 
 // SessionMeta holds per-session metadata stored in a .meta.json file.
@@ -63,6 +65,17 @@ type SessionMeta struct {
 type JSONLStore struct {
 	dir   string
 	locks [numLockShards]sync.Mutex
+
+	indexMu sync.RWMutex
+	index   sessionIndex
+	now     func() time.Time
+}
+
+type sessionIndex struct {
+	scannedAt      time.Time
+	keys           map[string]struct{}
+	aliasToKey     map[string]string
+	canonicalToKey map[string]string
 }
 
 // NewJSONLStore creates a new JSONL-backed store rooted at dir.
@@ -71,7 +84,10 @@ func NewJSONLStore(dir string) (*JSONLStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("memory: create directory: %w", err)
 	}
-	return &JSONLStore{dir: dir}, nil
+	return &JSONLStore{
+		dir: dir,
+		now: time.Now,
+	}, nil
 }
 
 // sessionLock returns a mutex for the given session key.
@@ -142,6 +158,14 @@ func cloneRawJSON(data json.RawMessage) json.RawMessage {
 		return nil
 	}
 	return append(json.RawMessage(nil), data...)
+}
+
+func newSessionIndex() sessionIndex {
+	return sessionIndex{
+		keys:           make(map[string]struct{}),
+		aliasToKey:     make(map[string]string),
+		canonicalToKey: make(map[string]string),
+	}
 }
 
 func normalizeAliases(canonicalKey string, aliases []string) []string {
@@ -222,7 +246,11 @@ func (s *JSONLStore) UpsertSessionMeta(
 	}
 	meta.UpdatedAt = now
 
-	return s.writeMeta(sessionKey, meta)
+	if err := s.writeMeta(sessionKey, meta); err != nil {
+		return err
+	}
+	s.updateSessionIndex(meta)
+	return nil
 }
 
 // PromoteAliasHistory atomically promotes the first non-empty alias session
@@ -265,46 +293,18 @@ func (s *JSONLStore) ResolveSessionKey(_ context.Context, sessionKey string) (st
 		return sessionKey, true, nil
 	}
 
-	entries, err := os.ReadDir(s.dir)
-	if err != nil {
-		return "", false, fmt.Errorf("memory: read sessions dir: %w", err)
+	if err := s.ensureFreshSessionIndex(); err != nil {
+		return "", false, err
 	}
 
-	var directMetaMatch string
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".meta.json") {
-			continue
-		}
+	s.indexMu.RLock()
+	defer s.indexMu.RUnlock()
 
-		data, readErr := os.ReadFile(filepath.Join(s.dir, entry.Name()))
-		if readErr != nil {
-			log.Printf("memory: skipping unreadable meta %s: %v", entry.Name(), readErr)
-			continue
-		}
-
-		var meta SessionMeta
-		if err := json.Unmarshal(data, &meta); err != nil {
-			log.Printf("memory: skipping corrupt meta %s: %v", entry.Name(), err)
-			continue
-		}
-
-		if meta.Key == "" {
-			continue
-		}
-
-		if meta.Key == sessionKey {
-			directMetaMatch = meta.Key
-		}
-
-		for _, alias := range meta.Aliases {
-			if alias == sessionKey && meta.Key != sessionKey {
-				return meta.Key, true, nil
-			}
-		}
+	if resolved := s.index.aliasToKey[sessionKey]; resolved != "" && resolved != sessionKey {
+		return resolved, true, nil
 	}
-
-	if directMetaMatch != "" {
-		return directMetaMatch, true, nil
+	if resolved := s.index.canonicalToKey[sessionKey]; resolved != "" {
+		return resolved, true, nil
 	}
 
 	if hasDirectSession {
@@ -403,6 +403,7 @@ func (s *JSONLStore) promoteAliasHistoryLocked(
 		}
 		return false, err
 	}
+	s.updateSessionIndex(canonicalMeta)
 	return true, nil
 }
 
@@ -605,7 +606,11 @@ func (s *JSONLStore) addMsg(sessionKey string, msg providers.Message) error {
 	meta.Count++
 	meta.UpdatedAt = now
 
-	return s.writeMeta(sessionKey, meta)
+	if err := s.writeMeta(sessionKey, meta); err != nil {
+		return err
+	}
+	s.updateSessionIndex(meta)
+	return nil
 }
 
 func (s *JSONLStore) GetHistory(
@@ -662,7 +667,11 @@ func (s *JSONLStore) SetSummary(
 	meta.Summary = summary
 	meta.UpdatedAt = now
 
-	return s.writeMeta(sessionKey, meta)
+	if err := s.writeMeta(sessionKey, meta); err != nil {
+		return err
+	}
+	s.updateSessionIndex(meta)
+	return nil
 }
 
 func (s *JSONLStore) TruncateHistory(
@@ -700,7 +709,11 @@ func (s *JSONLStore) TruncateHistory(
 	}
 	meta.UpdatedAt = time.Now()
 
-	return s.writeMeta(sessionKey, meta)
+	if err := s.writeMeta(sessionKey, meta); err != nil {
+		return err
+	}
+	s.updateSessionIndex(meta)
+	return nil
 }
 
 func (s *JSONLStore) SetHistory(
@@ -734,6 +747,7 @@ func (s *JSONLStore) SetHistory(
 	if err != nil {
 		return err
 	}
+	s.updateSessionIndex(meta)
 
 	return s.rewriteJSONL(sessionKey, history)
 }
@@ -779,6 +793,7 @@ func (s *JSONLStore) Compact(
 	if err != nil {
 		return err
 	}
+	s.updateSessionIndex(meta)
 
 	return s.rewriteJSONL(sessionKey, active)
 }
@@ -802,31 +817,107 @@ func (s *JSONLStore) rewriteJSONL(
 	return fileutil.WriteFileAtomic(s.jsonlPath(sessionKey), buf.Bytes(), 0o644)
 }
 
-// ListSessions returns all known session keys by reading .meta.json files.
+// ListSessions returns all known session keys from the cached session index,
+// rebuilding that index from .meta.json files when the refresh TTL expires.
 func (s *JSONLStore) ListSessions() []string {
-	entries, err := os.ReadDir(s.dir)
-	if err != nil {
+	if err := s.ensureFreshSessionIndex(); err != nil {
 		return nil
 	}
-	var keys []string
+
+	s.indexMu.RLock()
+	keys := make([]string, 0, len(s.index.keys))
+	for key := range s.index.keys {
+		keys = append(keys, key)
+	}
+	s.indexMu.RUnlock()
+	sort.Strings(keys)
+	return keys
+}
+
+func (s *JSONLStore) ensureFreshSessionIndex() error {
+	s.indexMu.RLock()
+	if s.indexIsFreshLocked() {
+		s.indexMu.RUnlock()
+		return nil
+	}
+	s.indexMu.RUnlock()
+
+	s.indexMu.Lock()
+	defer s.indexMu.Unlock()
+	if s.indexIsFreshLocked() {
+		return nil
+	}
+	idx, err := s.rebuildSessionIndex()
+	if err != nil {
+		return err
+	}
+	s.index = idx
+	return nil
+}
+
+func (s *JSONLStore) indexIsFreshLocked() bool {
+	return !s.index.scannedAt.IsZero() && s.now().Sub(s.index.scannedAt) < sessionIndexRefreshInterval
+}
+
+func (s *JSONLStore) rebuildSessionIndex() (sessionIndex, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return sessionIndex{}, fmt.Errorf("memory: read sessions dir: %w", err)
+	}
+
+	idx := newSessionIndex()
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".meta.json") {
 			continue
 		}
-		// Read the meta file to get the original key
-		data, err := os.ReadFile(filepath.Join(s.dir, entry.Name()))
-		if err != nil {
+
+		data, readErr := os.ReadFile(filepath.Join(s.dir, entry.Name()))
+		if readErr != nil {
+			log.Printf("memory: skipping unreadable meta %s: %v", entry.Name(), readErr)
 			continue
 		}
+
 		var meta SessionMeta
 		if err := json.Unmarshal(data, &meta); err != nil {
+			log.Printf("memory: skipping corrupt meta %s: %v", entry.Name(), err)
 			continue
 		}
-		if meta.Key != "" {
-			keys = append(keys, meta.Key)
+		if strings.TrimSpace(meta.Key) == "" {
+			continue
+		}
+		idx.keys[meta.Key] = struct{}{}
+		idx.canonicalToKey[meta.Key] = meta.Key
+		for _, alias := range meta.Aliases {
+			if alias == "" || alias == meta.Key {
+				continue
+			}
+			idx.aliasToKey[alias] = meta.Key
 		}
 	}
-	return keys
+	idx.scannedAt = s.now()
+	return idx, nil
+}
+
+func (s *JSONLStore) updateSessionIndex(meta SessionMeta) {
+	key := strings.TrimSpace(meta.Key)
+	if key == "" {
+		return
+	}
+	s.indexMu.Lock()
+	defer s.indexMu.Unlock()
+	if s.index.keys == nil {
+		s.index = newSessionIndex()
+	}
+	s.index.keys[key] = struct{}{}
+	s.index.canonicalToKey[key] = key
+	for alias, canonical := range s.index.aliasToKey {
+		if canonical == key {
+			delete(s.index.aliasToKey, alias)
+		}
+	}
+	for _, alias := range normalizeAliases(key, meta.Aliases) {
+		s.index.aliasToKey[alias] = key
+	}
 }
 
 func (s *JSONLStore) Close() error {

--- a/pkg/memory/jsonl_test.go
+++ b/pkg/memory/jsonl_test.go
@@ -468,6 +468,128 @@ func TestResolveSessionKey_SkipsCorruptMetadataDuringAliasScan(t *testing.T) {
 	}
 }
 
+func TestListSessions_ReturnsCachedKeysInSortedOrder(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if err := store.UpsertSessionMeta(ctx, "z-last", nil, nil); err != nil {
+		t.Fatalf("UpsertSessionMeta(z-last) error = %v", err)
+	}
+	if err := store.UpsertSessionMeta(ctx, "a-first", nil, nil); err != nil {
+		t.Fatalf("UpsertSessionMeta(a-first) error = %v", err)
+	}
+
+	got := store.ListSessions()
+	want := []string{"a-first", "z-last"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListSessions() = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveSessionKey_RefreshesIndexAfterTTLForExternalMetaChange(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	baseTime := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	now := baseTime
+	store.now = func() time.Time { return now }
+
+	if err := store.UpsertSessionMeta(ctx, "canonical-one", nil, []string{"legacy:key"}); err != nil {
+		t.Fatalf("UpsertSessionMeta() error = %v", err)
+	}
+
+	resolved, found, err := store.ResolveSessionKey(ctx, "legacy:key")
+	if err != nil {
+		t.Fatalf("ResolveSessionKey() error = %v", err)
+	}
+	if !found || resolved != "canonical-one" {
+		t.Fatalf("initial resolve = (%q, %v), want (%q, true)", resolved, found, "canonical-one")
+	}
+
+	externalMeta := SessionMeta{
+		Key:       "canonical-two",
+		Aliases:   []string{"legacy:key"},
+		CreatedAt: baseTime,
+		UpdatedAt: baseTime,
+	}
+	data, err := json.MarshalIndent(externalMeta, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent(externalMeta) error = %v", err)
+	}
+	if err := os.WriteFile(store.metaPath("canonical-two"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile(canonical-two.meta.json) error = %v", err)
+	}
+
+	resolved, found, err = store.ResolveSessionKey(ctx, "legacy:key")
+	if err != nil {
+		t.Fatalf("ResolveSessionKey() before TTL error = %v", err)
+	}
+	if !found || resolved != "canonical-one" {
+		t.Fatalf("resolve before TTL = (%q, %v), want (%q, true)", resolved, found, "canonical-one")
+	}
+
+	now = now.Add(sessionIndexRefreshInterval + time.Second)
+	resolved, found, err = store.ResolveSessionKey(ctx, "legacy:key")
+	if err != nil {
+		t.Fatalf("ResolveSessionKey() after TTL error = %v", err)
+	}
+	if !found || resolved != "canonical-two" {
+		t.Fatalf("resolve after TTL = (%q, %v), want (%q, true)", resolved, found, "canonical-two")
+	}
+}
+
+func TestResolveSessionKey_RefreshesExternalMetaAfterTTLDespiteLocalWrites(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	baseTime := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	now := baseTime
+	store.now = func() time.Time { return now }
+
+	if err := store.UpsertSessionMeta(ctx, "canonical-one", nil, []string{"legacy:key"}); err != nil {
+		t.Fatalf("UpsertSessionMeta(canonical-one) error = %v", err)
+	}
+	if _, _, err := store.ResolveSessionKey(ctx, "legacy:key"); err != nil {
+		t.Fatalf("ResolveSessionKey() warm index error = %v", err)
+	}
+
+	externalMeta := SessionMeta{
+		Key:       "canonical-two",
+		Aliases:   []string{"legacy:key"},
+		CreatedAt: baseTime,
+		UpdatedAt: baseTime,
+	}
+	data, err := json.MarshalIndent(externalMeta, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent(externalMeta) error = %v", err)
+	}
+	if err := os.WriteFile(store.metaPath("canonical-two"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile(canonical-two.meta.json) error = %v", err)
+	}
+
+	now = now.Add(sessionIndexRefreshInterval - time.Second)
+	if err := store.UpsertSessionMeta(ctx, "local-only", nil, nil); err != nil {
+		t.Fatalf("UpsertSessionMeta(local-only) error = %v", err)
+	}
+
+	resolved, found, err := store.ResolveSessionKey(ctx, "legacy:key")
+	if err != nil {
+		t.Fatalf("ResolveSessionKey() before TTL error = %v", err)
+	}
+	if !found || resolved != "canonical-one" {
+		t.Fatalf("resolve before TTL = (%q, %v), want (%q, true)", resolved, found, "canonical-one")
+	}
+
+	now = baseTime.Add(sessionIndexRefreshInterval + time.Second)
+	resolved, found, err = store.ResolveSessionKey(ctx, "legacy:key")
+	if err != nil {
+		t.Fatalf("ResolveSessionKey() after TTL error = %v", err)
+	}
+	if !found || resolved != "canonical-two" {
+		t.Fatalf("resolve after TTL = (%q, %v), want (%q, true)", resolved, found, "canonical-two")
+	}
+}
+
 func TestTruncateHistory_KeepLast(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/memory/jsonl_test.go
+++ b/pkg/memory/jsonl_test.go
@@ -516,7 +516,8 @@ func TestResolveSessionKey_RefreshesIndexAfterTTLForExternalMetaChange(t *testin
 	if err != nil {
 		t.Fatalf("MarshalIndent(externalMeta) error = %v", err)
 	}
-	if err := os.WriteFile(store.metaPath("canonical-two"), data, 0o644); err != nil {
+	err = os.WriteFile(store.metaPath("canonical-two"), data, 0o644)
+	if err != nil {
 		t.Fatalf("WriteFile(canonical-two.meta.json) error = %v", err)
 	}
 
@@ -563,12 +564,14 @@ func TestResolveSessionKey_RefreshesExternalMetaAfterTTLDespiteLocalWrites(t *te
 	if err != nil {
 		t.Fatalf("MarshalIndent(externalMeta) error = %v", err)
 	}
-	if err := os.WriteFile(store.metaPath("canonical-two"), data, 0o644); err != nil {
+	err = os.WriteFile(store.metaPath("canonical-two"), data, 0o644)
+	if err != nil {
 		t.Fatalf("WriteFile(canonical-two.meta.json) error = %v", err)
 	}
 
 	now = now.Add(sessionIndexRefreshInterval - time.Second)
-	if err := store.UpsertSessionMeta(ctx, "local-only", nil, nil); err != nil {
+	err = store.UpsertSessionMeta(ctx, "local-only", nil, nil)
+	if err != nil {
 		t.Fatalf("UpsertSessionMeta(local-only) error = %v", err)
 	}
 


### PR DESCRIPTION
## 📝 Description

This PR fixes two related issues in the JSONL session metadata index used by `pkg/memory`.

Before this change, `ResolveSessionKey` no longer scanned the filesystem on every lookup, but it still cloned the entire in-memory index on every cache hit. That meant the hot path still performed O(n) allocations and O(n) map copies for `keys`, `aliasToKey`, and `canonicalToKey`, even when the final operation was only a single alias lookup.

The refresh logic also conflated two different concepts into one timestamp:
- when the index was last rebuilt from disk
- when the current process last applied a local incremental metadata update

Because `updateSessionIndex()` refreshed the same timestamp used by TTL validation, a process with steady local write traffic could keep the index permanently "fresh" and prevent the scheduled rescan from ever happening. In practice, external edits to `.meta.json` files could remain invisible indefinitely.

This PR separates those behaviors and makes the fast path actually cheap:
- `ResolveSessionKey` and `ListSessions` now ensure the shared index is fresh, then read it directly under `RLock` instead of cloning the full structure.
- The index now tracks `scannedAt`, which is only updated after a full directory rebuild.
- Local incremental writes still keep the in-memory index up to date, but they no longer extend the TTL for rescanning external changes.
- The helper formerly named `sessionIndexSnapshot()` has been simplified into `ensureFreshSessionIndex()` to match its current responsibility.

As a result, alias resolution remains fast under normal load and external `.meta.json` changes become visible again after the refresh interval, even if the current process continues to write session metadata.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

No linked issue.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
  - Local code review and regression analysis against `pkg/memory/jsonl.go`
- **Reasoning:**
  - `ResolveSessionKey` should not pay O(n) cloning cost on every lookup after moving away from filesystem scans.
  - TTL-based refresh for external metadata changes must be based on the last full scan time, not on local incremental writes.
  - The shared index is already protected by `indexMu`, so direct reads under `RLock` are sufficient and avoid repeated map duplication.
  - Splitting full-scan freshness from local incremental updates preserves both goals: cheap hot-path lookups and eventual visibility of external `.meta.json` edits.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Ubuntu
- **Model/Provider:** N/A
- **Channels:** N/A


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```text
go test ./pkg/memory
ok   	github.com/sipeed/picoclaw/pkg/memory	0.427s
```

Added coverage includes:
- cached `ListSessions()` ordering via the shared session index
- refresh after TTL when an external `.meta.json` changes alias ownership
- refresh after TTL even when local metadata writes continue during the TTL window

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
