### PR TITLE
feat(skills): skip skills whose required binaries are missing on PATH

### DIFF
--- a/pkg/skills/loader.go
+++ b/pkg/skills/loader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -28,6 +29,11 @@ const (
 type SkillMetadata struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	// RequiresBins are the executables a skill declares it needs at runtime,
+	// parsed from `metadata.nanobot.requires.bins` in the SKILL.md frontmatter.
+	// ListSkills uses this to filter out skills whose required binaries are
+	// not on PATH (so the LLM doesn't get told it can use tools it can't run).
+	RequiresBins []string `json:"-"`
 }
 
 type SkillInfo struct {
@@ -127,6 +133,16 @@ func (sl *SkillsLoader) ListSkills() []SkillInfo {
 			if err := info.validate(); err != nil {
 				slog.Warn("invalid skill from "+source, "name", info.Name, "error", err)
 				continue
+			}
+			if metadata != nil {
+				if missing := missingBinaries(metadata.RequiresBins); len(missing) > 0 {
+					slog.Info("skipping skill: required binary not found on PATH",
+						"name", info.Name,
+						"source", source,
+						"missing", missing,
+					)
+					continue
+				}
 			}
 			if seen[info.Name] {
 				continue
@@ -246,8 +262,9 @@ func (sl *SkillsLoader) getSkillMetadata(skillPath string) *SkillMetadata {
 
 	// Try JSON first (for backward compatibility)
 	var jsonMeta struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
+		Name        string                 `json:"name"`
+		Description string                 `json:"description"`
+		Metadata    *skillExtendedMetadata `json:"metadata"`
 	}
 	if err := json.Unmarshal([]byte(frontmatter), &jsonMeta); err == nil {
 		if jsonMeta.Name != "" {
@@ -256,6 +273,7 @@ func (sl *SkillsLoader) getSkillMetadata(skillPath string) *SkillMetadata {
 		if jsonMeta.Description != "" {
 			metadata.Description = jsonMeta.Description
 		}
+		metadata.RequiresBins = jsonMeta.Metadata.requiresBins()
 		return metadata
 	}
 
@@ -267,7 +285,49 @@ func (sl *SkillsLoader) getSkillMetadata(skillPath string) *SkillMetadata {
 	if description := yamlMeta["description"]; description != "" {
 		metadata.Description = description
 	}
+	metadata.RequiresBins = sl.parseRequiresBins(frontmatter)
 	return metadata
+}
+
+// skillExtendedMetadata models the optional `metadata.nanobot.*` block in
+// SKILL.md frontmatter. Today we only consume `requires.bins`; other nanobot
+// fields (emoji, os, install) are intentionally ignored.
+type skillExtendedMetadata struct {
+	Nanobot *struct {
+		Requires *struct {
+			Bins []string `json:"bins" yaml:"bins"`
+		} `json:"requires" yaml:"requires"`
+	} `json:"nanobot" yaml:"nanobot"`
+}
+
+func (m *skillExtendedMetadata) requiresBins() []string {
+	if m == nil || m.Nanobot == nil || m.Nanobot.Requires == nil {
+		return nil
+	}
+	return m.Nanobot.Requires.Bins
+}
+
+// parseRequiresBins extracts metadata.nanobot.requires.bins from YAML
+// frontmatter. The metadata value itself is typically written as inline
+// (flow-style) JSON in real skills, e.g.:
+//
+//	metadata: {"nanobot":{"requires":{"bins":["agent-browser"]}}}
+//
+// yaml.v3 parses both block-style and flow-style, so a single Unmarshal
+// covers both forms.
+func (sl *SkillsLoader) parseRequiresBins(frontmatter string) []string {
+	var meta struct {
+		Metadata *skillExtendedMetadata `yaml:"metadata"`
+	}
+	if err := yaml.Unmarshal([]byte(frontmatter), &meta); err != nil {
+		// Malformed frontmatter would otherwise silently disable the
+		// requires.bins guard for this skill. Surface it at debug level
+		// so operators investigating "why is this skill loading despite
+		// missing $TOOL?" have a breadcrumb.
+		slog.Debug("skills: failed to parse frontmatter for requires.bins", "error", err)
+		return nil
+	}
+	return meta.Metadata.requiresBins()
 }
 
 func extractMarkdownMetadata(content string) (title, description string) {
@@ -377,6 +437,29 @@ func splitFrontmatter(content string) (frontmatter, body string) {
 	body = strings.Join(lines[end+1:], "\n")
 	body = strings.TrimLeft(body, "\n")
 	return frontmatter, body
+}
+
+// missingBinaries returns the subset of bins that cannot be resolved via
+// exec.LookPath. Empty/whitespace-only entries are ignored. Entries that
+// contain a path separator are treated as missing: exec.LookPath would
+// otherwise resolve them relative to cwd, letting a SKILL.md "validate"
+// itself against an unrelated file the operator never installed.
+func missingBinaries(bins []string) []string {
+	var missing []string
+	for _, bin := range bins {
+		bin = strings.TrimSpace(bin)
+		if bin == "" {
+			continue
+		}
+		if strings.ContainsAny(bin, `/\`) {
+			missing = append(missing, bin)
+			continue
+		}
+		if _, err := exec.LookPath(bin); err != nil {
+			missing = append(missing, bin)
+		}
+	}
+	return missing
 }
 
 func escapeXML(s string) string {

--- a/pkg/skills/loader_test.go
+++ b/pkg/skills/loader_test.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -145,6 +146,32 @@ func createSkillDir(t *testing.T, base, dirName, name, description string) {
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	content := "---\nname: " + name + "\ndescription: " + description + "\n---\n\n# " + name
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644))
+}
+
+// createSkillWithFrontmatter creates a SKILL.md whose frontmatter is provided verbatim.
+// Use this when the test needs to exercise extended metadata (e.g. nanobot.requires.bins)
+// that the plain createSkillDir helper does not write.
+func createSkillWithFrontmatter(t *testing.T, base, dirName, frontmatter, body string) {
+	t.Helper()
+	dir := filepath.Join(base, dirName)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	content := "---\n" + frontmatter + "\n---\n\n" + body
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644))
+}
+
+// makeFakeBin writes a stub executable named `name` into a fresh tempdir and
+// returns the dir. Tests use it together with t.Setenv("PATH", dir) to control
+// what exec.LookPath resolves. On Windows the file gets a .exe extension so
+// LookPath honors it.
+func makeFakeBin(t *testing.T, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	binName := name
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, binName), []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	return dir
 }
 
 func TestListSkillsWorkspaceOverridesGlobal(t *testing.T) {
@@ -401,6 +428,202 @@ func TestGetSkillMetadata_InvalidHeadingNameFallsBackToDirName(t *testing.T) {
 	require.NotNil(t, meta)
 	assert.Equal(t, "valid-name", meta.Name)
 	assert.Equal(t, "Body description.", meta.Description)
+}
+
+func TestListSkillsSkipsWhenRequiredBinaryMissing(t *testing.T) {
+	// Empty PATH guarantees the named bin cannot be resolved no matter
+	// what's installed on the test host.
+	t.Setenv("PATH", t.TempDir())
+
+	tmp := t.TempDir()
+	ws := filepath.Join(tmp, "workspace")
+	frontmatter := `name: needs-tool
+description: requires a missing binary
+metadata: {"nanobot":{"requires":{"bins":["picoclaw-test-missing-xyz123"]}}}`
+	createSkillWithFrontmatter(t, filepath.Join(ws, "skills"), "needs-tool", frontmatter, "# needs-tool")
+
+	sl := NewSkillsLoader(ws, "", "")
+	skills := sl.ListSkills()
+
+	assert.Empty(t, skills, "skill with missing required binary should be skipped")
+}
+
+func TestListSkillsIncludesWhenRequiredBinaryPresent(t *testing.T) {
+	binDir := makeFakeBin(t, "picoclaw-test-present")
+	t.Setenv("PATH", binDir)
+
+	tmp := t.TempDir()
+	ws := filepath.Join(tmp, "workspace")
+	frontmatter := `name: needs-tool
+description: requires a present binary
+metadata: {"nanobot":{"requires":{"bins":["picoclaw-test-present"]}}}`
+	createSkillWithFrontmatter(t, filepath.Join(ws, "skills"), "needs-tool", frontmatter, "# needs-tool")
+
+	sl := NewSkillsLoader(ws, "", "")
+	skills := sl.ListSkills()
+
+	require.Len(t, skills, 1)
+	assert.Equal(t, "needs-tool", skills[0].Name)
+}
+
+func TestListSkillsSkipsWhenAnyRequiredBinaryMissing(t *testing.T) {
+	binDir := makeFakeBin(t, "picoclaw-test-present")
+	t.Setenv("PATH", binDir)
+
+	tmp := t.TempDir()
+	ws := filepath.Join(tmp, "workspace")
+	frontmatter := `name: multi-bin
+description: requires multiple binaries
+metadata: {"nanobot":{"requires":{"bins":["picoclaw-test-present","picoclaw-test-missing-xyz123"]}}}`
+	createSkillWithFrontmatter(t, filepath.Join(ws, "skills"), "multi-bin", frontmatter, "# multi-bin")
+
+	sl := NewSkillsLoader(ws, "", "")
+	skills := sl.ListSkills()
+
+	assert.Empty(t, skills, "skill should be skipped if any required binary is missing")
+}
+
+func TestListSkillsAllowsEmptyRequiresBins(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	tmp := t.TempDir()
+	ws := filepath.Join(tmp, "workspace")
+	frontmatter := `name: empty-bins
+description: declares an empty bins list
+metadata: {"nanobot":{"requires":{"bins":[]}}}`
+	createSkillWithFrontmatter(t, filepath.Join(ws, "skills"), "empty-bins", frontmatter, "# empty-bins")
+
+	sl := NewSkillsLoader(ws, "", "")
+	skills := sl.ListSkills()
+
+	require.Len(t, skills, 1)
+	assert.Equal(t, "empty-bins", skills[0].Name)
+}
+
+func TestListSkillsAllowsSkillsWithoutRequiresBins(t *testing.T) {
+	// A skill that doesn't declare metadata.nanobot.requires.bins at all
+	// must continue to load — this is the pre-validation behaviour and the
+	// shape of the vast majority of skills.
+	t.Setenv("PATH", t.TempDir())
+
+	tmp := t.TempDir()
+	ws := filepath.Join(tmp, "workspace")
+	createSkillDir(t, filepath.Join(ws, "skills"), "no-meta", "no-meta", "no extended metadata")
+
+	sl := NewSkillsLoader(ws, "", "")
+	skills := sl.ListSkills()
+
+	require.Len(t, skills, 1)
+	assert.Equal(t, "no-meta", skills[0].Name)
+}
+
+func TestListSkillsMissingBinaryFallsThroughSourcePriority(t *testing.T) {
+	// Workspace copy declares an unavailable bin → should be skipped.
+	// Global copy of the same skill name has no bin requirement → should win.
+	binDir := makeFakeBin(t, "picoclaw-test-fallthrough")
+	t.Setenv("PATH", binDir)
+
+	tmp := t.TempDir()
+	ws := filepath.Join(tmp, "workspace")
+	global := filepath.Join(tmp, "global")
+
+	wsFrontmatter := `name: shared
+description: workspace copy needs a missing bin
+metadata: {"nanobot":{"requires":{"bins":["picoclaw-test-missing-xyz123"]}}}`
+	createSkillWithFrontmatter(t, filepath.Join(ws, "skills"), "shared", wsFrontmatter, "# shared")
+	createSkillDir(t, global, "shared", "shared", "global copy without bin requirement")
+
+	sl := NewSkillsLoader(ws, global, "")
+	skills := sl.ListSkills()
+
+	require.Len(t, skills, 1)
+	assert.Equal(t, "global", skills[0].Source, "global copy must replace the skipped workspace copy")
+	assert.Equal(t, "global copy without bin requirement", skills[0].Description)
+}
+
+func TestGetSkillMetadata_ParsesRequiresBinsFromInlineJSON(t *testing.T) {
+	tmp := t.TempDir()
+	skillDir := filepath.Join(tmp, "browser-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+
+	// Real-world frontmatter shape: YAML keys with a flow-style (JSON) metadata value.
+	content := `---
+name: agent-browser
+description: Browser automation
+metadata: {"nanobot":{"emoji":"🌐","requires":{"bins":["agent-browser"]}}}
+---
+
+# Agent Browser`
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644))
+
+	sl := &SkillsLoader{}
+	meta := sl.getSkillMetadata(filepath.Join(skillDir, "SKILL.md"))
+	require.NotNil(t, meta)
+	assert.Equal(t, []string{"agent-browser"}, meta.RequiresBins)
+}
+
+func TestGetSkillMetadata_ParsesRequiresBinsFromPureJSON(t *testing.T) {
+	tmp := t.TempDir()
+	skillDir := filepath.Join(tmp, "pure-json")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+
+	content := `---
+{"name":"json-skill","description":"all JSON frontmatter","metadata":{"nanobot":{"requires":{"bins":["foo","bar"]}}}}
+---
+
+# JSON Skill`
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644))
+
+	sl := &SkillsLoader{}
+	meta := sl.getSkillMetadata(filepath.Join(skillDir, "SKILL.md"))
+	require.NotNil(t, meta)
+	assert.Equal(t, []string{"foo", "bar"}, meta.RequiresBins)
+}
+
+func TestMissingBinaries(t *testing.T) {
+	binDir := makeFakeBin(t, "picoclaw-test-real")
+	t.Setenv("PATH", binDir)
+
+	testcases := []struct {
+		name string
+		bins []string
+		want []string
+	}{
+		{name: "nil input", bins: nil, want: nil},
+		{name: "empty input", bins: []string{}, want: nil},
+		{name: "all present", bins: []string{"picoclaw-test-real"}, want: nil},
+		{
+			name: "all missing",
+			bins: []string{"picoclaw-missing-a", "picoclaw-missing-b"},
+			want: []string{"picoclaw-missing-a", "picoclaw-missing-b"},
+		},
+		{
+			name: "mixed",
+			bins: []string{"picoclaw-test-real", "picoclaw-missing-a"},
+			want: []string{"picoclaw-missing-a"},
+		},
+		{name: "whitespace-only entries are ignored", bins: []string{"  ", "\t", "picoclaw-test-real"}, want: nil},
+		{
+			name: "path-separator entry rejected (unix)",
+			bins: []string{"./picoclaw-test-real"},
+			want: []string{"./picoclaw-test-real"},
+		},
+		{
+			name: "path-separator entry rejected (windows-style)",
+			bins: []string{`subdir\picoclaw-test-real`},
+			want: []string{`subdir\picoclaw-test-real`},
+		},
+		{
+			name: "absolute path rejected even if file exists",
+			bins: []string{"/usr/bin/sh"},
+			want: []string{"/usr/bin/sh"},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, missingBinaries(tc.bins))
+		})
+	}
 }
 
 func TestGetSkillMetadata_IgnoresHTMLCommentBlocks(t *testing.T) {


### PR DESCRIPTION
## 📝 Description

Fixes #2351.

Parse `metadata.nanobot.requires.bins` from `SKILL.md` frontmatter and filter out skills whose declared binaries cannot be resolved via `exec.LookPath()`. The agent system prompt no longer advertises skills the LLM cannot actually run (e.g. `agent-browser` on a $10 RISC-V board without Chromium installed) — so the LLM stops confidently claiming capabilities that always fail at runtime.

Implements exactly the proposed solution from the issue:

> In `SkillsLoader.ListSkills()` (or a new validation step), check `metadata.nanobot.requires.bins` entries against `exec.LookPath()` before including the skill.

### What changed

- `pkg/skills/loader.go`
  - `SkillMetadata` gains a `RequiresBins []string` field (parsed, not serialized).
  - `getSkillMetadata` now extracts `metadata.nanobot.requires.bins` from:
    - **YAML frontmatter with inline-JSON metadata** — the real-world shape used by `agent-browser`, `tmux`, `weather` etc.: `metadata: {"nanobot":{"requires":{"bins":["agent-browser"]}}}`. yaml.v3 parses flow-style natively, so one `Unmarshal` covers both block and flow style.
    - **Pure-JSON frontmatter** — kept for the existing JSON-first parsing path.
  - `ListSkills` calls a new `missingBinaries()` helper after `info.validate()`. If any required bin is missing on `PATH`, the skill is logged at info level (`skipping skill: required binary not found on PATH`) and skipped. The same skill name at a lower-priority source (workspace → global → builtin) can still take over, mirroring the existing fall-through used for invalid skills.
- `pkg/skills/loader_test.go`
  - Two new helpers: `createSkillWithFrontmatter` (arbitrary frontmatter) and `makeFakeBin` (cross-platform fake-bin in tempdir for deterministic `PATH` control).
  - New tests: missing bin skipped, present bin included, mixed missing/present skipped, empty `bins: []` included, no metadata block at all stays loaded (backward-compat), missing-bin workspace skill falls through to global, parser handles inline-JSON and pure-JSON shapes, and a table-driven `missingBinaries` test (nil / empty / present / missing / mixed / whitespace-only).

### Why filter at `ListSkills`

Every consumer that puts skills in front of the LLM (`pkg/agent/context.go` → `BuildSkillsSummary`), the Web UI (`web/backend/api/skills.go`), and the CLI (`cmd/picoclaw/internal/skills/helpers.go`) all funnel through `ListSkills`. Filtering once here keeps the surface small and means the LLM never sees a skill it cannot execute.

Direct `LoadSkill(name)` callers (`pkg/evolution/skills_recall.go`, `drafts.go`) are post-selection lookups; their inputs already came from a filtered listing.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

AI drafted the parser extension, the `missingBinaries` helper, the filter in `ListSkills`, and the test cases. I curated the approach (filter at `ListSkills` surface), chose `slog.Info` rather than `slog.Warn` so a board without an optional tool is not noisy, made the JSON-encoded `metadata` value reach both parsing paths, designed the cross-platform `makeFakeBin` test helper, and ran an independent fresh-context code review (Opus) before opening this PR.

## 🔗 Related Issue

Fixes #2351 — `[Feature] Validate skill binary requirements before injecting into system prompt`.

## 📚 Technical Context

- **Reference URL:** https://github.com/sipeed/picoclaw/issues/2351
- **Reasoning:** The reporter identified that `pkg/skills/loader.go` parses frontmatter but never checks `metadata.nanobot.requires.bins`, so skills like `agent-browser` get injected into the system prompt even when the required CLI is absent. This PR implements the reporter's proposed solution: read the field, check each entry against `exec.LookPath()`, skip the skill if anything is missing. The skill files themselves (`workspace/skills/agent-browser/SKILL.md`, `tmux/SKILL.md`, `weather/SKILL.md`) already declare `requires.bins`, so no metadata authoring change is needed.

## 🧪 Test Environment
- **Hardware:** Apple MacBook Pro (M-series)
- **OS:** macOS 25.5.0 (Darwin)
- **Model/Provider:** N/A — pure server-side filter; not exercised against an LLM call
- **Channels:** N/A — no channel code touched

### Verification performed

```bash
# Focused suite (all new + existing skill loader tests)
go test -v ./pkg/skills/ -run "TestListSkills|TestGetSkillMetadata|TestMissingBinaries"
# 25 subtests PASS, including 16 new ones for this change

go vet ./pkg/skills/      # clean
make fmt                  # clean (no changes)
make lint-docs            # PASS
make check                # PASS for everything except 2 pre-existing macOS
                          # symlink tests in pkg/tools (TestShellTool_DevNullAllowed,
                          # TestShellTool_FileURISandboxing) which fail identically
                          # on a pristine upstream/main checkout — unrelated to
                          # this PR.
```

## 📸 Evidence (Optional)
<details>
<summary>Filter log line — what an operator sees on a board without the tool</summary>

```
INFO skipping skill: required binary not found on PATH name=needs-tool source=workspace missing=[picoclaw-test-missing-xyz123]
```

`source` makes it easy to track which root (workspace/global/builtin) hosted the unusable skill copy.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly. (N/A — internal behaviour change; skill authoring spec already documents `requires.bins`.)