### PR TITLE
feat(openai_compat): map DeepSeek thinking fields

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -605,6 +605,43 @@ func TestProcessMessage_PassesExplicitThinkingOffToProviderWithoutThinkingCapabi
 	}
 }
 
+func TestProcessMessage_PassesDeepSeekThinkingLevelToThinkingCapableProvider(t *testing.T) {
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         t.TempDir(),
+				ModelName:         "deepseek-v4-flash",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+			},
+		},
+		ModelList: []*config.ModelConfig{{
+			ModelName:     "deepseek-v4-flash",
+			Provider:      "deepseek",
+			Model:         "deepseek-v4-flash",
+			ThinkingLevel: "xhigh",
+		}},
+	}
+
+	provider := &thinkingRecordingProvider{}
+	al := NewAgentLoop(cfg, bus.NewMessageBus(), provider)
+
+	response, err := al.processMessage(context.Background(), testInboundMessage(bus.InboundMessage{
+		Channel: "pico",
+		ChatID:  "chat-1",
+		Content: "hello",
+	}))
+	if err != nil {
+		t.Fatalf("processMessage() error = %v", err)
+	}
+	if response != "Mock response" {
+		t.Fatalf("processMessage() response = %q, want %q", response, "Mock response")
+	}
+	if got := provider.lastOptions["thinking_level"]; got != "xhigh" {
+		t.Fatalf("thinking_level option = %#v, want %q", got, "xhigh")
+	}
+}
+
 func TestProcessMessage_SuppressesReasoningWhenThinkingOff(t *testing.T) {
 	cfg := &config.Config{
 		Agents: config.AgentsConfig{

--- a/pkg/providers/factory_provider_test.go
+++ b/pkg/providers/factory_provider_test.go
@@ -171,6 +171,30 @@ func TestCreateProviderFromConfig_UsesExplicitProvider(t *testing.T) {
 	}
 }
 
+func TestCreateProviderFromConfig_DeepSeekSupportsThinking(t *testing.T) {
+	cfg := &config.ModelConfig{
+		ModelName: "deepseek-v4-flash",
+		Provider:  "deepseek",
+		Model:     "deepseek-v4-flash",
+	}
+	cfg.SetAPIKey("test-key")
+
+	provider, modelID, err := CreateProviderFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("CreateProviderFromConfig() error = %v", err)
+	}
+	if modelID != "deepseek-v4-flash" {
+		t.Fatalf("modelID = %q, want %q", modelID, "deepseek-v4-flash")
+	}
+	tc, ok := provider.(ThinkingCapable)
+	if !ok {
+		t.Fatalf("provider %T should implement ThinkingCapable for DeepSeek", provider)
+	}
+	if !tc.SupportsThinking() {
+		t.Fatalf("DeepSeek provider SupportsThinking() = false, want true")
+	}
+}
+
 func TestCreateProviderFromConfig_PreservesExplicitProviderPrefixedModel(t *testing.T) {
 	cfg := &config.ModelConfig{
 		ModelName: "test-openai",

--- a/pkg/providers/httpapi/http_provider.go
+++ b/pkg/providers/httpapi/http_provider.go
@@ -89,6 +89,13 @@ func (p *HTTPProvider) SupportsNativeSearch() bool {
 	return p.delegate.SupportsNativeSearch()
 }
 
+func (p *HTTPProvider) SupportsThinking() bool {
+	if p == nil || p.delegate == nil {
+		return false
+	}
+	return p.delegate.SupportsThinking()
+}
+
 func (p *HTTPProvider) SetProviderName(providerName string) {
 	if p == nil || p.delegate == nil {
 		return

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sipeed/picoclaw/pkg/logger"
 	"github.com/sipeed/picoclaw/pkg/providers/common"
 	"github.com/sipeed/picoclaw/pkg/providers/messageutil"
 	"github.com/sipeed/picoclaw/pkg/providers/protocoltypes"
@@ -204,7 +205,16 @@ func (p *Provider) buildRequestBody(
 
 func (p *Provider) applyThinkingControl(requestBody map[string]any, model string, options map[string]any) {
 	level, ok := normalizedThinkingLevel(options)
-	if !ok || level != "off" {
+	if !ok {
+		return
+	}
+
+	if p.SupportsThinking() {
+		p.applyDeepSeekThinkingControl(requestBody, level)
+		return
+	}
+
+	if level != "off" {
 		return
 	}
 
@@ -213,6 +223,28 @@ func (p *Provider) applyThinkingControl(requestBody map[string]any, model string
 		requestBody["thinking"] = map[string]any{"type": "disabled"}
 	case "enable_thinking":
 		requestBody["enable_thinking"] = false
+	}
+}
+
+func (p *Provider) applyDeepSeekThinkingControl(requestBody map[string]any, level string) {
+	switch level {
+	case "off":
+		requestBody["thinking"] = map[string]any{"type": "disabled"}
+	case "low", "medium", "high":
+		requestBody["thinking"] = map[string]any{"type": "enabled"}
+		requestBody["reasoning_effort"] = "high"
+	case "xhigh":
+		requestBody["thinking"] = map[string]any{"type": "enabled"}
+		requestBody["reasoning_effort"] = "max"
+	case "adaptive":
+		logger.WarnCF("provider.openai_compat",
+			`DeepSeek does not support thinking_level="adaptive"; using provider default thinking behavior`,
+			map[string]any{
+				"provider":       p.providerName,
+				"api_base":       p.apiBase,
+				"thinking_level": level,
+			},
+		)
 	}
 }
 
@@ -288,6 +320,10 @@ func (p *Provider) applyCustomHeaders(req *http.Request) {
 
 func (p *Provider) SetProviderName(providerName string) {
 	p.providerName = strings.ToLower(strings.TrimSpace(providerName))
+}
+
+func (p *Provider) SupportsThinking() bool {
+	return strings.EqualFold(strings.TrimSpace(p.providerName), "deepseek") || isDeepSeekHost(p.apiBase)
 }
 
 func (p *Provider) prepareMessagesForRequest(messages []Message) []Message {

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -8,11 +8,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/sipeed/picoclaw/pkg/logger"
 	"github.com/sipeed/picoclaw/pkg/providers/common"
 	"github.com/sipeed/picoclaw/pkg/providers/protocoltypes"
 )
@@ -122,6 +124,146 @@ func TestBuildRequestBody_PreservesDoubaoRequestWhenThinkingLevelIsNotOff(t *tes
 				t.Fatalf("enable_thinking should be omitted for %q, got %#v", level, body["enable_thinking"])
 			}
 		})
+	}
+}
+
+func TestBuildRequestBody_MapsDeepSeekThinkingLevels(t *testing.T) {
+	p := NewProvider("key", "https://api.deepseek.com/v1", "")
+	p.SetProviderName("deepseek")
+
+	tests := []struct {
+		name             string
+		level            string
+		wantThinkingType string
+		wantEffort       any
+	}{
+		{name: "off", level: "off", wantThinkingType: "disabled"},
+		{name: "low", level: "low", wantThinkingType: "enabled", wantEffort: "high"},
+		{name: "medium", level: "medium", wantThinkingType: "enabled", wantEffort: "high"},
+		{name: "high", level: "high", wantThinkingType: "enabled", wantEffort: "high"},
+		{name: "xhigh", level: "xhigh", wantThinkingType: "enabled", wantEffort: "max"},
+		{name: "adaptive", level: "adaptive"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := p.buildRequestBody(
+				[]Message{{Role: "user", Content: "hi"}},
+				nil,
+				"deepseek-v4-pro",
+				map[string]any{"thinking_level": tt.level},
+			)
+
+			if tt.wantThinkingType == "" {
+				if _, ok := body["thinking"]; ok {
+					t.Fatalf("thinking should be omitted for %q, got %#v", tt.level, body["thinking"])
+				}
+			} else {
+				thinking, ok := body["thinking"].(map[string]any)
+				if !ok {
+					t.Fatalf("thinking = %#v, want map", body["thinking"])
+				}
+				if got := thinking["type"]; got != tt.wantThinkingType {
+					t.Fatalf("thinking.type = %#v, want %q", got, tt.wantThinkingType)
+				}
+			}
+
+			if tt.wantEffort == nil {
+				if _, ok := body["reasoning_effort"]; ok {
+					t.Fatalf("reasoning_effort should be omitted for %q, got %#v", tt.level, body["reasoning_effort"])
+				}
+			} else if got := body["reasoning_effort"]; got != tt.wantEffort {
+				t.Fatalf("reasoning_effort = %#v, want %#v", got, tt.wantEffort)
+			}
+		})
+	}
+}
+
+func TestBuildRequestBody_MapsDeepSeekThinkingLevelsByHost(t *testing.T) {
+	p := NewProvider("key", "https://api.deepseek.com/v1", "")
+
+	body := p.buildRequestBody(
+		[]Message{{Role: "user", Content: "hi"}},
+		nil,
+		"deepseek-v4-flash",
+		map[string]any{"thinking_level": "xhigh"},
+	)
+
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("thinking = %#v, want map", body["thinking"])
+	}
+	if got := thinking["type"]; got != "enabled" {
+		t.Fatalf("thinking.type = %#v, want enabled", got)
+	}
+	if got := body["reasoning_effort"]; got != "max" {
+		t.Fatalf("reasoning_effort = %#v, want max", got)
+	}
+}
+
+func TestBuildRequestBody_DeepSeekExtraBodyStillOverridesThinkingFields(t *testing.T) {
+	extraBody := map[string]any{
+		"thinking":         map[string]any{"type": "disabled"},
+		"reasoning_effort": "max",
+	}
+	p := NewProvider("key", "https://api.deepseek.com/v1", "", WithExtraBody(extraBody))
+	p.SetProviderName("deepseek")
+
+	body := p.buildRequestBody(
+		[]Message{{Role: "user", Content: "hi"}},
+		nil,
+		"deepseek-v4-pro",
+		map[string]any{"thinking_level": "high"},
+	)
+
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("thinking = %#v, want map", body["thinking"])
+	}
+	if got := thinking["type"]; got != "disabled" {
+		t.Fatalf("thinking.type = %#v, want disabled from extra_body override", got)
+	}
+	if got := body["reasoning_effort"]; got != "max" {
+		t.Fatalf("reasoning_effort = %#v, want max from extra_body override", got)
+	}
+}
+
+func TestBuildRequestBody_WarnsForUnsupportedDeepSeekAdaptiveThinkingLevel(t *testing.T) {
+	logFile := t.TempDir() + "/deepseek-adaptive-warning.log"
+	prevLevel := logger.GetLevel()
+	logger.SetLevel(logger.WARN)
+	if err := logger.EnableFileLogging(logFile); err != nil {
+		t.Fatalf("EnableFileLogging() error = %v", err)
+	}
+	defer func() {
+		logger.DisableFileLogging()
+		logger.SetLevel(prevLevel)
+	}()
+
+	p := NewProvider("key", "https://api.deepseek.com/v1", "")
+	p.SetProviderName("deepseek")
+
+	body := p.buildRequestBody(
+		[]Message{{Role: "user", Content: "hi"}},
+		nil,
+		"deepseek-v4-pro",
+		map[string]any{"thinking_level": "adaptive"},
+	)
+
+	if _, ok := body["thinking"]; ok {
+		t.Fatalf("thinking should be omitted for adaptive, got %#v", body["thinking"])
+	}
+	if _, ok := body["reasoning_effort"]; ok {
+		t.Fatalf("reasoning_effort should be omitted for adaptive, got %#v", body["reasoning_effort"])
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", logFile, err)
+	}
+	logs := string(data)
+	if !strings.Contains(logs, `thinking_level=\"adaptive\"`) {
+		t.Fatalf("warning log = %q, want adaptive warning message", logs)
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

Map DeepSeek-specific thinking controls on the OpenAI-compatible provider path so `thinking_level` works without manual `extra_body` overrides. This wires DeepSeek through `ThinkingCapable`, maps `off/low/medium/high/xhigh` to DeepSeek's documented `thinking` and `reasoning_effort` fields, and warns when `thinking_level=adaptive` is configured because DeepSeek does not document an adaptive mode.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue
Resolves #2903

## 📚 Technical Context
- **Reference URL:** https://api-docs.deepseek.com/zh-cn/guides/thinking_mode
- **Reasoning:** Align PicoClaw's internal `thinking_level` abstraction with DeepSeek's OpenAI-compatible request fields, preserve explicit `off`, keep `extra_body` override precedence, and avoid silently ignoring unsupported `adaptive` by emitting a warning. Verified with `go test ./pkg/providers/openai_compat ./pkg/providers/httpapi ./pkg/providers -run 'DeepSeek|Thinking|Doubao|Qwen'` and `go test ./pkg/agent -run 'Thinking|DeepSeek'`.

## 🧪 Test Environment
- **Hardware:** Local x64 Server
- **OS:** Ubuntu Server 24
- **Model/Provider:** DeepSeek V4 Flash
- **Channels:** Web

## 📸 Evidence
<details>
<summary>Click to view Logs/Screenshots</summary>

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.