### PR TITLE
fix(discord): download attachments for vision pipeline

### DIFF
--- a/pkg/channels/discord/discord.go
+++ b/pkg/channels/discord/discord.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -605,10 +606,11 @@ func (c *DiscordChannel) handleMessage(s *discordgo.Session, m *discordgo.Messag
 	scope := channels.BuildMediaScope("discord", m.ChannelID, m.ID)
 
 	// Helper to register a local file with the media store
-	storeMedia := func(localPath, filename string) string {
+	storeMedia := func(localPath string, attachment *discordgo.MessageAttachment) string {
 		if store := c.GetMediaStore(); store != nil {
 			ref, err := store.Store(localPath, media.MediaMeta{
-				Filename:      filename,
+				Filename:      attachment.Filename,
+				ContentType:   attachment.ContentType,
 				Source:        "discord",
 				CleanupPolicy: media.CleanupPolicyDeleteOnCleanup,
 			}, scope)
@@ -620,22 +622,16 @@ func (c *DiscordChannel) handleMessage(s *discordgo.Session, m *discordgo.Messag
 	}
 
 	for _, attachment := range m.Attachments {
-		isAudio := utils.IsAudioFile(attachment.Filename, attachment.ContentType)
-
-		if isAudio {
-			localPath := c.downloadAttachment(attachment.URL, attachment.Filename)
-			if localPath != "" {
-				mediaPaths = append(mediaPaths, storeMedia(localPath, attachment.Filename))
-				content = appendContent(content, fmt.Sprintf("[audio: %s]", attachment.Filename))
-			} else {
-				logger.WarnCF("discord", "Failed to download audio attachment", map[string]any{
-					"url":      attachment.URL,
-					"filename": attachment.Filename,
-				})
-				mediaPaths = append(mediaPaths, attachment.URL)
-				content = appendContent(content, fmt.Sprintf("[attachment: %s]", attachment.URL))
-			}
+		localPath := c.downloadAttachment(attachment.URL, attachment.Filename)
+		if localPath != "" {
+			mediaPaths = append(mediaPaths, storeMedia(localPath, attachment))
+			tag := attachmentMediaTag(attachment.Filename, attachment.ContentType)
+			content = appendContent(content, fmt.Sprintf("[%s: %s]", tag, attachment.Filename))
 		} else {
+			logger.WarnCF("discord", "Failed to download attachment", map[string]any{
+				"url":      attachment.URL,
+				"filename": attachment.Filename,
+			})
 			mediaPaths = append(mediaPaths, attachment.URL)
 			content = appendContent(content, fmt.Sprintf("[attachment: %s]", attachment.URL))
 		}
@@ -746,6 +742,30 @@ func (c *DiscordChannel) downloadAttachment(url, filename string) string {
 		LoggerPrefix: "discord",
 		ProxyURL:     c.config.Proxy,
 	})
+}
+
+func attachmentMediaTag(filename, contentType string) string {
+	ct := strings.ToLower(contentType)
+	switch {
+	case strings.HasPrefix(ct, "image/"):
+		return "image"
+	case strings.HasPrefix(ct, "audio/"), ct == "application/ogg", ct == "application/x-ogg":
+		return "audio"
+	case strings.HasPrefix(ct, "video/"):
+		return "video"
+	}
+
+	ext := strings.ToLower(filepath.Ext(filename))
+	switch ext {
+	case ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp":
+		return "image"
+	case ".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac", ".wma":
+		return "audio"
+	case ".mp4", ".avi", ".mov", ".webm", ".mkv":
+		return "video"
+	}
+
+	return "file"
 }
 
 func applyDiscordProxy(session *discordgo.Session, proxyAddr string) error {


### PR DESCRIPTION
## 📝 Description

Discord's handleMessage only downloaded audio attachments, passing all other attachments (images, files) as raw CDN URLs. These URLs were silently dropped by the provider serializer, which only accepts data:image/ base64 URLs.

The fix is to have  non-audio attachments downloaded and stored like audio already was. This implementation mirrors the pattern used by Slack and others. 

[Documentation](https://docs.picoclaw.io/docs/channels/discord/) says this should work but it clearly doesn't. Either a regression or an issue in the docs I think. No doc updates needed IMO. 

## 🗣️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 📸 Evidence
<details>
<summary>Click to view Logs/Screenshots</summary>
**Before**
<img width="1534" height="787" alt="image" src="https://github.com/user-attachments/assets/741f47bf-aa28-4a6e-9535-1dbe2dfdc458" />

**After**
<img width="1297" height="831" alt="image" src="https://github.com/user-attachments/assets/290d506b-0cca-4ac6-8053-15f5e3fa6edf" />

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
