### PR TITLE
fix(channels): allow whatsapp native mode with use_native flag

### DIFF
--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -1008,7 +1008,8 @@ func (m *Manager) getChannelConfigAndEnabled(channelName string) (*config.Channe
 	switch settings := decoded.(type) {
 	case *config.WhatsAppSettings:
 		if channelType == config.ChannelWhatsApp {
-			return bc, settings.BridgeURL != ""
+			// Bridge mode requires bridge_url, native mode requires use_native
+			return bc, settings.BridgeURL != "" || settings.UseNative
 		}
 		return bc, channelType == config.ChannelWhatsAppNative && settings.UseNative
 	case *config.MatrixSettings:

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -933,6 +933,18 @@ func (s *finalizeHookStreamer) ClearFinalizedStreamMarker() {
 // typeName is the channel type used for factory lookup (e.g., "telegram").
 // channelName is the config map key used as the channel's runtime name (e.g., "my_telegram").
 func (m *Manager) initChannel(typeName, channelName string) {
+	// Handle WhatsApp native mode: if type is "whatsapp" and use_native is true,
+	// use the "whatsapp_native" factory instead
+	if typeName == config.ChannelWhatsApp {
+		if bc := m.config.Channels[channelName]; bc != nil {
+			if decoded, err := bc.GetDecoded(); err == nil {
+				if settings, ok := decoded.(*config.WhatsAppSettings); ok && settings.UseNative {
+					typeName = config.ChannelWhatsAppNative
+				}
+			}
+		}
+	}
+
 	f, ok := getFactory(typeName)
 	if !ok {
 		logger.WarnCF("channels", "Factory not registered", map[string]any{


### PR DESCRIPTION
## 📝 Description

Fix WhatsApp channel configuration detection to support native mode with `use_native: true`.

Currently, when `type: "whatsapp"` is set, the channel is only considered configured if `bridge_url` is not empty. This prevents the native mode (whatsmeow) from working when users set `use_native: true` and leave `bridge_url` blank, as documented.

The fix changes the validation logic to accept either:
- `bridge_url != ""` (Bridge mode)
- `use_native == true` (Native mode)

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

<!-- No related issue number -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/blob/main/docs/guides/chat-apps.zh.md#L184
- **Reasoning:** The documentation states users can set `"use_native": true` and leave `bridge_url` blank for native mode, but the code only checked for `bridge_url`. This caused the WhatsApp channel to not start when configured for native mode.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Linux
- **Model/Provider:** N/A
- **Channels:** WhatsApp

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Before fix:
```

```
(WhatsApp channel not started despite being enabled with `use_native: true`)

After fix:
WhatsApp channel starts correctly when `use_native: true` is set without `bridge_url`.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly. (No doc update needed - aligns code with existing docs)
