### PR TITLE
feat(providers): add CommonModels for MiMo provider

### DIFF
--- a/pkg/providers/provider_metadata.go
+++ b/pkg/providers/provider_metadata.go
@@ -460,6 +460,7 @@ var modelProviderOptionsByName = map[string]ModelProviderOption{
 		DefaultModelAllowed: true,
 		SupportsFetch:       true,
 		Priority:            39,
+		CommonModels:        []string{"mimo-v2.5", "mimo-v2.5-pro"},
 		httpAPI:             true,
 	},
 	"avian": {


### PR DESCRIPTION
## Summary
- Add `CommonModels` for MiMo provider: `mimo-v2.5` (multimodal, supports image understanding) and `mimo-v2.5-pro` (text-only)
- This helps the WebUI recommend vision-capable MiMo models by default, avoiding the issue where users send images to a text-only model and get no visual understanding

## Background
MiMo's API accepts `image_url` content for all models without returning errors, but text-only models like `mimo-v2.5-pro` silently ignore image content. Adding `CommonModels` with the multimodal model listed first guides users toward the correct model for image tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)