### PR TITLE
Feat/agent collaboration

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -58,6 +58,7 @@ type AgentLoop struct {
 	evolution      *evolutionBridge
 	hookRuntime    hookRuntime
 	steering       *steeringQueue
+	collaboration  *AgentCollaborationBus
 	pendingSkills  sync.Map
 	pendingStops   sync.Map
 	mu             sync.RWMutex
@@ -92,6 +93,7 @@ type processOptions struct {
 	ForcedSkills            []string        // Skills explicitly requested for this message
 	TurnProfile             config.EffectiveTurnProfile
 	SystemPromptOverride    string                 // Override the default system prompt (Used by SubTurns)
+	RootPromptMessage       *providers.Message     // Optional pre-built root message (e.g. inter-agent request)
 	Media                   []string               // media:// refs from inbound message
 	InitialSteeringMessages []providers.Message    // Steering messages from refactor/agent
 	DefaultResponse         string                 // Response when LLM returns empty

--- a/pkg/agent/agent_init.go
+++ b/pkg/agent/agent_init.go
@@ -369,20 +369,23 @@ func registerSharedTools(
 		}
 
 		// Register delegate tool for multi-agent setups.
-		// Auto-enabled when multiple agents exist. Delegation uses the SubTurn
-		// mechanism directly (not SubagentManager) and is independent of the
-		// subagent tool.
+		// Auto-enabled when multiple agents exist. Delegation prefers the legacy
+		// SubTurn path when spawning is allowed, and falls back to collaboration
+		// only for communication-only agent topologies.
 		if len(registry.ListAgentIDs()) > 1 {
 			delegateTool := tools.NewDelegateTool()
 			delegateTool.SetSpawner(NewSubTurnSpawner(al))
-			if al.collaboration != nil {
-				delegateTool.SetRuntime(al.collaboration)
-			}
 			currentAgentID := agentID
-			delegateTool.SetSelfAgentID(currentAgentID)
 			delegateTool.SetAllowlistChecker(func(targetAgentID string) bool {
 				return registry.CanSpawnSubagent(currentAgentID, targetAgentID)
 			})
+			if al.collaboration != nil {
+				delegateTool.SetRuntime(al.collaboration)
+				delegateTool.SetCollaborationAllowlistChecker(func(targetAgentID string) bool {
+					return registry.CanCollaborate(currentAgentID, targetAgentID)
+				})
+			}
+			delegateTool.SetSelfAgentID(currentAgentID)
 			agent.Tools.Register(delegateTool)
 
 			if al.collaboration != nil {

--- a/pkg/agent/agent_init.go
+++ b/pkg/agent/agent_init.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/sipeed/picoclaw/pkg/agent/interfaces"
@@ -96,6 +97,19 @@ func NewAgentLoop(
 	al.hooks = NewHookManager(al.runtimeEvents.Channel())
 	configureHookManagerFromConfig(al.hooks, cfg)
 	al.contextManager = al.resolveContextManager()
+	if defaultAgent != nil {
+		collabBus, err := NewAgentCollaborationBus(
+			al,
+			filepath.Join(defaultAgent.Workspace, ".collaboration"),
+		)
+		if err != nil {
+			logger.WarnCF("agent", "Failed to initialize collaboration bus", map[string]any{
+				"error": err.Error(),
+			})
+		} else {
+			al.collaboration = collabBus
+		}
+	}
 
 	// Register shared tools to all agents (now that al is created)
 	registerSharedTools(al, cfg, msgBus, registry, provider)
@@ -361,12 +375,29 @@ func registerSharedTools(
 		if len(registry.ListAgentIDs()) > 1 {
 			delegateTool := tools.NewDelegateTool()
 			delegateTool.SetSpawner(NewSubTurnSpawner(al))
+			if al.collaboration != nil {
+				delegateTool.SetRuntime(al.collaboration)
+			}
 			currentAgentID := agentID
 			delegateTool.SetSelfAgentID(currentAgentID)
 			delegateTool.SetAllowlistChecker(func(targetAgentID string) bool {
 				return registry.CanSpawnSubagent(currentAgentID, targetAgentID)
 			})
 			agent.Tools.Register(delegateTool)
+
+			if al.collaboration != nil {
+				requestTool := tools.NewAgentRequestTool()
+				requestTool.SetRuntime(al.collaboration)
+				agent.Tools.Register(requestTool)
+
+				replyTool := tools.NewAgentReplyTool()
+				replyTool.SetRuntime(al.collaboration)
+				agent.Tools.Register(replyTool)
+
+				inboxTool := tools.NewAgentInboxTool()
+				inboxTool.SetRuntime(al.collaboration)
+				agent.Tools.Register(inboxTool)
+			}
 		}
 
 		warnOnUnknownAgentToolDeclarations(agentID, agent.Workspace, agent.Definition, agent.Tools)

--- a/pkg/agent/collaboration.go
+++ b/pkg/agent/collaboration.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 
@@ -146,7 +147,7 @@ func (b *AgentCollaborationBus) Request(
 		fromAgentID,
 		[]string{toAgentID},
 		threadID,
-		len(params.Content),
+		collaborationPayloadCharCount(strings.TrimSpace(params.Content), sharedContext),
 		0,
 	); policyErr != nil {
 		return nil, policyErr
@@ -285,7 +286,7 @@ func (b *AgentCollaborationBus) Reply(
 		fromAgentID,
 		recipients,
 		threadID,
-		len(params.Content),
+		collaborationPayloadCharCount(strings.TrimSpace(params.Content), ""),
 		len(params.Artifacts),
 	); policyErr != nil {
 		return nil, policyErr
@@ -949,6 +950,11 @@ func truncateForCollaboration(content string, limit int) string {
 		return content[:limit]
 	}
 	return content[:limit-3] + "..."
+}
+
+func collaborationPayloadCharCount(content, sharedContext string) int {
+	return utf8.RuneCountInString(strings.TrimSpace(content)) +
+		utf8.RuneCountInString(strings.TrimSpace(sharedContext))
 }
 
 func (b *AgentCollaborationBus) isQueueActive(sessionKey string) bool {

--- a/pkg/agent/collaboration.go
+++ b/pkg/agent/collaboration.go
@@ -462,11 +462,7 @@ func (b *AgentCollaborationBus) processQueuedRequest(
 	scope := collaborationSessionScope(targetAgentID, threadID)
 	requestMsg := interAgentPromptMessage(b.renderRequestMessage(requestEnv), requestEnv.Artifacts)
 
-	runCtx := context.Background()
-	cancel := func() {}
-	if requestEnv.Deadline != nil && !requestEnv.Deadline.IsZero() {
-		runCtx, cancel = context.WithDeadline(context.Background(), *requestEnv.Deadline)
-	}
+	runCtx, cancel := b.collaborationRunContext(requestEnv.Deadline)
 	defer cancel()
 
 	if err := b.al.ensureHooksInitialized(runCtx); err != nil {
@@ -632,12 +628,9 @@ func (b *AgentCollaborationBus) waitForResponse(
 		return response, nil
 	}
 
-	timeout := defaultCollaborationTimeout
-	if deadline != nil {
-		timeout = time.Until(*deadline)
-		if timeout <= 0 {
-			return collab.Envelope{}, fmt.Errorf("collaboration reply deadline expired before a response was received")
-		}
+	timeout, err := b.collaborationWaitTimeout(deadline)
+	if err != nil {
+		return collab.Envelope{}, err
 	}
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
@@ -654,6 +647,34 @@ func (b *AgentCollaborationBus) waitForResponse(
 			messageID,
 		)
 	}
+}
+
+func (b *AgentCollaborationBus) collaborationRunContext(deadline *time.Time) (context.Context, context.CancelFunc) {
+	if deadline != nil && !deadline.IsZero() {
+		return context.WithDeadline(context.Background(), *deadline)
+	}
+	return context.WithTimeout(context.Background(), b.defaultCollaborationTimeout())
+}
+
+func (b *AgentCollaborationBus) collaborationWaitTimeout(deadline *time.Time) (time.Duration, error) {
+	if deadline != nil {
+		timeout := time.Until(*deadline)
+		if timeout <= 0 {
+			return 0, fmt.Errorf("collaboration reply deadline expired before a response was received")
+		}
+		return timeout, nil
+	}
+	return b.defaultCollaborationTimeout(), nil
+}
+
+func (b *AgentCollaborationBus) defaultCollaborationTimeout() time.Duration {
+	if b != nil && b.al != nil {
+		timeout := b.al.getSubTurnConfig().defaultTimeout
+		if timeout > 0 {
+			return timeout
+		}
+	}
+	return defaultCollaborationTimeout
 }
 
 func (b *AgentCollaborationBus) addWaiter(messageID string, waiter chan collab.Envelope) {

--- a/pkg/agent/collaboration.go
+++ b/pkg/agent/collaboration.go
@@ -499,13 +499,14 @@ func (b *AgentCollaborationBus) processQueuedRequest(
 	if finalContent == "" {
 		finalContent = "No reply was produced for this collaboration request."
 	}
-	return b.synthesizeReply(requestEnv, targetAgentID, finalContent, collab.KindReply)
+	return b.synthesizeReply(requestEnv, targetAgentID, finalContent, collab.KindReply, true)
 }
 
 func (b *AgentCollaborationBus) synthesizeReply(
 	requestEnv collab.Envelope,
 	fromAgentID, content string,
 	kind collab.MessageKind,
+	markRequestReplied bool,
 ) error {
 	replyEnv := collab.Envelope{
 		ID:           "msg_" + uuid.New().String(),
@@ -524,12 +525,14 @@ func (b *AgentCollaborationBus) synthesizeReply(
 	if _, err := b.store.AddMessage(replyEnv); err != nil {
 		return err
 	}
-	if _, err := b.store.UpdateMessageStatus(requestEnv.ID, collab.StatusReplied, ""); err != nil {
-		logger.WarnCF("agent", "Failed to mark synthesized collaboration reply", map[string]any{
-			"thread_id":  requestEnv.ThreadID,
-			"message_id": requestEnv.ID,
-			"error":      err.Error(),
-		})
+	if markRequestReplied {
+		if _, err := b.store.UpdateMessageStatus(requestEnv.ID, collab.StatusReplied, ""); err != nil {
+			logger.WarnCF("agent", "Failed to mark synthesized collaboration reply", map[string]any{
+				"thread_id":  requestEnv.ThreadID,
+				"message_id": requestEnv.ID,
+				"error":      err.Error(),
+			})
+		}
 	}
 	b.emitCollaborationEvent(runtimeevents.KindAgentMessageReply, replyEnv, requestEnv.FromAgentID)
 	b.notifyWaiters(requestEnv.ID, replyEnv)
@@ -549,6 +552,7 @@ func (b *AgentCollaborationBus) recordRequestFailure(requestEnv collab.Envelope,
 		firstRecipient(requestEnv.ToAgentIDs),
 		fmt.Sprintf("Collaboration request failed: %v", err),
 		collab.KindStatus,
+		false,
 	); synthErr != nil {
 		return synthErr
 	}

--- a/pkg/agent/collaboration.go
+++ b/pkg/agent/collaboration.go
@@ -1,0 +1,941 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/collab"
+	runtimeevents "github.com/sipeed/picoclaw/pkg/events"
+	"github.com/sipeed/picoclaw/pkg/logger"
+	"github.com/sipeed/picoclaw/pkg/providers"
+	"github.com/sipeed/picoclaw/pkg/routing"
+	"github.com/sipeed/picoclaw/pkg/session"
+	"github.com/sipeed/picoclaw/pkg/tools"
+)
+
+const (
+	collaborationChannel        = "inter-agent"
+	collaborationAccount        = "collaboration"
+	defaultCollaborationTimeout = 5 * time.Minute
+	collaborationContentPreview = 240
+)
+
+type AgentCollaborationBus struct {
+	al    *AgentLoop
+	store *collab.Store
+
+	waitersMu sync.Mutex
+	waiters   map[string][]chan collab.Envelope
+
+	queueMu sync.Mutex
+	queues  map[string]*collaborationSessionQueue
+}
+
+type collaborationSessionQueue struct {
+	processing    bool
+	targetAgentID string
+	threadID      string
+	messageIDs    []string
+}
+
+func NewAgentCollaborationBus(al *AgentLoop, dir string) (*AgentCollaborationBus, error) {
+	store, err := collab.NewStore(dir)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentCollaborationBus{
+		al:      al,
+		store:   store,
+		waiters: make(map[string][]chan collab.Envelope),
+		queues:  make(map[string]*collaborationSessionQueue),
+	}, nil
+}
+
+func (b *AgentCollaborationBus) Request(
+	ctx context.Context,
+	params tools.AgentRequestParams,
+) (*tools.AgentRequestResponse, error) {
+	if b == nil || b.store == nil || b.al == nil {
+		return nil, fmt.Errorf("collaboration bus is not available")
+	}
+
+	fromAgentID := currentToolAgentID(ctx)
+	if fromAgentID == "" {
+		return nil, fmt.Errorf("agent_request requires an active agent turn")
+	}
+	toAgentID := routing.NormalizeAgentID(params.ToAgentID)
+	if toAgentID == "" {
+		return nil, fmt.Errorf("target agent is required")
+	}
+	if fromAgentID == toAgentID {
+		return nil, fmt.Errorf("cannot send collaboration request to self")
+	}
+
+	threadID := strings.TrimSpace(params.ThreadID)
+	var thread collab.Thread
+	var threadExists bool
+	if threadID == "" {
+		threadID = "thread_" + uuid.New().String()
+	} else {
+		var ok bool
+		thread, ok = b.store.GetThread(threadID)
+		if !ok {
+			return nil, fmt.Errorf("collaboration thread %q was not found", threadID)
+		}
+		threadExists = true
+	}
+
+	messageID := "msg_" + uuid.New().String()
+	traceID := "trace_" + uuid.New().String()
+	parentTurnID := currentTurnID(ctx)
+	policy := collab.NormalizeContextPolicy(params.ContextPolicy)
+	sharedContext, err := b.buildSharedContext(ctx, fromAgentID, policy, params.SelectedContext)
+	if err != nil {
+		return nil, err
+	}
+
+	if !b.al.registry.CanCollaborate(fromAgentID, toAgentID) {
+		env := collab.Envelope{
+			ID:            messageID,
+			ThreadID:      threadID,
+			FromAgentID:   fromAgentID,
+			ToAgentIDs:    []string{toAgentID},
+			Kind:          collab.KindRequest,
+			Content:       strings.TrimSpace(params.Content),
+			ExpectReply:   true,
+			Priority:      "normal",
+			Status:        collab.StatusBlocked,
+			TraceID:       traceID,
+			ParentTurnID:  parentTurnID,
+			ContextPolicy: policy,
+			ContextShared: sharedContext,
+			ErrorSummary:  "communication policy blocked this request",
+			CreatedAt:     time.Now().UTC(),
+		}
+		if _, ensureErr := b.store.EnsureThread(collab.Thread{
+			ID:                  threadID,
+			ParticipantAgentIDs: []string{fromAgentID, toAgentID},
+			Status:              collab.ThreadStatusOpen,
+		}); ensureErr == nil {
+			_, _ = b.store.AddMessage(env)
+		}
+		b.emitCollaborationEvent(runtimeevents.KindAgentMessageBlocked, env, toAgentID)
+		return nil, fmt.Errorf("agent %q is not allowed to message agent %q", fromAgentID, toAgentID)
+	}
+	if threadExists {
+		if thread.Status == collab.ThreadStatusClosed {
+			return nil, fmt.Errorf("collaboration thread %q is closed", threadID)
+		}
+		if !threadIncludesParticipant(thread, fromAgentID) || !threadIncludesParticipant(thread, toAgentID) {
+			return nil, fmt.Errorf(
+				"collaboration thread %q does not include both agent %q and agent %q",
+				threadID,
+				fromAgentID,
+				toAgentID,
+			)
+		}
+	}
+
+	if policyErr := b.enforceThreadPolicy(
+		fromAgentID,
+		[]string{toAgentID},
+		threadID,
+		len(params.Content),
+		0,
+	); policyErr != nil {
+		return nil, policyErr
+	}
+
+	now := time.Now().UTC()
+	parentID := ""
+	if threadExists {
+		parentID = strings.TrimSpace(thread.LastMessageID)
+	}
+	env := collab.Envelope{
+		ID:            messageID,
+		ThreadID:      threadID,
+		ParentID:      parentID,
+		FromAgentID:   fromAgentID,
+		ToAgentIDs:    []string{toAgentID},
+		Kind:          collab.KindRequest,
+		Content:       strings.TrimSpace(params.Content),
+		ExpectReply:   true,
+		Priority:      "normal",
+		Status:        collab.StatusQueued,
+		TraceID:       traceID,
+		ParentTurnID:  parentTurnID,
+		ContextPolicy: policy,
+		ContextShared: sharedContext,
+		CreatedAt:     now,
+	}
+	if params.DeadlineSeconds > 0 {
+		deadline := now.Add(time.Duration(params.DeadlineSeconds) * time.Second)
+		env.Deadline = &deadline
+	}
+
+	if _, ensureErr := b.store.EnsureThread(collab.Thread{
+		ID:                  threadID,
+		ParticipantAgentIDs: []string{fromAgentID, toAgentID},
+		Status:              collab.ThreadStatusOpen,
+	}); ensureErr != nil {
+		return nil, ensureErr
+	}
+	if _, addErr := b.store.AddMessage(env); addErr != nil {
+		return nil, addErr
+	}
+	b.emitCollaborationEvent(runtimeevents.KindAgentMessageSent, env, toAgentID)
+
+	var waiter chan collab.Envelope
+	if params.Wait {
+		waiter = make(chan collab.Envelope, 1)
+		b.addWaiter(messageID, waiter)
+		defer b.removeWaiter(messageID, waiter)
+	}
+
+	sessionKey := collaborationSessionKey(toAgentID, threadID)
+	b.enqueueRequest(sessionKey, toAgentID, threadID, messageID)
+	if _, statusErr := b.store.UpdateMessageStatus(
+		messageID,
+		collab.StatusDelivered,
+		"",
+	); statusErr == nil {
+		if latest, ok := b.store.GetMessage(messageID); ok {
+			b.emitCollaborationEvent(runtimeevents.KindAgentMessageDelivered, latest, toAgentID)
+		}
+	}
+
+	if !params.Wait {
+		return &tools.AgentRequestResponse{
+			ThreadID:  threadID,
+			MessageID: messageID,
+			Status:    collab.StatusDelivered,
+		}, nil
+	}
+
+	response, err := b.waitForResponse(ctx, threadID, messageID, waiter, env.Deadline)
+	if err != nil {
+		return nil, err
+	}
+	return &tools.AgentRequestResponse{
+		ThreadID:       response.ThreadID,
+		MessageID:      messageID,
+		ReplyMessageID: response.ID,
+		FromAgentID:    response.FromAgentID,
+		Content:        response.Content,
+		Status:         response.Status,
+	}, nil
+}
+
+func (b *AgentCollaborationBus) Reply(
+	ctx context.Context,
+	params tools.AgentReplyParams,
+) (*tools.AgentReplyResponse, error) {
+	if b == nil || b.store == nil || b.al == nil {
+		return nil, fmt.Errorf("collaboration bus is not available")
+	}
+
+	fromAgentID := currentToolAgentID(ctx)
+	if fromAgentID == "" {
+		return nil, fmt.Errorf("agent_reply requires an active agent turn")
+	}
+	threadID := strings.TrimSpace(params.ThreadID)
+	if threadID == "" {
+		return nil, fmt.Errorf("thread_id is required")
+	}
+	parentID := strings.TrimSpace(params.InReplyTo)
+	if parentID == "" {
+		return nil, fmt.Errorf("in_reply_to is required")
+	}
+	if strings.TrimSpace(params.Content) == "" {
+		return nil, fmt.Errorf("content is required")
+	}
+
+	thread, ok := b.store.GetThread(threadID)
+	if !ok {
+		return nil, fmt.Errorf("collaboration thread %q was not found", threadID)
+	}
+	if thread.Status == collab.ThreadStatusClosed {
+		return nil, fmt.Errorf("collaboration thread %q is closed", threadID)
+	}
+	if !threadIncludesParticipant(thread, fromAgentID) {
+		return nil, fmt.Errorf("agent %q is not a participant in thread %q", fromAgentID, threadID)
+	}
+	parentMsg, ok := b.store.GetMessage(parentID)
+	if !ok || parentMsg.ThreadID != threadID {
+		return nil, fmt.Errorf("message %q was not found in thread %q", parentID, threadID)
+	}
+
+	recipients := replyRecipients(parentMsg, fromAgentID, thread.ParticipantAgentIDs)
+	if len(recipients) == 0 {
+		return nil, fmt.Errorf("no collaboration recipient could be resolved for thread %q", threadID)
+	}
+	for _, toAgentID := range recipients {
+		if !b.al.registry.CanCollaborate(fromAgentID, toAgentID) {
+			return nil, fmt.Errorf("agent %q is not allowed to reply to agent %q", fromAgentID, toAgentID)
+		}
+	}
+
+	if policyErr := b.enforceThreadPolicy(
+		fromAgentID,
+		recipients,
+		threadID,
+		len(params.Content),
+		len(params.Artifacts),
+	); policyErr != nil {
+		return nil, policyErr
+	}
+
+	replyEnv := collab.Envelope{
+		ID:           "msg_" + uuid.New().String(),
+		ThreadID:     threadID,
+		ParentID:     parentID,
+		FromAgentID:  fromAgentID,
+		ToAgentIDs:   recipients,
+		Kind:         collab.KindReply,
+		Content:      strings.TrimSpace(params.Content),
+		Artifacts:    append([]providers.Attachment(nil), params.Artifacts...),
+		Priority:     "normal",
+		Status:       collab.StatusDelivered,
+		TraceID:      parentMsg.TraceID,
+		ParentTurnID: currentTurnID(ctx),
+		CreatedAt:    time.Now().UTC(),
+	}
+	if _, err := b.store.AddMessage(replyEnv); err != nil {
+		return nil, err
+	}
+	if _, err := b.store.UpdateMessageStatus(parentID, collab.StatusReplied, ""); err != nil {
+		logger.WarnCF("agent", "Failed to mark collaboration request as replied", map[string]any{
+			"thread_id":  threadID,
+			"message_id": parentID,
+			"error":      err.Error(),
+		})
+	}
+	b.appendReplyHistory(ctx, replyEnv)
+	b.emitCollaborationEvent(runtimeevents.KindAgentMessageReply, replyEnv, strings.Join(recipients, ","))
+	b.notifyWaiters(parentID, replyEnv)
+
+	return &tools.AgentReplyResponse{
+		ThreadID:  threadID,
+		MessageID: replyEnv.ID,
+		Status:    replyEnv.Status,
+	}, nil
+}
+
+func (b *AgentCollaborationBus) Inbox(
+	ctx context.Context,
+	params tools.AgentInboxParams,
+) (*tools.AgentInboxResponse, error) {
+	if b == nil || b.store == nil || b.al == nil {
+		return nil, fmt.Errorf("collaboration bus is not available")
+	}
+
+	agentID := currentToolAgentID(ctx)
+	if agentID == "" {
+		return nil, fmt.Errorf("agent_inbox requires an active agent turn")
+	}
+
+	inbox := &tools.AgentInboxResponse{
+		AgentID:  agentID,
+		ThreadID: strings.TrimSpace(params.ThreadID),
+	}
+
+	if inbox.ThreadID != "" {
+		thread, ok := b.store.GetThread(inbox.ThreadID)
+		if !ok {
+			return nil, fmt.Errorf("collaboration thread %q was not found", inbox.ThreadID)
+		}
+		if !containsString(thread.ParticipantAgentIDs, agentID) {
+			return nil, fmt.Errorf("agent %q is not a participant in thread %q", agentID, inbox.ThreadID)
+		}
+		inbox.ThreadStatus = string(thread.Status)
+		inbox.Participants = append([]string(nil), thread.ParticipantAgentIDs...)
+	}
+
+	messages := b.store.ListMailbox(agentID, inbox.ThreadID, params.Status)
+	inbox.Messages = make([]tools.AgentInboxMessage, 0, len(messages))
+	for _, message := range messages {
+		inbox.Messages = append(inbox.Messages, tools.AgentInboxMessage{
+			ID:             message.ID,
+			ThreadID:       message.ThreadID,
+			ParentID:       message.ParentID,
+			FromAgentID:    message.FromAgentID,
+			Kind:           message.Kind,
+			Status:         message.Status,
+			ExpectReply:    message.ExpectReply,
+			ContentPreview: truncateForCollaboration(message.Content, collaborationContentPreview),
+			ArtifactCount:  len(message.Artifacts),
+			CreatedAt:      message.CreatedAt,
+		})
+	}
+
+	return inbox, nil
+}
+
+func (b *AgentCollaborationBus) enqueueRequest(sessionKey, targetAgentID, threadID, messageID string) {
+	b.queueMu.Lock()
+	queue := b.queues[sessionKey]
+	if queue == nil {
+		queue = &collaborationSessionQueue{
+			targetAgentID: targetAgentID,
+			threadID:      threadID,
+		}
+		b.queues[sessionKey] = queue
+	}
+	queue.targetAgentID = targetAgentID
+	queue.threadID = threadID
+	queue.messageIDs = append(queue.messageIDs, messageID)
+	if queue.processing {
+		b.queueMu.Unlock()
+		return
+	}
+	queue.processing = true
+	b.queueMu.Unlock()
+
+	go b.processSessionQueue(sessionKey)
+}
+
+func (b *AgentCollaborationBus) processSessionQueue(sessionKey string) {
+	for {
+		b.queueMu.Lock()
+		queue := b.queues[sessionKey]
+		if queue == nil || len(queue.messageIDs) == 0 {
+			if queue != nil {
+				queue.processing = false
+				delete(b.queues, sessionKey)
+			}
+			b.queueMu.Unlock()
+			return
+		}
+		targetAgentID := queue.targetAgentID
+		threadID := queue.threadID
+		messageID := queue.messageIDs[0]
+		queue.messageIDs = queue.messageIDs[1:]
+		b.queueMu.Unlock()
+
+		if err := b.processQueuedRequest(sessionKey, targetAgentID, threadID, messageID); err != nil {
+			logger.WarnCF("agent", "Failed to process queued collaboration request", map[string]any{
+				"session_key": sessionKey,
+				"thread_id":   threadID,
+				"message_id":  messageID,
+				"error":       err.Error(),
+			})
+		}
+	}
+}
+
+func (b *AgentCollaborationBus) processQueuedRequest(
+	sessionKey, targetAgentID, threadID, messageID string,
+) error {
+	requestEnv, ok := b.store.GetMessage(messageID)
+	if !ok {
+		return fmt.Errorf("collaboration message %q not found", messageID)
+	}
+	if requestEnv.Status == collab.StatusBlocked || requestEnv.Status == collab.StatusClosed {
+		return nil
+	}
+
+	targetAgent, ok := b.al.registry.GetAgent(targetAgentID)
+	if !ok || targetAgent == nil {
+		return b.recordRequestFailure(requestEnv, fmt.Errorf("target agent %q not found", targetAgentID))
+	}
+
+	if _, err := b.store.UpdateMessageStatus(messageID, collab.StatusReceived, ""); err == nil {
+		if latest, ok := b.store.GetMessage(messageID); ok {
+			b.emitCollaborationEvent(runtimeevents.KindAgentMessageReceived, latest, targetAgentID)
+		}
+	}
+
+	inbound := &bus.InboundContext{
+		Channel:   collaborationChannel,
+		Account:   collaborationAccount,
+		ChatID:    threadID,
+		ChatType:  "direct",
+		SenderID:  requestEnv.FromAgentID,
+		MessageID: requestEnv.ID,
+	}
+	scope := collaborationSessionScope(targetAgentID, threadID)
+	requestMsg := interAgentPromptMessage(b.renderRequestMessage(requestEnv), requestEnv.Artifacts)
+
+	runCtx := context.Background()
+	cancel := func() {}
+	if requestEnv.Deadline != nil && !requestEnv.Deadline.IsZero() {
+		runCtx, cancel = context.WithDeadline(context.Background(), *requestEnv.Deadline)
+	}
+	defer cancel()
+
+	if err := b.al.ensureHooksInitialized(runCtx); err != nil {
+		return b.recordRequestFailure(requestEnv, err)
+	}
+	if err := b.al.ensureMCPInitialized(runCtx); err != nil {
+		return b.recordRequestFailure(requestEnv, err)
+	}
+
+	finalContent, err := b.al.runAgentLoop(runCtx, targetAgent, processOptions{
+		Dispatch: DispatchRequest{
+			SessionKey:     sessionKey,
+			SessionAliases: collaborationSessionAliases(targetAgentID, threadID),
+			InboundContext: inbound,
+			SessionScope:   scope,
+		},
+		DefaultResponse:      "",
+		EnableSummary:        true,
+		SendResponse:         false,
+		SuppressToolFeedback: true,
+		RootPromptMessage:    &requestMsg,
+	})
+	if err != nil {
+		return b.recordRequestFailure(requestEnv, err)
+	}
+
+	if _, exists := b.store.FindResponseTo(threadID, requestEnv.ID); exists {
+		_, _ = b.store.UpdateMessageStatus(requestEnv.ID, collab.StatusReplied, "")
+		return nil
+	}
+
+	finalContent = strings.TrimSpace(finalContent)
+	if finalContent == "" {
+		finalContent = "No reply was produced for this collaboration request."
+	}
+	return b.synthesizeReply(requestEnv, targetAgentID, finalContent, collab.KindReply)
+}
+
+func (b *AgentCollaborationBus) synthesizeReply(
+	requestEnv collab.Envelope,
+	fromAgentID, content string,
+	kind collab.MessageKind,
+) error {
+	replyEnv := collab.Envelope{
+		ID:           "msg_" + uuid.New().String(),
+		ThreadID:     requestEnv.ThreadID,
+		ParentID:     requestEnv.ID,
+		FromAgentID:  fromAgentID,
+		ToAgentIDs:   []string{requestEnv.FromAgentID},
+		Kind:         kind,
+		Content:      strings.TrimSpace(content),
+		Priority:     "normal",
+		Status:       collab.StatusDelivered,
+		TraceID:      requestEnv.TraceID,
+		CreatedAt:    time.Now().UTC(),
+		ParentTurnID: "",
+	}
+	if _, err := b.store.AddMessage(replyEnv); err != nil {
+		return err
+	}
+	if _, err := b.store.UpdateMessageStatus(requestEnv.ID, collab.StatusReplied, ""); err != nil {
+		logger.WarnCF("agent", "Failed to mark synthesized collaboration reply", map[string]any{
+			"thread_id":  requestEnv.ThreadID,
+			"message_id": requestEnv.ID,
+			"error":      err.Error(),
+		})
+	}
+	b.emitCollaborationEvent(runtimeevents.KindAgentMessageReply, replyEnv, requestEnv.FromAgentID)
+	b.notifyWaiters(requestEnv.ID, replyEnv)
+	return nil
+}
+
+func (b *AgentCollaborationBus) recordRequestFailure(requestEnv collab.Envelope, err error) error {
+	if _, statusErr := b.store.UpdateMessageStatus(requestEnv.ID, collab.StatusError, err.Error()); statusErr != nil {
+		logger.WarnCF("agent", "Failed to update collaboration error status", map[string]any{
+			"thread_id":  requestEnv.ThreadID,
+			"message_id": requestEnv.ID,
+			"error":      statusErr.Error(),
+		})
+	}
+	if synthErr := b.synthesizeReply(
+		requestEnv,
+		firstRecipient(requestEnv.ToAgentIDs),
+		fmt.Sprintf("Collaboration request failed: %v", err),
+		collab.KindStatus,
+	); synthErr != nil {
+		return synthErr
+	}
+	return err
+}
+
+func (b *AgentCollaborationBus) buildSharedContext(
+	ctx context.Context,
+	fromAgentID string,
+	policy collab.ContextPolicy,
+	selectedContext string,
+) (string, error) {
+	switch policy {
+	case collab.ContextPolicySummary:
+		sessionKey := tools.ToolSessionKey(ctx)
+		if sessionKey == "" {
+			return "", nil
+		}
+		senderAgent, ok := b.al.registry.GetAgent(fromAgentID)
+		if !ok || senderAgent == nil || senderAgent.Sessions == nil {
+			return "", nil
+		}
+		return strings.TrimSpace(senderAgent.Sessions.GetSummary(sessionKey)), nil
+	case collab.ContextPolicySelectedContext:
+		selectedContext = strings.TrimSpace(selectedContext)
+		if selectedContext == "" {
+			return "", fmt.Errorf("selected_context is required when context_policy is selected_context")
+		}
+		return selectedContext, nil
+	default:
+		return "", nil
+	}
+}
+
+func (b *AgentCollaborationBus) renderRequestMessage(env collab.Envelope) string {
+	var builder strings.Builder
+	builder.WriteString("[Internal collaboration message]\n")
+	fmt.Fprintf(&builder, "From agent: %s\n", env.FromAgentID)
+	fmt.Fprintf(&builder, "Thread ID: %s\n", env.ThreadID)
+	fmt.Fprintf(&builder, "Message ID: %s\n", env.ID)
+	fmt.Fprintf(&builder, "Kind: %s\n", env.Kind)
+	if env.ExpectReply {
+		builder.WriteString("Reply expected: yes\n")
+	}
+	if env.Deadline != nil {
+		fmt.Fprintf(&builder, "Deadline: %s\n", env.Deadline.UTC().Format(time.RFC3339))
+	}
+	if strings.TrimSpace(env.ContextShared) != "" {
+		fmt.Fprintf(&builder, "Shared context (%s):\n%s\n", env.ContextPolicy, env.ContextShared)
+	}
+	if len(env.Artifacts) > 0 {
+		builder.WriteString("Artifacts:\n")
+		for _, artifact := range env.Artifacts {
+			fmt.Fprintf(
+				&builder,
+				"- type=%s ref=%s url=%s filename=%s content_type=%s\n",
+				strings.TrimSpace(artifact.Type),
+				strings.TrimSpace(artifact.Ref),
+				strings.TrimSpace(artifact.URL),
+				strings.TrimSpace(artifact.Filename),
+				strings.TrimSpace(artifact.ContentType),
+			)
+		}
+	}
+	builder.WriteString("\nTask:\n")
+	builder.WriteString(env.Content)
+	builder.WriteString("\n\nUse the collaboration tools to reply inside this thread when appropriate.")
+	return builder.String()
+}
+
+func (b *AgentCollaborationBus) waitForResponse(
+	ctx context.Context,
+	threadID, messageID string,
+	waiter chan collab.Envelope,
+	deadline *time.Time,
+) (collab.Envelope, error) {
+	if response, ok := b.store.FindResponseTo(threadID, messageID); ok {
+		return response, nil
+	}
+
+	timeout := defaultCollaborationTimeout
+	if deadline != nil {
+		timeout = time.Until(*deadline)
+		if timeout <= 0 {
+			return collab.Envelope{}, fmt.Errorf("collaboration reply deadline expired before a response was received")
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case response := <-waiter:
+		return response, nil
+	case <-ctx.Done():
+		return collab.Envelope{}, ctx.Err()
+	case <-timer.C:
+		return collab.Envelope{}, fmt.Errorf(
+			"timed out waiting for a collaboration reply in thread %s for message %s",
+			threadID,
+			messageID,
+		)
+	}
+}
+
+func (b *AgentCollaborationBus) addWaiter(messageID string, waiter chan collab.Envelope) {
+	b.waitersMu.Lock()
+	defer b.waitersMu.Unlock()
+	b.waiters[messageID] = append(b.waiters[messageID], waiter)
+}
+
+func (b *AgentCollaborationBus) removeWaiter(messageID string, waiter chan collab.Envelope) {
+	b.waitersMu.Lock()
+	defer b.waitersMu.Unlock()
+
+	waiters := b.waiters[messageID]
+	if len(waiters) == 0 {
+		return
+	}
+	filtered := waiters[:0]
+	for _, current := range waiters {
+		if current != waiter {
+			filtered = append(filtered, current)
+		}
+	}
+	if len(filtered) == 0 {
+		delete(b.waiters, messageID)
+		return
+	}
+	b.waiters[messageID] = filtered
+}
+
+func (b *AgentCollaborationBus) notifyWaiters(messageID string, env collab.Envelope) {
+	b.waitersMu.Lock()
+	waiters := append([]chan collab.Envelope(nil), b.waiters[messageID]...)
+	delete(b.waiters, messageID)
+	b.waitersMu.Unlock()
+
+	for _, waiter := range waiters {
+		select {
+		case waiter <- env:
+		default:
+		}
+	}
+}
+
+func (b *AgentCollaborationBus) appendReplyHistory(ctx context.Context, replyEnv collab.Envelope) {
+	ts := turnStateFromContext(ctx)
+	if ts == nil || ts.agent == nil || ts.agent.Sessions == nil {
+		return
+	}
+	scope := collaborationSessionScope(replyEnv.FromAgentID, replyEnv.ThreadID)
+	expectedSessionKey := collaborationSessionKey(replyEnv.FromAgentID, replyEnv.ThreadID)
+	if ts.sessionKey != expectedSessionKey {
+		return
+	}
+	ensureSessionMetadata(
+		ts.agent.Sessions,
+		expectedSessionKey,
+		scope,
+		collaborationSessionAliases(replyEnv.FromAgentID, replyEnv.ThreadID),
+	)
+	msg := providers.Message{
+		Role: "assistant",
+		Content: fmt.Sprintf(
+			"[Collaboration reply to %s]\n%s",
+			strings.Join(replyEnv.ToAgentIDs, ", "),
+			replyEnv.Content,
+		),
+		Attachments: append([]providers.Attachment(nil), replyEnv.Artifacts...),
+	}
+	ts.agent.Sessions.AddFullMessage(expectedSessionKey, msg)
+}
+
+func (b *AgentCollaborationBus) enforceThreadPolicy(
+	fromAgentID string,
+	toAgentIDs []string,
+	threadID string,
+	contentLen, artifactCount int,
+) error {
+	limit := b.al.registry.CommunicationMaxThreadTurns(fromAgentID)
+	charLimit := b.al.registry.CommunicationMaxMessageChars(fromAgentID)
+	artifactsAllowed := b.al.registry.CommunicationAllowsArtifacts(fromAgentID)
+	for _, toAgentID := range toAgentIDs {
+		if turns := b.al.registry.CommunicationMaxThreadTurns(toAgentID); turns > 0 && turns < limit {
+			limit = turns
+		}
+		if chars := b.al.registry.CommunicationMaxMessageChars(toAgentID); chars > 0 && chars < charLimit {
+			charLimit = chars
+		}
+		artifactsAllowed = artifactsAllowed && b.al.registry.CommunicationAllowsArtifacts(toAgentID)
+	}
+	if contentLen > charLimit {
+		return fmt.Errorf("collaboration message exceeds max_message_chars=%d", charLimit)
+	}
+	if artifactCount > 0 && !artifactsAllowed {
+		return fmt.Errorf("artifact transfer is not allowed by collaboration policy")
+	}
+	if limit > 0 && b.store.ThreadMessageCount(threadID) >= limit {
+		if _, err := b.store.CloseThread(threadID, "max_thread_turns exceeded"); err == nil {
+			if closed, ok := b.store.GetThread(threadID); ok {
+				b.emitThreadClosedEvent(closed)
+			}
+		}
+		return fmt.Errorf("collaboration thread %s reached max_thread_turns=%d", threadID, limit)
+	}
+	return nil
+}
+
+func (b *AgentCollaborationBus) emitCollaborationEvent(
+	kind runtimeevents.Kind,
+	env collab.Envelope,
+	toAgentID string,
+) {
+	if b == nil || b.al == nil {
+		return
+	}
+	meta := HookMeta{
+		AgentID:      env.FromAgentID,
+		SessionKey:   collaborationSessionKey(firstNonEmpty(toAgentID, firstRecipient(env.ToAgentIDs)), env.ThreadID),
+		ParentTurnID: env.ParentTurnID,
+		TracePath:    env.TraceID,
+		Source:       "collaboration",
+		turnContext: &TurnContext{
+			Inbound: &bus.InboundContext{
+				Channel:   collaborationChannel,
+				Account:   collaborationAccount,
+				ChatID:    env.ThreadID,
+				ChatType:  "direct",
+				SenderID:  env.FromAgentID,
+				MessageID: env.ID,
+			},
+		},
+	}
+	b.al.emitEvent(kind, meta, AgentMessageEventPayload{
+		ThreadID:        env.ThreadID,
+		MessageID:       env.ID,
+		ParentMessageID: env.ParentID,
+		FromAgentID:     env.FromAgentID,
+		ToAgentID:       strings.TrimSpace(toAgentID),
+		Status:          string(env.Status),
+		TraceID:         env.TraceID,
+		ParentTurnID:    env.ParentTurnID,
+		Priority:        env.Priority,
+		Deadline:        env.Deadline,
+		ArtifactCount:   len(env.Artifacts),
+	})
+}
+
+func (b *AgentCollaborationBus) emitThreadClosedEvent(thread collab.Thread) {
+	if b == nil || b.al == nil {
+		return
+	}
+	b.al.emitEvent(runtimeevents.KindAgentThreadClosed, HookMeta{
+		AgentID:    firstRecipient(thread.ParticipantAgentIDs),
+		SessionKey: "",
+		Source:     "collaboration",
+		TracePath:  "thread_closed:" + thread.ID,
+	}, AgentThreadClosedPayload{
+		ThreadID:     thread.ID,
+		Status:       string(thread.Status),
+		CloseReason:  thread.CloseReason,
+		Participants: append([]string(nil), thread.ParticipantAgentIDs...),
+	})
+}
+
+func collaborationSessionScope(targetAgentID, threadID string) *session.SessionScope {
+	return &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    routing.NormalizeAgentID(targetAgentID),
+		Channel:    collaborationChannel,
+		Account:    collaborationAccount,
+		Dimensions: []string{"thread"},
+		Values: map[string]string{
+			"thread": strings.TrimSpace(threadID),
+		},
+	}
+}
+
+func collaborationSessionKey(targetAgentID, threadID string) string {
+	return session.BuildSessionKey(*collaborationSessionScope(targetAgentID, threadID))
+}
+
+func collaborationSessionAliases(targetAgentID, threadID string) []string {
+	return []string{
+		strings.ToLower(fmt.Sprintf(
+			"agent:%s:%s:thread:%s",
+			routing.NormalizeAgentID(targetAgentID),
+			collaborationChannel,
+			strings.TrimSpace(threadID),
+		)),
+	}
+}
+
+func currentToolAgentID(ctx context.Context) string {
+	if agentID := routing.NormalizeAgentID(tools.ToolAgentID(ctx)); agentID != "" {
+		return agentID
+	}
+	if ts := turnStateFromContext(ctx); ts != nil {
+		return routing.NormalizeAgentID(ts.agentID)
+	}
+	return ""
+}
+
+func currentTurnID(ctx context.Context) string {
+	if ts := turnStateFromContext(ctx); ts != nil {
+		return strings.TrimSpace(ts.turnID)
+	}
+	return ""
+}
+
+func replyRecipients(
+	parentMsg collab.Envelope,
+	fromAgentID string,
+	participants []string,
+) []string {
+	recipients := make([]string, 0, 1)
+	if parentMsg.FromAgentID != "" && parentMsg.FromAgentID != fromAgentID {
+		recipients = append(recipients, parentMsg.FromAgentID)
+	}
+	for _, participant := range participants {
+		if participant == "" || participant == fromAgentID || containsString(recipients, participant) {
+			continue
+		}
+		recipients = append(recipients, participant)
+	}
+	return recipients
+}
+
+func firstRecipient(values []string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func threadIncludesParticipant(thread collab.Thread, agentID string) bool {
+	agentID = routing.NormalizeAgentID(agentID)
+	for _, participant := range thread.ParticipantAgentIDs {
+		if routing.NormalizeAgentID(participant) == agentID {
+			return true
+		}
+	}
+	return false
+}
+
+func truncateForCollaboration(content string, limit int) string {
+	content = strings.TrimSpace(content)
+	if limit <= 0 || len(content) <= limit {
+		return content
+	}
+	if limit <= 3 {
+		return content[:limit]
+	}
+	return content[:limit-3] + "..."
+}
+
+func (b *AgentCollaborationBus) isQueueActive(sessionKey string) bool {
+	if b == nil {
+		return false
+	}
+	b.queueMu.Lock()
+	defer b.queueMu.Unlock()
+	queue := b.queues[sessionKey]
+	return queue != nil && (queue.processing || len(queue.messageIDs) > 0)
+}

--- a/pkg/agent/collaboration_test.go
+++ b/pkg/agent/collaboration_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +17,12 @@ import (
 )
 
 type collaborationReplyProvider struct{}
+
+type collaborationDeadlineProvider struct {
+	mu        sync.Mutex
+	sawCtxTTL bool
+	remaining time.Duration
+}
 
 var (
 	threadIDPattern  = regexp.MustCompile(`Thread ID:\s*([^\n]+)`)
@@ -67,6 +74,32 @@ func (p *collaborationReplyProvider) Chat(
 
 func (p *collaborationReplyProvider) GetDefaultModel() string {
 	return "collaboration-reply-model"
+}
+
+func (p *collaborationDeadlineProvider) Chat(
+	ctx context.Context,
+	_ []providers.Message,
+	_ []providers.ToolDefinition,
+	_ string,
+	_ map[string]any,
+) (*providers.LLMResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if deadline, ok := ctx.Deadline(); ok {
+		p.sawCtxTTL = true
+		p.remaining = time.Until(deadline)
+	}
+	return &providers.LLMResponse{Content: "Timeout observed."}, nil
+}
+
+func (p *collaborationDeadlineProvider) GetDefaultModel() string {
+	return "collaboration-deadline-model"
+}
+
+func (p *collaborationDeadlineProvider) snapshot() (bool, time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.sawCtxTTL, p.remaining
 }
 
 func TestCollaborationBus_RequestWaitTrue_ExplicitReplyAndHistory(t *testing.T) {
@@ -196,6 +229,48 @@ func TestCollaborationBus_RequestWaitFalse_ReplyDurableInInbox(t *testing.T) {
 	}
 	if !strings.Contains(inbox.Messages[0].ContentPreview, "Tradeoffs: faster indexing") {
 		t.Fatalf("inbox.Messages[0].ContentPreview = %q", inbox.Messages[0].ContentPreview)
+	}
+	waitForCollaborationIdle(t, al, reply.ThreadID, "research")
+}
+
+func TestCollaborationBus_RequestWithoutDeadline_UsesSubTurnDefaultTimeout(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := collaborationTestConfig(tmpDir)
+	cfg.Agents.Defaults.SubTurn.DefaultTimeoutMinutes = 1
+	provider := &collaborationDeadlineProvider{}
+	al := NewAgentLoop(cfg, nil, provider)
+	defer al.Close()
+
+	plannerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "planner",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	plannerSessionKey := session.BuildSessionKey(*plannerScope)
+	ctx := tools.WithToolSessionContext(context.Background(), "planner", plannerSessionKey, plannerScope)
+
+	reply, err := al.collaboration.Request(ctx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		Content:       "Verify default timeout handling.",
+		ContextPolicy: collab.ContextPolicyTaskOnly,
+		Wait:          true,
+	})
+	if err != nil {
+		t.Fatalf("Request() error = %v", err)
+	}
+	if reply.Content != "Timeout observed." {
+		t.Fatalf("reply.Content = %q", reply.Content)
+	}
+
+	sawDeadline, remaining := provider.snapshot()
+	if !sawDeadline {
+		t.Fatal("expected collaboration worker context to have a deadline")
+	}
+	if remaining <= 30*time.Second || remaining > time.Minute {
+		t.Fatalf("remaining timeout = %v, want between 30s and 1m", remaining)
 	}
 	waitForCollaborationIdle(t, al, reply.ThreadID, "research")
 }

--- a/pkg/agent/collaboration_test.go
+++ b/pkg/agent/collaboration_test.go
@@ -275,6 +275,79 @@ func TestCollaborationBus_RequestWithoutDeadline_UsesSubTurnDefaultTimeout(t *te
 	waitForCollaborationIdle(t, al, reply.ThreadID, "research")
 }
 
+func TestCollaborationBus_RequestRejectsOversizedSelectedContext(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := collaborationTestConfig(tmpDir)
+	cfg.Agents.List[0].Communication.MaxMessageChars = 20
+	cfg.Agents.List[1].Communication.MaxMessageChars = 20
+	al := NewAgentLoop(cfg, nil, &collaborationReplyProvider{})
+	defer al.Close()
+
+	plannerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "planner",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	plannerSessionKey := session.BuildSessionKey(*plannerScope)
+	ctx := tools.WithToolSessionContext(context.Background(), "planner", plannerSessionKey, plannerScope)
+
+	_, err := al.collaboration.Request(ctx, tools.AgentRequestParams{
+		ToAgentID:       "research",
+		Content:         "ok",
+		ContextPolicy:   collab.ContextPolicySelectedContext,
+		SelectedContext: "this shared context is way too large",
+		Wait:            false,
+	})
+	if err == nil {
+		t.Fatal("expected oversized selected_context to be rejected")
+	}
+	if !strings.Contains(err.Error(), "max_message_chars=20") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestCollaborationBus_RequestRejectsOversizedSummaryContext(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := collaborationTestConfig(tmpDir)
+	cfg.Agents.List[0].Communication.MaxMessageChars = 20
+	cfg.Agents.List[1].Communication.MaxMessageChars = 20
+	al := NewAgentLoop(cfg, nil, &collaborationReplyProvider{})
+	defer al.Close()
+
+	planner, ok := al.GetRegistry().GetAgent("planner")
+	if !ok || planner == nil {
+		t.Fatal("expected planner agent")
+	}
+
+	plannerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "planner",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	plannerSessionKey := session.BuildSessionKey(*plannerScope)
+	planner.Sessions.SetSummary(plannerSessionKey, "this summary is definitely too long")
+
+	ctx := tools.WithToolSessionContext(context.Background(), "planner", plannerSessionKey, plannerScope)
+	_, err := al.collaboration.Request(ctx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		Content:       "ok",
+		ContextPolicy: collab.ContextPolicySummary,
+		Wait:          false,
+	})
+	if err == nil {
+		t.Fatal("expected oversized summary context to be rejected")
+	}
+	if !strings.Contains(err.Error(), "max_message_chars=20") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
 func TestCollaborationBus_RequestBlockedByCommunicationPolicy(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := collaborationTestConfig(tmpDir)

--- a/pkg/agent/collaboration_test.go
+++ b/pkg/agent/collaboration_test.go
@@ -24,6 +24,8 @@ type collaborationDeadlineProvider struct {
 	remaining time.Duration
 }
 
+type collaborationFailProvider struct{}
+
 var (
 	threadIDPattern  = regexp.MustCompile(`Thread ID:\s*([^\n]+)`)
 	messageIDPattern = regexp.MustCompile(`Message ID:\s*([^\n]+)`)
@@ -100,6 +102,20 @@ func (p *collaborationDeadlineProvider) snapshot() (bool, time.Duration) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.sawCtxTTL, p.remaining
+}
+
+func (p *collaborationFailProvider) Chat(
+	_ context.Context,
+	_ []providers.Message,
+	_ []providers.ToolDefinition,
+	_ string,
+	_ map[string]any,
+) (*providers.LLMResponse, error) {
+	return nil, fmt.Errorf("forced collaboration failure")
+}
+
+func (p *collaborationFailProvider) GetDefaultModel() string {
+	return "collaboration-fail-model"
 }
 
 func TestCollaborationBus_RequestWaitTrue_ExplicitReplyAndHistory(t *testing.T) {
@@ -346,6 +362,62 @@ func TestCollaborationBus_RequestRejectsOversizedSummaryContext(t *testing.T) {
 	if !strings.Contains(err.Error(), "max_message_chars=20") {
 		t.Fatalf("err = %v", err)
 	}
+}
+
+func TestCollaborationBus_RequestFailurePreservesErrorStatus(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := collaborationTestConfig(tmpDir)
+	al := NewAgentLoop(cfg, nil, &collaborationFailProvider{})
+	defer al.Close()
+
+	plannerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "planner",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	plannerSessionKey := session.BuildSessionKey(*plannerScope)
+	ctx := tools.WithToolSessionContext(context.Background(), "planner", plannerSessionKey, plannerScope)
+
+	resp, err := al.collaboration.Request(ctx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		Content:       "Trigger a collaboration failure.",
+		ContextPolicy: collab.ContextPolicyTaskOnly,
+		Wait:          true,
+	})
+	if err != nil {
+		t.Fatalf("Request() error = %v", err)
+	}
+	if !strings.Contains(resp.Content, "Collaboration request failed:") ||
+		!strings.Contains(resp.Content, "forced collaboration failure") {
+		t.Fatalf("resp.Content = %q", resp.Content)
+	}
+
+	requestMsg, ok := al.collaboration.store.GetMessage(resp.MessageID)
+	if !ok {
+		t.Fatalf("expected stored request message %s", resp.MessageID)
+	}
+	if requestMsg.Status != collab.StatusError {
+		t.Fatalf("requestMsg.Status = %q, want error", requestMsg.Status)
+	}
+	if !strings.Contains(requestMsg.ErrorSummary, "forced collaboration failure") {
+		t.Fatalf("requestMsg.ErrorSummary = %q", requestMsg.ErrorSummary)
+	}
+
+	statusMsg, ok := al.collaboration.store.GetMessage(resp.ReplyMessageID)
+	if !ok {
+		t.Fatalf("expected stored status reply %s", resp.ReplyMessageID)
+	}
+	if statusMsg.Kind != collab.KindStatus {
+		t.Fatalf("statusMsg.Kind = %q, want status", statusMsg.Kind)
+	}
+	if !strings.Contains(statusMsg.Content, "Collaboration request failed:") ||
+		!strings.Contains(statusMsg.Content, "forced collaboration failure") {
+		t.Fatalf("statusMsg.Content = %q", statusMsg.Content)
+	}
+	waitForCollaborationIdle(t, al, resp.ThreadID, "research")
 }
 
 func TestCollaborationBus_RequestBlockedByCommunicationPolicy(t *testing.T) {

--- a/pkg/agent/collaboration_test.go
+++ b/pkg/agent/collaboration_test.go
@@ -1,0 +1,502 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sipeed/picoclaw/pkg/collab"
+	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sipeed/picoclaw/pkg/providers"
+	"github.com/sipeed/picoclaw/pkg/session"
+	"github.com/sipeed/picoclaw/pkg/tools"
+)
+
+type collaborationReplyProvider struct{}
+
+var (
+	threadIDPattern  = regexp.MustCompile(`Thread ID:\s*([^\n]+)`)
+	messageIDPattern = regexp.MustCompile(`Message ID:\s*([^\n]+)`)
+)
+
+func (p *collaborationReplyProvider) Chat(
+	_ context.Context,
+	messages []providers.Message,
+	toolDefs []providers.ToolDefinition,
+	_ string,
+	_ map[string]any,
+) (*providers.LLMResponse, error) {
+	lastUser := ""
+	hasToolReply := false
+	for _, msg := range messages {
+		if msg.Role == "user" {
+			lastUser = msg.Content
+		}
+		if msg.Role == "tool" && strings.Contains(msg.Content, "Reply recorded in collaboration thread") {
+			hasToolReply = true
+		}
+	}
+
+	if hasToolReply {
+		return &providers.LLMResponse{Content: "Reply sent."}, nil
+	}
+
+	if strings.Contains(lastUser, "[Internal collaboration message]") && hasTool(toolDefs, "agent_reply") {
+		threadID := matchFirst(threadIDPattern, lastUser)
+		messageID := matchFirst(messageIDPattern, lastUser)
+		return &providers.LLMResponse{
+			ToolCalls: []providers.ToolCall{
+				{
+					ID:   "call-agent-reply",
+					Name: "agent_reply",
+					Arguments: map[string]any{
+						"thread_id":   threadID,
+						"in_reply_to": messageID,
+						"content":     "Tradeoffs: faster indexing, clearer ownership, and durable follow-up.",
+					},
+				},
+			},
+		}, nil
+	}
+
+	return &providers.LLMResponse{Content: "generic"}, nil
+}
+
+func (p *collaborationReplyProvider) GetDefaultModel() string {
+	return "collaboration-reply-model"
+}
+
+func TestCollaborationBus_RequestWaitTrue_ExplicitReplyAndHistory(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := collaborationTestConfig(tmpDir)
+	al := NewAgentLoop(cfg, nil, &collaborationReplyProvider{})
+	defer al.Close()
+
+	planner, ok := al.GetRegistry().GetAgent("planner")
+	if !ok || planner == nil {
+		t.Fatal("expected planner agent")
+	}
+	research, ok := al.GetRegistry().GetAgent("research")
+	if !ok || research == nil {
+		t.Fatal("expected research agent")
+	}
+	if al.collaboration == nil {
+		t.Fatal("expected collaboration bus to be initialized")
+	}
+
+	plannerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "planner",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	plannerSessionKey := session.BuildSessionKey(*plannerScope)
+	ctx := tools.WithToolSessionContext(context.Background(), planner.ID, plannerSessionKey, plannerScope)
+
+	reply, err := al.collaboration.Request(ctx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		Content:       "Please investigate the collaboration bus tradeoffs.",
+		ContextPolicy: collab.ContextPolicyTaskOnly,
+		Wait:          true,
+	})
+	if err != nil {
+		t.Fatalf("Request() error = %v", err)
+	}
+	if reply.Content != "Tradeoffs: faster indexing, clearer ownership, and durable follow-up." {
+		t.Fatalf("reply.Content = %q", reply.Content)
+	}
+	if reply.FromAgentID != "research" {
+		t.Fatalf("reply.FromAgentID = %q, want research", reply.FromAgentID)
+	}
+
+	inbox, err := al.collaboration.Inbox(ctx, tools.AgentInboxParams{ThreadID: reply.ThreadID})
+	if err != nil {
+		t.Fatalf("Inbox() error = %v", err)
+	}
+	if len(inbox.Messages) != 1 {
+		t.Fatalf("Inbox messages = %d, want 1", len(inbox.Messages))
+	}
+	if inbox.Messages[0].FromAgentID != "research" || inbox.Messages[0].Kind != collab.KindReply {
+		t.Fatalf("Inbox message = %+v", inbox.Messages[0])
+	}
+
+	researchSessionKey := collaborationSessionKey("research", reply.ThreadID)
+	history := research.Sessions.GetHistory(researchSessionKey)
+	if len(history) < 2 {
+		t.Fatalf("research history len = %d, want at least 2", len(history))
+	}
+	if !strings.Contains(history[0].Content, "Please investigate the collaboration bus tradeoffs.") {
+		t.Fatalf("first history message = %q", history[0].Content)
+	}
+	foundReplyHistory := false
+	for _, msg := range history {
+		if strings.Contains(msg.Content, "Tradeoffs: faster indexing, clearer ownership, and durable follow-up.") {
+			foundReplyHistory = true
+			break
+		}
+	}
+	if !foundReplyHistory {
+		t.Fatalf("expected reply content to be present in research session history: %#v", history)
+	}
+	waitForCollaborationIdle(t, al, reply.ThreadID, "research")
+}
+
+func TestCollaborationBus_RequestWaitFalse_ReplyDurableInInbox(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := collaborationTestConfig(tmpDir)
+	al := NewAgentLoop(cfg, nil, &collaborationReplyProvider{})
+	defer al.Close()
+
+	plannerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "planner",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	plannerSessionKey := session.BuildSessionKey(*plannerScope)
+	ctx := tools.WithToolSessionContext(context.Background(), "planner", plannerSessionKey, plannerScope)
+
+	reply, err := al.collaboration.Request(ctx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		Content:       "Need a durable async reply.",
+		ContextPolicy: collab.ContextPolicyTaskOnly,
+		Wait:          false,
+	})
+	if err != nil {
+		t.Fatalf("Request() error = %v", err)
+	}
+	if reply.ThreadID == "" || reply.MessageID == "" {
+		t.Fatalf("async response = %+v", reply)
+	}
+
+	var inbox *tools.AgentInboxResponse
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		inbox, err = al.collaboration.Inbox(ctx, tools.AgentInboxParams{ThreadID: reply.ThreadID})
+		if err != nil {
+			t.Fatalf("Inbox() error = %v", err)
+		}
+		if len(inbox.Messages) > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if inbox == nil || len(inbox.Messages) == 0 {
+		t.Fatal("expected durable reply to appear in sender inbox")
+	}
+	if inbox.Messages[0].Status != collab.StatusDelivered {
+		t.Fatalf("inbox.Messages[0].Status = %q, want delivered", inbox.Messages[0].Status)
+	}
+	if !strings.Contains(inbox.Messages[0].ContentPreview, "Tradeoffs: faster indexing") {
+		t.Fatalf("inbox.Messages[0].ContentPreview = %q", inbox.Messages[0].ContentPreview)
+	}
+	waitForCollaborationIdle(t, al, reply.ThreadID, "research")
+}
+
+func TestCollaborationBus_RequestBlockedByCommunicationPolicy(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := collaborationTestConfig(tmpDir)
+	cfg.Agents.List[1].Communication.AllowReceiveFrom = nil
+	al := NewAgentLoop(cfg, nil, &collaborationReplyProvider{})
+	defer al.Close()
+
+	plannerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "planner",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	plannerSessionKey := session.BuildSessionKey(*plannerScope)
+	ctx := tools.WithToolSessionContext(context.Background(), "planner", plannerSessionKey, plannerScope)
+
+	_, err := al.collaboration.Request(ctx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		Content:       "Should be blocked.",
+		ContextPolicy: collab.ContextPolicyTaskOnly,
+		Wait:          true,
+	})
+	if err == nil {
+		t.Fatal("expected collaboration request to be blocked")
+	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestCollaborationBus_RequestRejectsThreadParticipantHijack(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := collaborationTestConfig(tmpDir)
+	cfg.Agents.List = append(cfg.Agents.List, config.AgentConfig{
+		ID: "reviewer",
+		Communication: &config.AgentCommunicationConfig{
+			AllowSendTo:      []string{"research"},
+			AllowReceiveFrom: []string{"research"},
+			MaxThreadTurns:   8,
+			MaxMessageChars:  12000,
+		},
+	})
+	cfg.Agents.List[1].Communication.AllowSendTo = []string{"planner", "reviewer"}
+	cfg.Agents.List[1].Communication.AllowReceiveFrom = []string{"planner", "reviewer"}
+
+	al := NewAgentLoop(cfg, nil, &collaborationReplyProvider{})
+	defer al.Close()
+
+	plannerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "planner",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	plannerSessionKey := session.BuildSessionKey(*plannerScope)
+	plannerCtx := tools.WithToolSessionContext(context.Background(), "planner", plannerSessionKey, plannerScope)
+
+	reply, err := al.collaboration.Request(plannerCtx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		Content:       "Open the original collaboration thread.",
+		ContextPolicy: collab.ContextPolicyTaskOnly,
+		Wait:          true,
+	})
+	if err != nil {
+		t.Fatalf("planner Request() error = %v", err)
+	}
+	waitForCollaborationIdle(t, al, reply.ThreadID, "research")
+
+	reviewerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "reviewer",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	reviewerSessionKey := session.BuildSessionKey(*reviewerScope)
+	reviewerCtx := tools.WithToolSessionContext(context.Background(), "reviewer", reviewerSessionKey, reviewerScope)
+
+	_, err = al.collaboration.Request(reviewerCtx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		ThreadID:      reply.ThreadID,
+		Content:       "Attempt to hijack the existing thread.",
+		ContextPolicy: collab.ContextPolicyTaskOnly,
+		Wait:          false,
+	})
+	if err == nil {
+		t.Fatal("expected thread participant hijack to be rejected")
+	}
+	if !strings.Contains(err.Error(), "does not include both agent") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestCollaborationBus_FollowUpRequestLinksParentMessage(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := collaborationTestConfig(tmpDir)
+	al := NewAgentLoop(cfg, nil, &collaborationReplyProvider{})
+	defer al.Close()
+
+	plannerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "planner",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	plannerSessionKey := session.BuildSessionKey(*plannerScope)
+	plannerCtx := tools.WithToolSessionContext(context.Background(), "planner", plannerSessionKey, plannerScope)
+
+	firstReply, err := al.collaboration.Request(plannerCtx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		Content:       "Open a thread for a follow-up request.",
+		ContextPolicy: collab.ContextPolicyTaskOnly,
+		Wait:          true,
+	})
+	if err != nil {
+		t.Fatalf("first Request() error = %v", err)
+	}
+	waitForCollaborationIdle(t, al, firstReply.ThreadID, "research")
+
+	followUp, err := al.collaboration.Request(plannerCtx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		ThreadID:      firstReply.ThreadID,
+		Content:       "Follow up with another question.",
+		ContextPolicy: collab.ContextPolicyTaskOnly,
+		Wait:          false,
+	})
+	if err != nil {
+		t.Fatalf("follow-up Request() error = %v", err)
+	}
+
+	message, ok := al.collaboration.store.GetMessage(followUp.MessageID)
+	if !ok {
+		t.Fatalf("expected stored follow-up message %s", followUp.MessageID)
+	}
+	if message.ParentID != firstReply.ReplyMessageID {
+		t.Fatalf("message.ParentID = %q, want %q", message.ParentID, firstReply.ReplyMessageID)
+	}
+	waitForCollaborationIdle(t, al, firstReply.ThreadID, "research")
+}
+
+func TestCollaborationBus_ClosedThreadRejectsNewMessages(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := collaborationTestConfig(tmpDir)
+	al := NewAgentLoop(cfg, nil, &collaborationReplyProvider{})
+	defer al.Close()
+
+	plannerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "planner",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	plannerSessionKey := session.BuildSessionKey(*plannerScope)
+	plannerCtx := tools.WithToolSessionContext(context.Background(), "planner", plannerSessionKey, plannerScope)
+
+	reply, err := al.collaboration.Request(plannerCtx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		Content:       "Create a thread that will be closed.",
+		ContextPolicy: collab.ContextPolicyTaskOnly,
+		Wait:          true,
+	})
+	if err != nil {
+		t.Fatalf("planner Request() error = %v", err)
+	}
+	waitForCollaborationIdle(t, al, reply.ThreadID, "research")
+
+	if _, closeErr := al.collaboration.store.CloseThread(reply.ThreadID, "test close"); closeErr != nil {
+		t.Fatalf("CloseThread() error = %v", closeErr)
+	}
+
+	_, err = al.collaboration.Request(plannerCtx, tools.AgentRequestParams{
+		ToAgentID:     "research",
+		ThreadID:      reply.ThreadID,
+		Content:       "This follow-up should be rejected.",
+		ContextPolicy: collab.ContextPolicyTaskOnly,
+		Wait:          false,
+	})
+	if err == nil {
+		t.Fatal("expected request on closed thread to be rejected")
+	}
+	if !strings.Contains(err.Error(), "is closed") {
+		t.Fatalf("request err = %v", err)
+	}
+
+	researchScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "research",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	researchSessionKey := session.BuildSessionKey(*researchScope)
+	researchCtx := tools.WithToolSessionContext(context.Background(), "research", researchSessionKey, researchScope)
+
+	_, err = al.collaboration.Reply(researchCtx, tools.AgentReplyParams{
+		ThreadID:  reply.ThreadID,
+		InReplyTo: reply.MessageID,
+		Content:   "This reply should also be rejected.",
+	})
+	if err == nil {
+		t.Fatal("expected reply on closed thread to be rejected")
+	}
+	if !strings.Contains(err.Error(), "is closed") {
+		t.Fatalf("reply err = %v", err)
+	}
+}
+
+func collaborationTestConfig(workspace string) *config.Config {
+	return &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         workspace,
+				ModelName:         "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 4,
+			},
+			List: []config.AgentConfig{
+				{
+					ID: "planner",
+					Communication: &config.AgentCommunicationConfig{
+						AllowSendTo:      []string{"research"},
+						AllowReceiveFrom: []string{"research"},
+						MaxThreadTurns:   8,
+						MaxMessageChars:  12000,
+					},
+				},
+				{
+					ID: "research",
+					Communication: &config.AgentCommunicationConfig{
+						AllowSendTo:      []string{"planner"},
+						AllowReceiveFrom: []string{"planner"},
+						MaxThreadTurns:   8,
+						MaxMessageChars:  12000,
+					},
+				},
+			},
+		},
+	}
+}
+
+func hasTool(toolDefs []providers.ToolDefinition, name string) bool {
+	for _, toolDef := range toolDefs {
+		if toolDef.Function.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func matchFirst(pattern *regexp.Regexp, value string) string {
+	match := pattern.FindStringSubmatch(value)
+	if len(match) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(match[1])
+}
+
+func TestCollaborationSessionAliases_AreStable(t *testing.T) {
+	aliases := collaborationSessionAliases("Research", "thread_123")
+	if len(aliases) != 1 {
+		t.Fatalf("aliases = %v", aliases)
+	}
+	want := "agent:research:inter-agent:thread:thread_123"
+	if aliases[0] != want {
+		t.Fatalf("aliases[0] = %q, want %q", aliases[0], want)
+	}
+	if got := collaborationSessionKey("research", "thread_123"); got == "" {
+		t.Fatal("collaborationSessionKey should not be empty")
+	}
+	if got := fmt.Sprintf(
+		"%v",
+		collaborationSessionScope("research", "thread_123").Values["thread"],
+	); got != "thread_123" {
+		t.Fatalf("thread scope value = %q", got)
+	}
+}
+
+func waitForCollaborationIdle(t *testing.T, al *AgentLoop, threadID, targetAgentID string) {
+	t.Helper()
+
+	sessionKey := collaborationSessionKey(targetAgentID, threadID)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if al.GetActiveTurnBySession(sessionKey) == nil && !al.collaboration.isQueueActive(sessionKey) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("collaboration session %s did not become idle", sessionKey)
+}

--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -1004,7 +1004,15 @@ func (cb *ContextBuilder) BuildMessagesFromPrompt(req PromptBuildRequest) []prov
 	// Add current user message. Media-only turns must still be preserved so
 	// multimodal providers receive the uploaded image even when the user sends
 	// no accompanying text.
-	if strings.TrimSpace(req.CurrentMessage) != "" || len(req.Media) > 0 {
+	if req.CurrentPromptMessage != nil {
+		msg := clonePromptMessage(req.CurrentPromptMessage)
+		messages = append(messages, promptMessageWithDefaultMetadata(
+			*msg,
+			PromptLayerTurn,
+			PromptSlotMessage,
+			PromptSourceUserMessage,
+		))
+	} else if strings.TrimSpace(req.CurrentMessage) != "" || len(req.Media) > 0 {
 		messages = append(messages, userPromptMessage(req.CurrentMessage, req.Media))
 	}
 	if len(messages) == 0 {

--- a/pkg/agent/delegate_regression_test.go
+++ b/pkg/agent/delegate_regression_test.go
@@ -1,0 +1,136 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sipeed/picoclaw/pkg/session"
+	toolspkg "github.com/sipeed/picoclaw/pkg/tools"
+)
+
+func TestDelegateTool_SubagentsOnlyConfig_UsesSubTurnPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	plannerDir := filepath.Join(tmpDir, "planner")
+	researchDir := filepath.Join(tmpDir, "research")
+	if err := os.MkdirAll(plannerDir, 0o755); err != nil {
+		t.Fatalf("mkdir planner workspace: %v", err)
+	}
+	if err := os.MkdirAll(researchDir, 0o755); err != nil {
+		t.Fatalf("mkdir research workspace: %v", err)
+	}
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				ModelName:         "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 4,
+			},
+			List: []config.AgentConfig{
+				{
+					ID:        "planner",
+					Default:   true,
+					Workspace: plannerDir,
+					Subagents: &config.SubagentsConfig{
+						AllowAgents: []string{"research"},
+					},
+				},
+				{
+					ID:        "research",
+					Workspace: researchDir,
+				},
+			},
+		},
+	}
+
+	al := NewAgentLoop(cfg, bus.NewMessageBus(), &plainProvider{})
+	defer al.Close()
+
+	planner, ok := al.registry.GetAgent("planner")
+	if !ok || planner == nil {
+		t.Fatal("expected planner agent")
+	}
+	delegateTool, ok := planner.Tools.Get("delegate")
+	if !ok {
+		t.Fatal("expected delegate tool")
+	}
+
+	parent := &turnState{
+		ctx:            context.Background(),
+		turnID:         "parent-planner",
+		agent:          planner,
+		agentID:        planner.ID,
+		session:        newEphemeralSession(nil),
+		pendingResults: make(chan *toolspkg.ToolResult, 4),
+		concurrencySem: make(chan struct{}, testMaxConcurrentSubTurns),
+	}
+
+	result := delegateTool.Execute(withTurnState(context.Background(), parent), map[string]any{
+		"agent_id": "research",
+		"task":     "Summarize the logs",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected delegate to use sub-turn path, got error: %s", result.ForLLM)
+	}
+	if !strings.Contains(result.ForLLM, `[Response from agent "research"]`) {
+		t.Fatalf("result.ForLLM = %q", result.ForLLM)
+	}
+}
+
+func TestDelegateTool_CommunicationOnlyConfig_UsesCollaborationPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := collaborationTestConfig(tmpDir)
+	al := NewAgentLoop(cfg, bus.NewMessageBus(), &collaborationReplyProvider{})
+	defer al.Close()
+
+	planner, ok := al.registry.GetAgent("planner")
+	if !ok || planner == nil {
+		t.Fatal("expected planner agent")
+	}
+	delegateTool, ok := planner.Tools.Get("delegate")
+	if !ok {
+		t.Fatal("expected delegate tool")
+	}
+
+	plannerScope := &session.SessionScope{
+		Version:    session.ScopeVersionV1,
+		AgentID:    "planner",
+		Channel:    "cli",
+		Account:    "default",
+		Dimensions: []string{"chat"},
+		Values:     map[string]string{"chat": "direct:tester"},
+	}
+	plannerSessionKey := session.BuildSessionKey(*plannerScope)
+	ctx := toolspkg.WithToolSessionContext(context.Background(), "planner", plannerSessionKey, plannerScope)
+
+	result := delegateTool.Execute(ctx, map[string]any{
+		"agent_id": "research",
+		"task":     "Summarize the collaboration tradeoffs",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected delegate to use collaboration path, got error: %s", result.ForLLM)
+	}
+	if !strings.Contains(result.ForLLM, `[Response from agent "research"]`) {
+		t.Fatalf("result.ForLLM = %q", result.ForLLM)
+	}
+	if !strings.Contains(result.ForLLM, "Tradeoffs: faster indexing") {
+		t.Fatalf("result.ForLLM = %q", result.ForLLM)
+	}
+
+	inbox, err := al.collaboration.Inbox(ctx, toolspkg.AgentInboxParams{})
+	if err != nil {
+		t.Fatalf("Inbox() error = %v", err)
+	}
+	if len(inbox.Messages) == 0 {
+		t.Fatal("expected collaboration reply in planner inbox")
+	}
+	waitForCollaborationIdle(t, al, inbox.Messages[0].ThreadID, "research")
+}

--- a/pkg/agent/event_payloads.go
+++ b/pkg/agent/event_payloads.go
@@ -191,6 +191,29 @@ type SubTurnOrphanPayload struct {
 	Reason       string
 }
 
+// AgentMessageEventPayload describes collaboration-bus message flow without logging raw content.
+type AgentMessageEventPayload struct {
+	ThreadID        string
+	MessageID       string
+	ParentMessageID string
+	FromAgentID     string
+	ToAgentID       string
+	Status          string
+	TraceID         string
+	ParentTurnID    string
+	Priority        string
+	Deadline        *time.Time
+	ArtifactCount   int
+}
+
+// AgentThreadClosedPayload describes closure of a collaboration thread.
+type AgentThreadClosedPayload struct {
+	ThreadID     string
+	Status       string
+	CloseReason  string
+	Participants []string
+}
+
 // ErrorPayload describes an execution error inside the agent loop.
 type ErrorPayload struct {
 	Stage   string

--- a/pkg/agent/events_runtime.go
+++ b/pkg/agent/events_runtime.go
@@ -43,7 +43,9 @@ func runtimeCorrelationFromHookMeta(meta HookMeta) runtimeevents.Correlation {
 
 func runtimeSeverityForAgentEvent(kind runtimeevents.Kind, payload any) runtimeevents.Severity {
 	switch kind {
-	case runtimeevents.KindAgentError, runtimeevents.KindAgentSubTurnOrphan:
+	case runtimeevents.KindAgentError,
+		runtimeevents.KindAgentSubTurnOrphan,
+		runtimeevents.KindAgentMessageBlocked:
 		return runtimeevents.SeverityError
 	case runtimeevents.KindAgentLLMRetry,
 		runtimeevents.KindAgentContextCompress,

--- a/pkg/agent/hook_mount.go
+++ b/pkg/agent/hook_mount.go
@@ -334,6 +334,12 @@ func validHookEventKinds() map[string]string {
 	kinds["subturn_end"] = runtimeevents.KindAgentSubTurnEnd.String()
 	kinds["subturn_result_delivered"] = runtimeevents.KindAgentSubTurnResultDelivered.String()
 	kinds["subturn_orphan"] = runtimeevents.KindAgentSubTurnOrphan.String()
+	kinds["message_sent"] = runtimeevents.KindAgentMessageSent.String()
+	kinds["message_delivered"] = runtimeevents.KindAgentMessageDelivered.String()
+	kinds["message_received"] = runtimeevents.KindAgentMessageReceived.String()
+	kinds["message_reply"] = runtimeevents.KindAgentMessageReply.String()
+	kinds["message_blocked"] = runtimeevents.KindAgentMessageBlocked.String()
+	kinds["thread_closed"] = runtimeevents.KindAgentThreadClosed.String()
 	kinds["error"] = runtimeevents.KindAgentError.String()
 	return kinds
 }

--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -41,6 +41,7 @@ type AgentInstance struct {
 	Tools                     *tools.ToolRegistry
 	Definition                AgentContextDefinition
 	Subagents                 *config.SubagentsConfig
+	Communication             *config.AgentCommunicationConfig
 	SkillsFilter              []string
 	MCPServerAllowlist        map[string]struct{}
 	Candidates                []providers.FallbackCandidate
@@ -140,6 +141,7 @@ func NewAgentInstance(
 	agentID := routing.DefaultAgentID
 	agentName := ""
 	var subagents *config.SubagentsConfig
+	var communication *config.AgentCommunicationConfig
 	var skillsFilter []string
 
 	if agentCfg != nil {
@@ -149,6 +151,7 @@ func NewAgentInstance(
 			agentName = strings.TrimSpace(definition.Agent.Frontmatter.Name)
 		}
 		subagents = agentCfg.Subagents
+		communication = agentCfg.Communication
 		skillsFilter = resolveAgentSkillsFilter(agentCfg, definition)
 	}
 	provider = resolvePrimaryProviderForAgent(cfg, workspace, agentID, model, provider)
@@ -263,6 +266,7 @@ func NewAgentInstance(
 		Tools:                     toolsRegistry,
 		Definition:                definition,
 		Subagents:                 subagents,
+		Communication:             communication,
 		SkillsFilter:              skillsFilter,
 		MCPServerAllowlist:        agentMCPServerAllowlist,
 		Candidates:                candidates,

--- a/pkg/agent/pipeline_setup.go
+++ b/pkg/agent/pipeline_setup.go
@@ -108,15 +108,17 @@ func (p *Pipeline) SetupTurn(ctx context.Context, ts *turnState) (*turnExecution
 		}
 	}
 
-	if !ts.opts.NoHistory && (strings.TrimSpace(ts.userMessage) != "" || len(ts.media) > 0) {
-		rootMsg := userPromptMessage(ts.userMessage, ts.media)
-		if len(rootMsg.Media) > 0 {
-			ts.agent.Sessions.AddFullMessage(ts.sessionKey, rootMsg)
-		} else {
-			ts.agent.Sessions.AddMessage(ts.sessionKey, rootMsg.Role, rootMsg.Content)
+	if !ts.opts.NoHistory {
+		rootMsg := ts.rootPromptHistoryMessage()
+		if rootMsg != nil {
+			if len(rootMsg.Media) > 0 || len(rootMsg.Attachments) > 0 {
+				ts.agent.Sessions.AddFullMessage(ts.sessionKey, *rootMsg)
+			} else {
+				ts.agent.Sessions.AddMessage(ts.sessionKey, rootMsg.Role, rootMsg.Content)
+			}
+			ts.recordPersistedMessage(*rootMsg)
+			ts.ingestMessage(ctx, p.al, *rootMsg)
 		}
-		ts.recordPersistedMessage(rootMsg)
-		ts.ingestMessage(ctx, p.al, rootMsg)
 	}
 
 	activeCandidates, activeModel, usedLight := p.al.selectCandidates(ts.agent, ts.userMessage, messages)

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -44,23 +44,24 @@ const (
 type PromptSourceID string
 
 const (
-	PromptSourceKernel         PromptSourceID = "runtime.kernel"
-	PromptSourceHierarchy      PromptSourceID = "runtime.hierarchy"
-	PromptSourceWorkspace      PromptSourceID = "workspace.definition"
-	PromptSourceRuntime        PromptSourceID = "runtime.context"
-	PromptSourceSummary        PromptSourceID = "context.summary"
-	PromptSourceMemory         PromptSourceID = "memory:workspace"
-	PromptSourceSkillCatalog   PromptSourceID = "skill:index"
-	PromptSourceActiveSkills   PromptSourceID = "skill:active"
-	PromptSourceAgentDiscovery PromptSourceID = "agent:discovery"
-	PromptSourceToolRegistry   PromptSourceID = "tool_registry:native"
-	PromptSourceToolDiscovery  PromptSourceID = "tool_registry:discovery"
-	PromptSourceOutputPolicy   PromptSourceID = "runtime.output"
-	PromptSourceSubTurnProfile PromptSourceID = "subturn.profile"
-	PromptSourceUserMessage    PromptSourceID = "turn:user_message"
-	PromptSourceSteering       PromptSourceID = "turn:steering"
-	PromptSourceSubTurnResult  PromptSourceID = "turn:subturn_result"
-	PromptSourceInterrupt      PromptSourceID = "turn:interrupt"
+	PromptSourceKernel            PromptSourceID = "runtime.kernel"
+	PromptSourceHierarchy         PromptSourceID = "runtime.hierarchy"
+	PromptSourceWorkspace         PromptSourceID = "workspace.definition"
+	PromptSourceRuntime           PromptSourceID = "runtime.context"
+	PromptSourceSummary           PromptSourceID = "context.summary"
+	PromptSourceMemory            PromptSourceID = "memory:workspace"
+	PromptSourceSkillCatalog      PromptSourceID = "skill:index"
+	PromptSourceActiveSkills      PromptSourceID = "skill:active"
+	PromptSourceAgentDiscovery    PromptSourceID = "agent:discovery"
+	PromptSourceToolRegistry      PromptSourceID = "tool_registry:native"
+	PromptSourceToolDiscovery     PromptSourceID = "tool_registry:discovery"
+	PromptSourceOutputPolicy      PromptSourceID = "runtime.output"
+	PromptSourceSubTurnProfile    PromptSourceID = "subturn.profile"
+	PromptSourceUserMessage       PromptSourceID = "turn:user_message"
+	PromptSourceInterAgentMessage PromptSourceID = "turn:inter_agent_message"
+	PromptSourceSteering          PromptSourceID = "turn:steering"
+	PromptSourceSubTurnResult     PromptSourceID = "turn:subturn_result"
+	PromptSourceInterrupt         PromptSourceID = "turn:interrupt"
 )
 
 type PromptCachePolicy string
@@ -105,8 +106,9 @@ type PromptBuildRequest struct {
 	History []providers.Message
 	Summary string
 
-	CurrentMessage string
-	Media          []string
+	CurrentMessage       string
+	CurrentPromptMessage *providers.Message
+	Media                []string
 
 	Channel           string
 	ChatID            string
@@ -201,6 +203,13 @@ func builtinPromptSources() []PromptSourceDescriptor {
 			Owner:           "skills",
 			Description:     "Active skill instructions for the current request",
 			Allowed:         []PromptPlacement{{Layer: PromptLayerCapability, Slot: PromptSlotActiveSkill}},
+			StableByDefault: false,
+		},
+		{
+			ID:              PromptSourceInterAgentMessage,
+			Owner:           "agent",
+			Description:     "Internal collaboration message from another agent",
+			Allowed:         []PromptPlacement{{Layer: PromptLayerTurn, Slot: PromptSlotMessage}},
 			StableByDefault: false,
 		},
 		{

--- a/pkg/agent/prompt_turn.go
+++ b/pkg/agent/prompt_turn.go
@@ -17,16 +17,17 @@ func promptBuildRequestForTurn(
 	cfg *config.Config,
 ) PromptBuildRequest {
 	req := PromptBuildRequest{
-		History:           history,
-		Summary:           summary,
-		CurrentMessage:    currentMessage,
-		Media:             append([]string(nil), media...),
-		Channel:           ts.channel,
-		ChatID:            ts.chatID,
-		SenderID:          ts.opts.Dispatch.SenderID(),
-		SenderDisplayName: ts.opts.SenderDisplayName,
-		ActiveSkills:      activeSkillNames(ts.agent, ts.opts),
-		Overlays:          promptOverlaysForOptions(ts.opts),
+		History:              history,
+		Summary:              summary,
+		CurrentMessage:       currentMessage,
+		CurrentPromptMessage: clonePromptMessage(ts.rootPromptMessage),
+		Media:                append([]string(nil), media...),
+		Channel:              ts.channel,
+		ChatID:               ts.chatID,
+		SenderID:             ts.opts.Dispatch.SenderID(),
+		SenderDisplayName:    ts.opts.SenderDisplayName,
+		ActiveSkills:         activeSkillNames(ts.agent, ts.opts),
+		Overlays:             promptOverlaysForOptions(ts.opts),
 	}
 	hasCallableTools := true
 	if ts.profile.Enabled {
@@ -80,16 +81,17 @@ func promptBuildRequestForProcessOptions(
 	media []string,
 ) PromptBuildRequest {
 	req := PromptBuildRequest{
-		History:           history,
-		Summary:           summary,
-		CurrentMessage:    currentMessage,
-		Media:             append([]string(nil), media...),
-		Channel:           opts.Channel,
-		ChatID:            opts.ChatID,
-		SenderID:          opts.SenderID,
-		SenderDisplayName: opts.SenderDisplayName,
-		ActiveSkills:      activeSkillNames(agent, opts),
-		Overlays:          promptOverlaysForOptions(opts),
+		History:              history,
+		Summary:              summary,
+		CurrentMessage:       currentMessage,
+		CurrentPromptMessage: clonePromptMessage(opts.RootPromptMessage),
+		Media:                append([]string(nil), media...),
+		Channel:              opts.Channel,
+		ChatID:               opts.ChatID,
+		SenderID:             opts.SenderID,
+		SenderDisplayName:    opts.SenderDisplayName,
+		ActiveSkills:         activeSkillNames(agent, opts),
+		Overlays:             promptOverlaysForOptions(opts),
 	}
 	profile := opts.TurnProfile
 	hasCallableTools := true
@@ -192,6 +194,37 @@ func userPromptMessage(content string, media []string) providers.Message {
 		msg.Media = append([]string(nil), media...)
 	}
 	return promptMessageWithMetadata(msg, PromptLayerTurn, PromptSlotMessage, PromptSourceUserMessage)
+}
+
+func interAgentPromptMessage(content string, attachments []providers.Attachment) providers.Message {
+	msg := providers.Message{
+		Role:    "user",
+		Content: content,
+	}
+	if len(attachments) > 0 {
+		msg.Attachments = append([]providers.Attachment(nil), attachments...)
+	}
+	return promptMessageWithMetadata(msg, PromptLayerTurn, PromptSlotMessage, PromptSourceInterAgentMessage)
+}
+
+func clonePromptMessage(msg *providers.Message) *providers.Message {
+	if msg == nil {
+		return nil
+	}
+	cloned := *msg
+	if len(msg.Media) > 0 {
+		cloned.Media = append([]string(nil), msg.Media...)
+	}
+	if len(msg.Attachments) > 0 {
+		cloned.Attachments = append([]providers.Attachment(nil), msg.Attachments...)
+	}
+	if len(msg.SystemParts) > 0 {
+		cloned.SystemParts = append([]providers.ContentBlock(nil), msg.SystemParts...)
+	}
+	if len(msg.ToolCalls) > 0 {
+		cloned.ToolCalls = append([]providers.ToolCall(nil), msg.ToolCalls...)
+	}
+	return &cloned
 }
 
 func steeringPromptMessage(msg providers.Message) providers.Message {

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -19,6 +19,11 @@ type AgentRegistry struct {
 	mu       sync.RWMutex
 }
 
+const (
+	defaultCommunicationMaxThreadTurns  = 8
+	defaultCommunicationMaxMessageChars = 12000
+)
+
 // NewAgentRegistry creates a registry from config, instantiating all agents.
 func NewAgentRegistry(
 	cfg *config.Config,
@@ -122,6 +127,65 @@ func (r *AgentRegistry) CanSpawnSubagent(parentAgentID, targetAgentID string) bo
 	return agentAllowsSubagent(parent, routing.NormalizeAgentID(targetAgentID))
 }
 
+func (r *AgentRegistry) CanSendCollaboration(parentAgentID, targetAgentID string) bool {
+	parent, ok := r.GetAgent(parentAgentID)
+	if !ok {
+		return false
+	}
+
+	targetNorm := routing.NormalizeAgentID(targetAgentID)
+	for _, allowed := range resolvedCommunicationSendTargets(parent) {
+		if allowed == "*" || routing.NormalizeAgentID(allowed) == targetNorm {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *AgentRegistry) CanReceiveCollaboration(targetAgentID, fromAgentID string) bool {
+	target, ok := r.GetAgent(targetAgentID)
+	if !ok {
+		return false
+	}
+
+	fromNorm := routing.NormalizeAgentID(fromAgentID)
+	for _, allowed := range resolvedCommunicationReceiveSources(target) {
+		if allowed == "*" || routing.NormalizeAgentID(allowed) == fromNorm {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *AgentRegistry) CanCollaborate(fromAgentID, targetAgentID string) bool {
+	return r.CanSendCollaboration(fromAgentID, targetAgentID) &&
+		r.CanReceiveCollaboration(targetAgentID, fromAgentID)
+}
+
+func (r *AgentRegistry) CommunicationMaxThreadTurns(agentID string) int {
+	agent, ok := r.GetAgent(agentID)
+	if !ok {
+		return defaultCommunicationMaxThreadTurns
+	}
+	return communicationMaxThreadTurns(agent)
+}
+
+func (r *AgentRegistry) CommunicationMaxMessageChars(agentID string) int {
+	agent, ok := r.GetAgent(agentID)
+	if !ok {
+		return defaultCommunicationMaxMessageChars
+	}
+	return communicationMaxMessageChars(agent)
+}
+
+func (r *AgentRegistry) CommunicationAllowsArtifacts(agentID string) bool {
+	agent, ok := r.GetAgent(agentID)
+	if !ok {
+		return false
+	}
+	return communicationAllowsArtifacts(agent)
+}
+
 func agentAllowsSubagent(parent *AgentInstance, targetNorm string) bool {
 	if parent == nil || parent.Subagents == nil || parent.Subagents.AllowAgents == nil {
 		return false
@@ -135,6 +199,55 @@ func agentAllowsSubagent(parent *AgentInstance, targetNorm string) bool {
 		}
 	}
 	return false
+}
+
+func resolvedCommunicationSendTargets(agent *AgentInstance) []string {
+	if agent == nil {
+		return nil
+	}
+	if agentCommunication := communicationConfig(agent); agentCommunication != nil &&
+		agentCommunication.AllowSendTo != nil {
+		return append([]string(nil), agentCommunication.AllowSendTo...)
+	}
+	if agent.Subagents != nil && agent.Subagents.AllowAgents != nil {
+		return append([]string(nil), agent.Subagents.AllowAgents...)
+	}
+	return nil
+}
+
+func resolvedCommunicationReceiveSources(agent *AgentInstance) []string {
+	if cfg := communicationConfig(agent); cfg != nil && cfg.AllowReceiveFrom != nil {
+		return append([]string(nil), cfg.AllowReceiveFrom...)
+	}
+	return nil
+}
+
+func communicationMaxThreadTurns(agent *AgentInstance) int {
+	cfg := communicationConfig(agent)
+	if cfg != nil && cfg.MaxThreadTurns > 0 {
+		return cfg.MaxThreadTurns
+	}
+	return defaultCommunicationMaxThreadTurns
+}
+
+func communicationMaxMessageChars(agent *AgentInstance) int {
+	cfg := communicationConfig(agent)
+	if cfg != nil && cfg.MaxMessageChars > 0 {
+		return cfg.MaxMessageChars
+	}
+	return defaultCommunicationMaxMessageChars
+}
+
+func communicationAllowsArtifacts(agent *AgentInstance) bool {
+	cfg := communicationConfig(agent)
+	return cfg != nil && cfg.AllowArtifacts
+}
+
+func communicationConfig(agent *AgentInstance) *config.AgentCommunicationConfig {
+	if agent == nil {
+		return nil
+	}
+	return agent.Communication
 }
 
 func agentHasSpawnTool(agent *AgentInstance) bool {

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -163,6 +163,57 @@ func TestAgentRegistry_CanSpawnSubagent_Wildcard(t *testing.T) {
 	}
 }
 
+func TestAgentRegistry_CanCollaborate_RequiresSendAndReceive(t *testing.T) {
+	cfg := testCfg([]config.AgentConfig{
+		{
+			ID: "planner",
+			Subagents: &config.SubagentsConfig{
+				AllowAgents: []string{"research"},
+			},
+			Communication: &config.AgentCommunicationConfig{
+				AllowReceiveFrom: []string{"research"},
+			},
+		},
+		{
+			ID: "research",
+			Communication: &config.AgentCommunicationConfig{
+				AllowReceiveFrom: []string{"planner"},
+			},
+		},
+	})
+	registry := NewAgentRegistry(cfg, &mockRegistryProvider{})
+
+	if !registry.CanSendCollaboration("planner", "research") {
+		t.Fatal("planner should inherit allow_send_to from subagents.allow_agents")
+	}
+	if !registry.CanReceiveCollaboration("research", "planner") {
+		t.Fatal("research should explicitly allow inbound collaboration from planner")
+	}
+	if !registry.CanCollaborate("planner", "research") {
+		t.Fatal("planner should be allowed to collaborate with research")
+	}
+	if registry.CanCollaborate("research", "planner") {
+		t.Fatal("research should not be allowed to collaborate back without allow_send_to")
+	}
+}
+
+func TestAgentRegistry_CommunicationDefaults(t *testing.T) {
+	cfg := testCfg([]config.AgentConfig{
+		{ID: "planner"},
+	})
+	registry := NewAgentRegistry(cfg, &mockRegistryProvider{})
+
+	if got := registry.CommunicationMaxThreadTurns("planner"); got != defaultCommunicationMaxThreadTurns {
+		t.Fatalf("CommunicationMaxThreadTurns() = %d, want %d", got, defaultCommunicationMaxThreadTurns)
+	}
+	if got := registry.CommunicationMaxMessageChars("planner"); got != defaultCommunicationMaxMessageChars {
+		t.Fatalf("CommunicationMaxMessageChars() = %d, want %d", got, defaultCommunicationMaxMessageChars)
+	}
+	if registry.CommunicationAllowsArtifacts("planner") {
+		t.Fatal("artifacts should be disabled by default")
+	}
+}
+
 func TestAgentInstance_Model(t *testing.T) {
 	model := &config.AgentModelConfig{Primary: "claude-opus"}
 	cfg := testCfg([]config.AgentConfig{

--- a/pkg/agent/turn_state.go
+++ b/pkg/agent/turn_state.go
@@ -195,11 +195,12 @@ type turnState struct {
 	toolExecutions    []ToolExecutionRecord
 	turnCtx           *TurnContext
 
-	channel     string
-	chatID      string
-	workspace   string
-	userMessage string
-	media       []string
+	channel           string
+	chatID            string
+	workspace         string
+	userMessage       string
+	rootPromptMessage *providers.Message
+	media             []string
 
 	phase        TurnPhase
 	iteration    int
@@ -253,22 +254,23 @@ type turnState struct {
 
 func newTurnState(agent *AgentInstance, opts processOptions, scope turnEventScope) *turnState {
 	ts := &turnState{
-		agent:        agent,
-		opts:         opts,
-		profile:      opts.TurnProfile,
-		scope:        scope,
-		turnID:       scope.turnID,
-		agentID:      agent.ID,
-		sessionKey:   opts.Dispatch.SessionKey,
-		activeSkills: activeSkillNames(agent, opts),
-		turnCtx:      cloneTurnContext(scope.context),
-		channel:      opts.Dispatch.Channel(),
-		chatID:       opts.Dispatch.ChatID(),
-		workspace:    agent.Workspace,
-		userMessage:  opts.Dispatch.UserMessage,
-		media:        append([]string(nil), opts.Dispatch.Media...),
-		phase:        TurnPhaseSetup,
-		startedAt:    time.Now(),
+		agent:             agent,
+		opts:              opts,
+		profile:           opts.TurnProfile,
+		scope:             scope,
+		turnID:            scope.turnID,
+		agentID:           agent.ID,
+		sessionKey:        opts.Dispatch.SessionKey,
+		activeSkills:      activeSkillNames(agent, opts),
+		turnCtx:           cloneTurnContext(scope.context),
+		channel:           opts.Dispatch.Channel(),
+		chatID:            opts.Dispatch.ChatID(),
+		workspace:         agent.Workspace,
+		userMessage:       opts.Dispatch.UserMessage,
+		rootPromptMessage: clonePromptMessage(opts.RootPromptMessage),
+		media:             append([]string(nil), opts.Dispatch.Media...),
+		phase:             TurnPhaseSetup,
+		startedAt:         time.Now(),
 	}
 
 	// Bind session store and capture initial history length for rollback logic
@@ -400,6 +402,20 @@ func (ts *turnState) finalContentSnapshot() string {
 	ts.mu.RLock()
 	defer ts.mu.RUnlock()
 	return ts.finalContent
+}
+
+func (ts *turnState) rootPromptHistoryMessage() *providers.Message {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+
+	if ts.rootPromptMessage != nil {
+		return clonePromptMessage(ts.rootPromptMessage)
+	}
+	if strings.TrimSpace(ts.userMessage) == "" && len(ts.media) == 0 {
+		return nil
+	}
+	msg := userPromptMessage(ts.userMessage, ts.media)
+	return &msg
 }
 
 func (ts *turnState) recordToolKind(tool string) {

--- a/pkg/collab/store.go
+++ b/pkg/collab/store.go
@@ -1,0 +1,371 @@
+package collab
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sipeed/picoclaw/pkg/fileutil"
+)
+
+type stateFile struct {
+	Threads   map[string]*Thread   `json:"threads,omitempty"`
+	Messages  map[string]*Envelope `json:"messages,omitempty"`
+	Mailboxes map[string]*Mailbox  `json:"mailboxes,omitempty"`
+}
+
+type Store struct {
+	mu    sync.RWMutex
+	path  string
+	state stateFile
+}
+
+func NewStore(dir string) (*Store, error) {
+	store := &Store{
+		state: stateFile{
+			Threads:   make(map[string]*Thread),
+			Messages:  make(map[string]*Envelope),
+			Mailboxes: make(map[string]*Mailbox),
+		},
+	}
+
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return store, nil
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	store.path = filepath.Join(dir, "state.json")
+	if err := store.load(); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *Store) load() error {
+	if strings.TrimSpace(s.path) == "" {
+		return nil
+	}
+	data, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+
+	var state stateFile
+	if err := json.Unmarshal(data, &state); err != nil {
+		return err
+	}
+	if state.Threads == nil {
+		state.Threads = make(map[string]*Thread)
+	}
+	if state.Messages == nil {
+		state.Messages = make(map[string]*Envelope)
+	}
+	if state.Mailboxes == nil {
+		state.Mailboxes = make(map[string]*Mailbox)
+	}
+	s.state = state
+	return nil
+}
+
+func (s *Store) saveLocked() error {
+	if strings.TrimSpace(s.path) == "" {
+		return nil
+	}
+	data, err := json.MarshalIndent(s.state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return fileutil.WriteFileAtomic(s.path, data, 0o600)
+}
+
+func (s *Store) EnsureThread(thread Thread) (Thread, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+	thread.ID = strings.TrimSpace(thread.ID)
+	if thread.ID == "" {
+		return Thread{}, errors.New("thread id is required")
+	}
+
+	existing, ok := s.state.Threads[thread.ID]
+	if !ok {
+		cloned := CloneThread(thread)
+		if cloned.Status == "" {
+			cloned.Status = ThreadStatusOpen
+		}
+		if cloned.CreatedAt.IsZero() {
+			cloned.CreatedAt = now
+		}
+		cloned.UpdatedAt = now
+		existing = &cloned
+		s.state.Threads[thread.ID] = existing
+	} else {
+		existing.ParticipantAgentIDs = MergeParticipants(existing.ParticipantAgentIDs, thread.ParticipantAgentIDs...)
+		if thread.Status != "" {
+			existing.Status = thread.Status
+		}
+		if strings.TrimSpace(thread.CloseReason) != "" {
+			existing.CloseReason = thread.CloseReason
+		}
+		existing.UpdatedAt = now
+	}
+
+	if err := s.saveLocked(); err != nil {
+		return Thread{}, err
+	}
+	return CloneThread(*existing), nil
+}
+
+func (s *Store) AddMessage(env Envelope) (Envelope, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+	env.ID = strings.TrimSpace(env.ID)
+	env.ThreadID = strings.TrimSpace(env.ThreadID)
+	env.FromAgentID = strings.TrimSpace(env.FromAgentID)
+	if env.ID == "" || env.ThreadID == "" || env.FromAgentID == "" {
+		return Envelope{}, errors.New("id, thread_id, and from_agent_id are required")
+	}
+	if env.CreatedAt.IsZero() {
+		env.CreatedAt = now
+	}
+	env.UpdatedAt = now
+	switch env.Status {
+	case StatusDelivered:
+		if env.DeliveredAt == nil {
+			delivered := now
+			env.DeliveredAt = &delivered
+		}
+	case StatusReceived:
+		if env.DeliveredAt == nil {
+			delivered := now
+			env.DeliveredAt = &delivered
+		}
+		if env.ReceivedAt == nil {
+			received := now
+			env.ReceivedAt = &received
+		}
+	case StatusReplied:
+		if env.RepliedAt == nil {
+			replied := now
+			env.RepliedAt = &replied
+		}
+	}
+
+	cloned := CloneEnvelope(env)
+	s.state.Messages[env.ID] = &cloned
+
+	thread := s.state.Threads[env.ThreadID]
+	if thread == nil {
+		thread = &Thread{
+			ID:        env.ThreadID,
+			Status:    ThreadStatusOpen,
+			CreatedAt: env.CreatedAt,
+		}
+		s.state.Threads[env.ThreadID] = thread
+	}
+	thread.ParticipantAgentIDs = MergeParticipants(thread.ParticipantAgentIDs, env.FromAgentID)
+	thread.ParticipantAgentIDs = MergeParticipants(thread.ParticipantAgentIDs, env.ToAgentIDs...)
+	if !contains(thread.MessageIDs, env.ID) {
+		thread.MessageIDs = append(thread.MessageIDs, env.ID)
+	}
+	thread.LastMessageID = env.ID
+	thread.UpdatedAt = now
+
+	for _, agentID := range env.ToAgentIDs {
+		agentID = strings.TrimSpace(agentID)
+		if agentID == "" {
+			continue
+		}
+		mailbox := s.state.Mailboxes[agentID]
+		if mailbox == nil {
+			mailbox = &Mailbox{AgentID: agentID}
+			s.state.Mailboxes[agentID] = mailbox
+		}
+		if !contains(mailbox.MessageIDs, env.ID) {
+			mailbox.MessageIDs = append(mailbox.MessageIDs, env.ID)
+		}
+		mailbox.UpdatedAt = now
+	}
+
+	if err := s.saveLocked(); err != nil {
+		return Envelope{}, err
+	}
+	return CloneEnvelope(cloned), nil
+}
+
+func (s *Store) UpdateMessageStatus(id string, status MessageStatus, errorSummary string) (Envelope, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	msg := s.state.Messages[strings.TrimSpace(id)]
+	if msg == nil {
+		return Envelope{}, errors.New("message not found")
+	}
+
+	now := time.Now().UTC()
+	msg.Status = status
+	msg.UpdatedAt = now
+	if strings.TrimSpace(errorSummary) != "" {
+		msg.ErrorSummary = strings.TrimSpace(errorSummary)
+	}
+	switch status {
+	case StatusDelivered:
+		msg.DeliveredAt = &now
+	case StatusReceived:
+		msg.ReceivedAt = &now
+	case StatusReplied:
+		msg.RepliedAt = &now
+	}
+
+	if err := s.saveLocked(); err != nil {
+		return Envelope{}, err
+	}
+	return CloneEnvelope(*msg), nil
+}
+
+func (s *Store) GetMessage(id string) (Envelope, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	msg := s.state.Messages[strings.TrimSpace(id)]
+	if msg == nil {
+		return Envelope{}, false
+	}
+	return CloneEnvelope(*msg), true
+}
+
+func (s *Store) GetThread(id string) (Thread, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	thread := s.state.Threads[strings.TrimSpace(id)]
+	if thread == nil {
+		return Thread{}, false
+	}
+	return CloneThread(*thread), true
+}
+
+func (s *Store) ListThreadMessages(threadID string) []Envelope {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	thread := s.state.Threads[strings.TrimSpace(threadID)]
+	if thread == nil {
+		return nil
+	}
+
+	out := make([]Envelope, 0, len(thread.MessageIDs))
+	for _, messageID := range thread.MessageIDs {
+		if msg := s.state.Messages[messageID]; msg != nil {
+			out = append(out, CloneEnvelope(*msg))
+		}
+	}
+	return out
+}
+
+func (s *Store) ListMailbox(agentID, threadID, status string) []Envelope {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	mailbox := s.state.Mailboxes[strings.TrimSpace(agentID)]
+	if mailbox == nil {
+		return nil
+	}
+
+	threadID = strings.TrimSpace(threadID)
+	status = strings.TrimSpace(strings.ToLower(status))
+
+	out := make([]Envelope, 0, len(mailbox.MessageIDs))
+	for _, messageID := range mailbox.MessageIDs {
+		msg := s.state.Messages[messageID]
+		if msg == nil {
+			continue
+		}
+		if threadID != "" && msg.ThreadID != threadID {
+			continue
+		}
+		if status != "" && status != "all" && strings.ToLower(string(msg.Status)) != status {
+			continue
+		}
+		out = append(out, CloneEnvelope(*msg))
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
+	})
+	return out
+}
+
+func (s *Store) FindResponseTo(threadID, parentID string) (Envelope, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	thread := s.state.Threads[strings.TrimSpace(threadID)]
+	if thread == nil {
+		return Envelope{}, false
+	}
+	for _, messageID := range thread.MessageIDs {
+		msg := s.state.Messages[messageID]
+		if msg == nil || msg.ParentID != parentID {
+			continue
+		}
+		switch msg.Kind {
+		case KindReply, KindStatus, KindCancel:
+			return CloneEnvelope(*msg), true
+		}
+	}
+	return Envelope{}, false
+}
+
+func (s *Store) ThreadMessageCount(threadID string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	thread := s.state.Threads[strings.TrimSpace(threadID)]
+	if thread == nil {
+		return 0
+	}
+	return len(thread.MessageIDs)
+}
+
+func (s *Store) CloseThread(threadID, reason string) (Thread, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	thread := s.state.Threads[strings.TrimSpace(threadID)]
+	if thread == nil {
+		return Thread{}, errors.New("thread not found")
+	}
+	thread.Status = ThreadStatusClosed
+	thread.CloseReason = strings.TrimSpace(reason)
+	thread.UpdatedAt = time.Now().UTC()
+	if err := s.saveLocked(); err != nil {
+		return Thread{}, err
+	}
+	return CloneThread(*thread), nil
+}
+
+func contains(items []string, needle string) bool {
+	for _, item := range items {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/collab/store_test.go
+++ b/pkg/collab/store_test.go
@@ -1,0 +1,102 @@
+package collab
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStore_PersistsThreadsMessagesAndMailboxes(t *testing.T) {
+	dir := t.TempDir()
+
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	deadline := time.Now().UTC().Add(2 * time.Minute).Truncate(time.Second)
+	if _, ensureErr := store.EnsureThread(Thread{
+		ID:                  "thread_persist",
+		ParticipantAgentIDs: []string{"planner", "research"},
+		Status:              ThreadStatusOpen,
+	}); ensureErr != nil {
+		t.Fatalf("EnsureThread() error = %v", ensureErr)
+	}
+	if _, addRequestErr := store.AddMessage(Envelope{
+		ID:           "msg_request",
+		ThreadID:     "thread_persist",
+		FromAgentID:  "planner",
+		ToAgentIDs:   []string{"research"},
+		Kind:         KindRequest,
+		Content:      "Investigate mailbox durability.",
+		ExpectReply:  true,
+		Status:       StatusDelivered,
+		TraceID:      "trace_persist",
+		ParentTurnID: "turn_planner",
+		Deadline:     &deadline,
+	}); addRequestErr != nil {
+		t.Fatalf("AddMessage(request) error = %v", addRequestErr)
+	}
+	if _, addReplyErr := store.AddMessage(Envelope{
+		ID:           "msg_reply",
+		ThreadID:     "thread_persist",
+		ParentID:     "msg_request",
+		FromAgentID:  "research",
+		ToAgentIDs:   []string{"planner"},
+		Kind:         KindReply,
+		Content:      "Mailbox durability confirmed.",
+		Status:       StatusDelivered,
+		TraceID:      "trace_persist",
+		ParentTurnID: "turn_research",
+	}); addReplyErr != nil {
+		t.Fatalf("AddMessage(reply) error = %v", addReplyErr)
+	}
+	if _, updateErr := store.UpdateMessageStatus("msg_request", StatusReplied, ""); updateErr != nil {
+		t.Fatalf("UpdateMessageStatus() error = %v", updateErr)
+	}
+
+	reloaded, err := NewStore(filepath.Clean(dir))
+	if err != nil {
+		t.Fatalf("NewStore(reload) error = %v", err)
+	}
+
+	thread, ok := reloaded.GetThread("thread_persist")
+	if !ok {
+		t.Fatal("expected persisted thread")
+	}
+	if thread.Status != ThreadStatusOpen {
+		t.Fatalf("thread.Status = %q, want open", thread.Status)
+	}
+	if len(thread.MessageIDs) != 2 {
+		t.Fatalf("thread.MessageIDs = %v, want 2 messages", thread.MessageIDs)
+	}
+
+	request, ok := reloaded.GetMessage("msg_request")
+	if !ok {
+		t.Fatal("expected persisted request message")
+	}
+	if request.Status != StatusReplied {
+		t.Fatalf("request.Status = %q, want replied", request.Status)
+	}
+	if request.Deadline == nil || !request.Deadline.Equal(deadline) {
+		t.Fatalf("request.Deadline = %v, want %v", request.Deadline, deadline)
+	}
+
+	reply, ok := reloaded.FindResponseTo("thread_persist", "msg_request")
+	if !ok {
+		t.Fatal("expected persisted reply lookup")
+	}
+	if reply.Content != "Mailbox durability confirmed." {
+		t.Fatalf("reply.Content = %q", reply.Content)
+	}
+
+	plannerMailbox := reloaded.ListMailbox("planner", "thread_persist", "")
+	if len(plannerMailbox) != 1 || plannerMailbox[0].ID != "msg_reply" {
+		t.Fatalf("planner mailbox = %+v", plannerMailbox)
+	}
+
+	researchMailbox := reloaded.ListMailbox("research", "thread_persist", "")
+	if len(researchMailbox) != 1 || researchMailbox[0].ID != "msg_request" {
+		t.Fatalf("research mailbox = %+v", researchMailbox)
+	}
+}

--- a/pkg/collab/types.go
+++ b/pkg/collab/types.go
@@ -1,0 +1,152 @@
+package collab
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/sipeed/picoclaw/pkg/providers"
+)
+
+type MessageKind string
+
+const (
+	KindRequest MessageKind = "request"
+	KindReply   MessageKind = "reply"
+	KindNotice  MessageKind = "notice"
+	KindStatus  MessageKind = "status"
+	KindCancel  MessageKind = "cancel"
+)
+
+type MessageStatus string
+
+const (
+	StatusQueued    MessageStatus = "queued"
+	StatusDelivered MessageStatus = "delivered"
+	StatusReceived  MessageStatus = "received"
+	StatusReplied   MessageStatus = "replied"
+	StatusBlocked   MessageStatus = "blocked"
+	StatusClosed    MessageStatus = "closed"
+	StatusError     MessageStatus = "error"
+)
+
+type ThreadStatus string
+
+const (
+	ThreadStatusOpen   ThreadStatus = "open"
+	ThreadStatusClosed ThreadStatus = "closed"
+)
+
+type ContextPolicy string
+
+const (
+	ContextPolicyTaskOnly        ContextPolicy = "task_only"
+	ContextPolicySummary         ContextPolicy = "summary"
+	ContextPolicySelectedContext ContextPolicy = "selected_context"
+)
+
+type Envelope struct {
+	ID            string                 `json:"id"`
+	ThreadID      string                 `json:"thread_id"`
+	ParentID      string                 `json:"parent_id,omitempty"`
+	FromAgentID   string                 `json:"from_agent_id"`
+	ToAgentIDs    []string               `json:"to_agent_ids,omitempty"`
+	Kind          MessageKind            `json:"kind"`
+	Content       string                 `json:"content"`
+	Artifacts     []providers.Attachment `json:"artifacts,omitempty"`
+	ExpectReply   bool                   `json:"expect_reply,omitempty"`
+	Deadline      *time.Time             `json:"deadline,omitempty"`
+	Priority      string                 `json:"priority,omitempty"`
+	Status        MessageStatus          `json:"status"`
+	TraceID       string                 `json:"trace_id,omitempty"`
+	ParentTurnID  string                 `json:"parent_turn_id,omitempty"`
+	ContextPolicy ContextPolicy          `json:"context_policy,omitempty"`
+	ContextShared string                 `json:"context_shared,omitempty"`
+	ErrorSummary  string                 `json:"error_summary,omitempty"`
+	CreatedAt     time.Time              `json:"created_at"`
+	UpdatedAt     time.Time              `json:"updated_at"`
+	DeliveredAt   *time.Time             `json:"delivered_at,omitempty"`
+	ReceivedAt    *time.Time             `json:"received_at,omitempty"`
+	RepliedAt     *time.Time             `json:"replied_at,omitempty"`
+}
+
+type Thread struct {
+	ID                  string       `json:"id"`
+	ParticipantAgentIDs []string     `json:"participant_agent_ids,omitempty"`
+	MessageIDs          []string     `json:"message_ids,omitempty"`
+	Status              ThreadStatus `json:"status"`
+	CloseReason         string       `json:"close_reason,omitempty"`
+	CreatedAt           time.Time    `json:"created_at"`
+	UpdatedAt           time.Time    `json:"updated_at"`
+	LastMessageID       string       `json:"last_message_id,omitempty"`
+}
+
+type Mailbox struct {
+	AgentID    string    `json:"agent_id"`
+	MessageIDs []string  `json:"message_ids,omitempty"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+func NormalizeContextPolicy(policy ContextPolicy) ContextPolicy {
+	switch strings.ToLower(strings.TrimSpace(string(policy))) {
+	case string(ContextPolicySummary):
+		return ContextPolicySummary
+	case string(ContextPolicySelectedContext):
+		return ContextPolicySelectedContext
+	default:
+		return ContextPolicyTaskOnly
+	}
+}
+
+func CloneEnvelope(env Envelope) Envelope {
+	cloned := env
+	if len(env.ToAgentIDs) > 0 {
+		cloned.ToAgentIDs = append([]string(nil), env.ToAgentIDs...)
+	}
+	if len(env.Artifacts) > 0 {
+		cloned.Artifacts = append([]providers.Attachment(nil), env.Artifacts...)
+	}
+	if env.Deadline != nil {
+		deadline := *env.Deadline
+		cloned.Deadline = &deadline
+	}
+	if env.DeliveredAt != nil {
+		delivered := *env.DeliveredAt
+		cloned.DeliveredAt = &delivered
+	}
+	if env.ReceivedAt != nil {
+		received := *env.ReceivedAt
+		cloned.ReceivedAt = &received
+	}
+	if env.RepliedAt != nil {
+		replied := *env.RepliedAt
+		cloned.RepliedAt = &replied
+	}
+	return cloned
+}
+
+func CloneThread(thread Thread) Thread {
+	cloned := thread
+	if len(thread.ParticipantAgentIDs) > 0 {
+		cloned.ParticipantAgentIDs = append([]string(nil), thread.ParticipantAgentIDs...)
+	}
+	if len(thread.MessageIDs) > 0 {
+		cloned.MessageIDs = append([]string(nil), thread.MessageIDs...)
+	}
+	return cloned
+}
+
+func MergeParticipants(existing []string, participants ...string) []string {
+	if len(participants) == 0 {
+		return append([]string(nil), existing...)
+	}
+	merged := append([]string(nil), existing...)
+	for _, participant := range participants {
+		participant = strings.TrimSpace(participant)
+		if participant == "" || slices.Contains(merged, participant) {
+			continue
+		}
+		merged = append(merged, participant)
+	}
+	return merged
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -308,18 +308,27 @@ func (m AgentModelConfig) MarshalJSON() ([]byte, error) {
 }
 
 type AgentConfig struct {
-	ID        string            `json:"id"`
-	Default   bool              `json:"default,omitempty"`
-	Name      string            `json:"name,omitempty"`
-	Workspace string            `json:"workspace,omitempty"`
-	Model     *AgentModelConfig `json:"model,omitempty"`
-	Skills    []string          `json:"skills,omitempty"`
-	Subagents *SubagentsConfig  `json:"subagents,omitempty"`
+	ID            string                    `json:"id"`
+	Default       bool                      `json:"default,omitempty"`
+	Name          string                    `json:"name,omitempty"`
+	Workspace     string                    `json:"workspace,omitempty"`
+	Model         *AgentModelConfig         `json:"model,omitempty"`
+	Skills        []string                  `json:"skills,omitempty"`
+	Subagents     *SubagentsConfig          `json:"subagents,omitempty"`
+	Communication *AgentCommunicationConfig `json:"communication,omitempty"`
 }
 
 type SubagentsConfig struct {
 	AllowAgents []string          `json:"allow_agents,omitempty"`
 	Model       *AgentModelConfig `json:"model,omitempty"`
+}
+
+type AgentCommunicationConfig struct {
+	AllowSendTo      []string `json:"allow_send_to,omitempty"`
+	AllowReceiveFrom []string `json:"allow_receive_from,omitempty"`
+	MaxThreadTurns   int      `json:"max_thread_turns,omitempty"`
+	MaxMessageChars  int      `json:"max_message_chars,omitempty"`
+	AllowArtifacts   bool     `json:"allow_artifacts,omitempty"`
 }
 
 type DispatchConfig struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -105,6 +105,13 @@ func TestAgentConfig_FullParse(t *testing.T) {
 				},
 				"subagents": {
 					"allow_agents": ["sales"]
+				},
+				"communication": {
+					"allow_send_to": ["sales"],
+					"allow_receive_from": ["sales"],
+					"max_thread_turns": 8,
+					"max_message_chars": 12000,
+					"allow_artifacts": true
 				}
 			}
 			]
@@ -146,6 +153,24 @@ func TestAgentConfig_FullParse(t *testing.T) {
 	}
 	if support.Subagents == nil || len(support.Subagents.AllowAgents) != 1 {
 		t.Errorf("support.Subagents = %+v", support.Subagents)
+	}
+	if support.Communication == nil {
+		t.Fatal("support.Communication should be parsed")
+	}
+	if len(support.Communication.AllowSendTo) != 1 || support.Communication.AllowSendTo[0] != "sales" {
+		t.Errorf("support.Communication.AllowSendTo = %v", support.Communication.AllowSendTo)
+	}
+	if len(support.Communication.AllowReceiveFrom) != 1 || support.Communication.AllowReceiveFrom[0] != "sales" {
+		t.Errorf("support.Communication.AllowReceiveFrom = %v", support.Communication.AllowReceiveFrom)
+	}
+	if support.Communication.MaxThreadTurns != 8 {
+		t.Errorf("support.Communication.MaxThreadTurns = %d, want 8", support.Communication.MaxThreadTurns)
+	}
+	if support.Communication.MaxMessageChars != 12000 {
+		t.Errorf("support.Communication.MaxMessageChars = %d, want 12000", support.Communication.MaxMessageChars)
+	}
+	if !support.Communication.AllowArtifacts {
+		t.Error("support.Communication.AllowArtifacts should be true")
 	}
 
 	if len(cfg.Session.Dimensions) != 1 || cfg.Session.Dimensions[0] != "sender" {

--- a/pkg/constants/channels.go
+++ b/pkg/constants/channels.go
@@ -4,9 +4,10 @@ package constants
 // internalChannels defines channels that are used for internal communication
 // and should not be exposed to external users or recorded as last active channel.
 var internalChannels = map[string]struct{}{
-	"cli":      {},
-	"system":   {},
-	"subagent": {},
+	"cli":         {},
+	"system":      {},
+	"subagent":    {},
+	"inter-agent": {},
 }
 
 // IsInternalChannel returns true if the channel is an internal channel.

--- a/pkg/events/kind.go
+++ b/pkg/events/kind.go
@@ -44,6 +44,18 @@ const (
 	KindAgentSubTurnOrphan Kind = "agent.subturn.orphan"
 	// KindAgentError is emitted when agent execution reports an error.
 	KindAgentError Kind = "agent.error"
+	// KindAgentMessageSent is emitted when an inter-agent message is created.
+	KindAgentMessageSent Kind = "agent.message.sent"
+	// KindAgentMessageDelivered is emitted when an inter-agent message is queued for delivery.
+	KindAgentMessageDelivered Kind = "agent.message.delivered"
+	// KindAgentMessageReceived is emitted when an inter-agent message starts processing.
+	KindAgentMessageReceived Kind = "agent.message.received"
+	// KindAgentMessageReply is emitted when an inter-agent reply is recorded.
+	KindAgentMessageReply Kind = "agent.message.reply"
+	// KindAgentMessageBlocked is emitted when policy blocks an inter-agent message.
+	KindAgentMessageBlocked Kind = "agent.message.blocked"
+	// KindAgentThreadClosed is emitted when a collaboration thread is closed.
+	KindAgentThreadClosed Kind = "agent.thread.closed"
 
 	// KindChannelLifecycleStarted is emitted when a channel starts.
 	KindChannelLifecycleStarted Kind = "channel.lifecycle.started"
@@ -122,6 +134,12 @@ var knownKinds = []Kind{
 	KindAgentSubTurnResultDelivered,
 	KindAgentSubTurnOrphan,
 	KindAgentError,
+	KindAgentMessageSent,
+	KindAgentMessageDelivered,
+	KindAgentMessageReceived,
+	KindAgentMessageReply,
+	KindAgentMessageBlocked,
+	KindAgentThreadClosed,
 	KindChannelLifecycleStarted,
 	KindChannelLifecycleInitialized,
 	KindChannelLifecycleStartFailed,

--- a/pkg/tools/agent_collaboration.go
+++ b/pkg/tools/agent_collaboration.go
@@ -1,0 +1,415 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sipeed/picoclaw/pkg/collab"
+	"github.com/sipeed/picoclaw/pkg/providers"
+)
+
+type AgentRequestParams struct {
+	ToAgentID       string
+	ThreadID        string
+	Content         string
+	DeadlineSeconds int
+	ContextPolicy   collab.ContextPolicy
+	SelectedContext string
+	Wait            bool
+}
+
+type AgentRequestResponse struct {
+	ThreadID       string
+	MessageID      string
+	ReplyMessageID string
+	FromAgentID    string
+	Content        string
+	Status         collab.MessageStatus
+}
+
+type AgentReplyParams struct {
+	ThreadID  string
+	InReplyTo string
+	Content   string
+	Artifacts []providers.Attachment
+}
+
+type AgentReplyResponse struct {
+	ThreadID  string
+	MessageID string
+	Status    collab.MessageStatus
+}
+
+type AgentInboxParams struct {
+	ThreadID string
+	Status   string
+}
+
+type AgentInboxMessage struct {
+	ID             string
+	ThreadID       string
+	ParentID       string
+	FromAgentID    string
+	Kind           collab.MessageKind
+	Status         collab.MessageStatus
+	ExpectReply    bool
+	ContentPreview string
+	ArtifactCount  int
+	CreatedAt      time.Time
+}
+
+type AgentInboxResponse struct {
+	AgentID      string
+	ThreadID     string
+	ThreadStatus string
+	Participants []string
+	Messages     []AgentInboxMessage
+}
+
+type AgentCollaborationRuntime interface {
+	Request(ctx context.Context, params AgentRequestParams) (*AgentRequestResponse, error)
+	Reply(ctx context.Context, params AgentReplyParams) (*AgentReplyResponse, error)
+	Inbox(ctx context.Context, params AgentInboxParams) (*AgentInboxResponse, error)
+}
+
+type AgentRequestTool struct {
+	runtime AgentCollaborationRuntime
+}
+
+func NewAgentRequestTool() *AgentRequestTool {
+	return &AgentRequestTool{}
+}
+
+func (t *AgentRequestTool) SetRuntime(runtime AgentCollaborationRuntime) {
+	t.runtime = runtime
+}
+
+func (t *AgentRequestTool) Name() string {
+	return "agent_request"
+}
+
+func (t *AgentRequestTool) Description() string {
+	return "Send a structured internal collaboration request to another permitted agent. Use this for peer-to-peer coordination that needs a durable thread and mailbox."
+}
+
+func (t *AgentRequestTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"to": map[string]any{
+				"type":        "string",
+				"description": "Target agent ID",
+			},
+			"content": map[string]any{
+				"type":        "string",
+				"description": "The collaboration request to send",
+			},
+			"thread_id": map[string]any{
+				"type":        "string",
+				"description": "Optional existing collaboration thread ID",
+			},
+			"deadline_seconds": map[string]any{
+				"type":        "integer",
+				"description": "Optional timeout for waiting and target processing",
+			},
+			"context_policy": map[string]any{
+				"type":        "string",
+				"description": "Context sharing policy: task_only, summary, or selected_context",
+				"enum":        []string{"task_only", "summary", "selected_context"},
+			},
+			"selected_context": map[string]any{
+				"type":        "string",
+				"description": "Explicit context to share when context_policy is selected_context",
+			},
+			"wait": map[string]any{
+				"type":        "boolean",
+				"description": "Wait for a reply before returning. Defaults to true.",
+			},
+		},
+		"required": []string{"to", "content"},
+	}
+}
+
+func (t *AgentRequestTool) Execute(ctx context.Context, args map[string]any) *ToolResult {
+	if t.runtime == nil {
+		return ErrorResult("agent_request is not configured")
+	}
+
+	toAgentID, _ := args["to"].(string)
+	if strings.TrimSpace(toAgentID) == "" {
+		return ErrorResult("to is required and must be a non-empty string")
+	}
+
+	content, _ := args["content"].(string)
+	if strings.TrimSpace(content) == "" {
+		return ErrorResult("content is required and must be a non-empty string")
+	}
+
+	threadID, _ := args["thread_id"].(string)
+	deadlineSeconds := intFromAny(args["deadline_seconds"])
+	selectedContext, _ := args["selected_context"].(string)
+	wait, waitSet := args["wait"].(bool)
+	if !waitSet {
+		wait = true
+	}
+
+	response, err := t.runtime.Request(ctx, AgentRequestParams{
+		ToAgentID:       toAgentID,
+		ThreadID:        threadID,
+		Content:         content,
+		DeadlineSeconds: deadlineSeconds,
+		ContextPolicy:   collab.NormalizeContextPolicy(collab.ContextPolicy(stringValue(args["context_policy"]))),
+		SelectedContext: selectedContext,
+		Wait:            wait,
+	})
+	if err != nil {
+		return ErrorResult(err.Error()).WithError(err)
+	}
+
+	if wait {
+		return &ToolResult{
+			ForLLM: fmt.Sprintf(
+				"[Reply from agent %q in thread %s]\n%s",
+				response.FromAgentID,
+				response.ThreadID,
+				response.Content,
+			),
+			ForUser: response.Content,
+		}
+	}
+
+	return NewToolResult(fmt.Sprintf(
+		"Internal request queued for agent %q in thread %s (message_id=%s).",
+		toAgentID,
+		response.ThreadID,
+		response.MessageID,
+	))
+}
+
+type AgentReplyTool struct {
+	runtime AgentCollaborationRuntime
+}
+
+func NewAgentReplyTool() *AgentReplyTool {
+	return &AgentReplyTool{}
+}
+
+func (t *AgentReplyTool) SetRuntime(runtime AgentCollaborationRuntime) {
+	t.runtime = runtime
+}
+
+func (t *AgentReplyTool) Name() string {
+	return "agent_reply"
+}
+
+func (t *AgentReplyTool) Description() string {
+	return "Reply inside an existing internal collaboration thread. Use this to send a structured response back to another agent."
+}
+
+func (t *AgentReplyTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"thread_id": map[string]any{
+				"type":        "string",
+				"description": "The collaboration thread ID",
+			},
+			"in_reply_to": map[string]any{
+				"type":        "string",
+				"description": "The message ID being answered",
+			},
+			"content": map[string]any{
+				"type":        "string",
+				"description": "The reply content",
+			},
+			"artifacts": map[string]any{
+				"type":        "array",
+				"description": "Optional artifact references to include with the reply",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"type":         map[string]any{"type": "string"},
+						"ref":          map[string]any{"type": "string"},
+						"url":          map[string]any{"type": "string"},
+						"filename":     map[string]any{"type": "string"},
+						"content_type": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+		"required": []string{"thread_id", "in_reply_to", "content"},
+	}
+}
+
+func (t *AgentReplyTool) Execute(ctx context.Context, args map[string]any) *ToolResult {
+	if t.runtime == nil {
+		return ErrorResult("agent_reply is not configured")
+	}
+
+	threadID, _ := args["thread_id"].(string)
+	if strings.TrimSpace(threadID) == "" {
+		return ErrorResult("thread_id is required and must be a non-empty string")
+	}
+
+	inReplyTo, _ := args["in_reply_to"].(string)
+	if strings.TrimSpace(inReplyTo) == "" {
+		return ErrorResult("in_reply_to is required and must be a non-empty string")
+	}
+
+	content, _ := args["content"].(string)
+	if strings.TrimSpace(content) == "" {
+		return ErrorResult("content is required and must be a non-empty string")
+	}
+
+	reply, err := t.runtime.Reply(ctx, AgentReplyParams{
+		ThreadID:  threadID,
+		InReplyTo: inReplyTo,
+		Content:   content,
+		Artifacts: attachmentsFromAny(args["artifacts"]),
+	})
+	if err != nil {
+		return ErrorResult(err.Error()).WithError(err)
+	}
+
+	return NewToolResult(fmt.Sprintf(
+		"Reply recorded in collaboration thread %s (message_id=%s, status=%s).",
+		reply.ThreadID,
+		reply.MessageID,
+		reply.Status,
+	))
+}
+
+type AgentInboxTool struct {
+	runtime AgentCollaborationRuntime
+}
+
+func NewAgentInboxTool() *AgentInboxTool {
+	return &AgentInboxTool{}
+}
+
+func (t *AgentInboxTool) SetRuntime(runtime AgentCollaborationRuntime) {
+	t.runtime = runtime
+}
+
+func (t *AgentInboxTool) Name() string {
+	return "agent_inbox"
+}
+
+func (t *AgentInboxTool) Description() string {
+	return "Inspect the current agent mailbox and collaboration-thread delivery state."
+}
+
+func (t *AgentInboxTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"thread_id": map[string]any{
+				"type":        "string",
+				"description": "Optional thread ID filter",
+			},
+			"status": map[string]any{
+				"type":        "string",
+				"description": "Optional message status filter",
+			},
+		},
+	}
+}
+
+func (t *AgentInboxTool) Execute(ctx context.Context, args map[string]any) *ToolResult {
+	if t.runtime == nil {
+		return ErrorResult("agent_inbox is not configured")
+	}
+
+	threadID, _ := args["thread_id"].(string)
+	status, _ := args["status"].(string)
+	inbox, err := t.runtime.Inbox(ctx, AgentInboxParams{
+		ThreadID: threadID,
+		Status:   status,
+	})
+	if err != nil {
+		return ErrorResult(err.Error()).WithError(err)
+	}
+
+	return NewToolResult(formatAgentInbox(inbox))
+}
+
+func formatAgentInbox(inbox *AgentInboxResponse) string {
+	if inbox == nil {
+		return "No mailbox data available."
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Mailbox for agent %q", inbox.AgentID)
+	if strings.TrimSpace(inbox.ThreadID) != "" {
+		fmt.Fprintf(&b, " in thread %s", inbox.ThreadID)
+	}
+	if strings.TrimSpace(inbox.ThreadStatus) != "" {
+		fmt.Fprintf(&b, " (thread_status=%s)", inbox.ThreadStatus)
+	}
+	if len(inbox.Participants) > 0 {
+		fmt.Fprintf(&b, "\nParticipants: %s", strings.Join(inbox.Participants, ", "))
+	}
+	if len(inbox.Messages) == 0 {
+		b.WriteString("\nNo matching messages.")
+		return b.String()
+	}
+	for _, msg := range inbox.Messages {
+		fmt.Fprintf(&b,
+			"\n- %s | from=%s | kind=%s | status=%s | expect_reply=%t | artifacts=%d | at=%s\n  %s",
+			msg.ID,
+			msg.FromAgentID,
+			msg.Kind,
+			msg.Status,
+			msg.ExpectReply,
+			msg.ArtifactCount,
+			msg.CreatedAt.UTC().Format(time.RFC3339),
+			msg.ContentPreview,
+		)
+	}
+	return b.String()
+}
+
+func attachmentsFromAny(raw any) []providers.Attachment {
+	items, ok := raw.([]any)
+	if !ok || len(items) == 0 {
+		return nil
+	}
+
+	attachments := make([]providers.Attachment, 0, len(items))
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		attachments = append(attachments, providers.Attachment{
+			Type:        stringValue(m["type"]),
+			Ref:         stringValue(m["ref"]),
+			URL:         stringValue(m["url"]),
+			Filename:    stringValue(m["filename"]),
+			ContentType: stringValue(m["content_type"]),
+		})
+	}
+	return attachments
+}
+
+func intFromAny(raw any) int {
+	switch value := raw.(type) {
+	case int:
+		return value
+	case int32:
+		return int(value)
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func stringValue(raw any) string {
+	value, _ := raw.(string)
+	return strings.TrimSpace(value)
+}

--- a/pkg/tools/delegate.go
+++ b/pkg/tools/delegate.go
@@ -14,10 +14,11 @@ import (
 // generic), delegate targets a named agent and runs the task using that
 // agent's own workspace, model, and tools.
 type DelegateTool struct {
-	spawner        SubTurnSpawner
-	runtime        AgentCollaborationRuntime
-	allowlistCheck func(targetAgentID string) bool
-	selfAgentID    string
+	spawner                     SubTurnSpawner
+	runtime                     AgentCollaborationRuntime
+	allowlistCheck              func(targetAgentID string) bool
+	collaborationAllowlistCheck func(targetAgentID string) bool
+	selfAgentID                 string
 }
 
 func NewDelegateTool() *DelegateTool {
@@ -34,6 +35,10 @@ func (t *DelegateTool) SetRuntime(runtime AgentCollaborationRuntime) {
 
 func (t *DelegateTool) SetAllowlistChecker(check func(targetAgentID string) bool) {
 	t.allowlistCheck = check
+}
+
+func (t *DelegateTool) SetCollaborationAllowlistChecker(check func(targetAgentID string) bool) {
+	t.collaborationAllowlistCheck = check
 }
 
 func (t *DelegateTool) SetSelfAgentID(id string) {
@@ -84,17 +89,40 @@ func (t *DelegateTool) Execute(ctx context.Context, args map[string]any) *ToolRe
 		return ErrorResult("cannot delegate to self")
 	}
 
-	if t.allowlistCheck != nil && !t.allowlistCheck(agentID) {
+	spawnAllowed := t.spawner != nil && t.pathAllowed(agentID, t.allowlistCheck)
+	collaborationCheck := t.collaborationAllowlistCheck
+	if collaborationCheck == nil {
+		collaborationCheck = t.allowlistCheck
+	}
+	collaborationAllowed := t.runtime != nil && t.pathAllowed(agentID, collaborationCheck)
+
+	if !spawnAllowed && !collaborationAllowed && t.spawner == nil && t.runtime == nil {
+		return ErrorResult("delegate tool not configured")
+	}
+
+	if !spawnAllowed && !collaborationAllowed {
 		return ErrorResult(fmt.Sprintf("not allowed to delegate to agent %q", agentID))
 	}
 
-	if t.spawner == nil {
-		if t.runtime == nil {
-			return ErrorResult("delegate tool not configured")
+	// Preserve legacy behavior by preferring the sub-turn path when it is allowed.
+	if spawnAllowed {
+		result, err := t.spawner.SpawnSubTurn(ctx, SubTurnConfig{
+			TargetAgentID: agentID,
+			SystemPrompt:  task,
+			Async:         false,
+		})
+		if err != nil {
+			return ErrorResult(fmt.Sprintf("delegation to agent %q failed: %v", agentID, err)).WithError(err)
 		}
+		if result == nil {
+			return ErrorResult(fmt.Sprintf("delegation to agent %q returned no result", agentID))
+		}
+
+		result.ForLLM = fmt.Sprintf("[Response from agent %q]\n%s", agentID, result.ForLLM)
+		return result
 	}
 
-	if t.runtime != nil {
+	if collaborationAllowed {
 		reply, err := t.runtime.Request(ctx, AgentRequestParams{
 			ToAgentID:     agentID,
 			Content:       task,
@@ -112,19 +140,12 @@ func (t *DelegateTool) Execute(ctx context.Context, args map[string]any) *ToolRe
 		return result
 	}
 
-	result, err := t.spawner.SpawnSubTurn(ctx, SubTurnConfig{
-		TargetAgentID: agentID,
-		SystemPrompt:  task,
-		Async:         false,
-	})
-	if err != nil {
-		return ErrorResult(fmt.Sprintf("delegation to agent %q failed: %v", agentID, err)).WithError(err)
-	}
-	if result == nil {
-		return ErrorResult(fmt.Sprintf("delegation to agent %q returned no result", agentID))
-	}
+	return ErrorResult(fmt.Sprintf("not allowed to delegate to agent %q", agentID))
+}
 
-	result.ForLLM = fmt.Sprintf("[Response from agent %q]\n%s", agentID, result.ForLLM)
-
-	return result
+func (t *DelegateTool) pathAllowed(agentID string, check func(targetAgentID string) bool) bool {
+	if check == nil {
+		return true
+	}
+	return check(agentID)
 }

--- a/pkg/tools/delegate.go
+++ b/pkg/tools/delegate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sipeed/picoclaw/pkg/collab"
 	"github.com/sipeed/picoclaw/pkg/routing"
 )
 
@@ -14,6 +15,7 @@ import (
 // agent's own workspace, model, and tools.
 type DelegateTool struct {
 	spawner        SubTurnSpawner
+	runtime        AgentCollaborationRuntime
 	allowlistCheck func(targetAgentID string) bool
 	selfAgentID    string
 }
@@ -24,6 +26,10 @@ func NewDelegateTool() *DelegateTool {
 
 func (t *DelegateTool) SetSpawner(spawner SubTurnSpawner) {
 	t.spawner = spawner
+}
+
+func (t *DelegateTool) SetRuntime(runtime AgentCollaborationRuntime) {
+	t.runtime = runtime
 }
 
 func (t *DelegateTool) SetAllowlistChecker(check func(targetAgentID string) bool) {
@@ -83,7 +89,27 @@ func (t *DelegateTool) Execute(ctx context.Context, args map[string]any) *ToolRe
 	}
 
 	if t.spawner == nil {
-		return ErrorResult("delegate tool not configured")
+		if t.runtime == nil {
+			return ErrorResult("delegate tool not configured")
+		}
+	}
+
+	if t.runtime != nil {
+		reply, err := t.runtime.Request(ctx, AgentRequestParams{
+			ToAgentID:     agentID,
+			Content:       task,
+			ContextPolicy: collab.ContextPolicyTaskOnly,
+			Wait:          true,
+		})
+		if err != nil {
+			return ErrorResult(fmt.Sprintf("delegation to agent %q failed: %v", agentID, err)).WithError(err)
+		}
+		result := &ToolResult{
+			ForLLM:  reply.Content,
+			ForUser: reply.Content,
+		}
+		result.ForLLM = fmt.Sprintf("[Response from agent %q]\n%s", agentID, result.ForLLM)
+		return result
 	}
 
 	result, err := t.spawner.SpawnSubTurn(ctx, SubTurnConfig{

--- a/pkg/tools/delegate_test.go
+++ b/pkg/tools/delegate_test.go
@@ -14,15 +14,18 @@ type delegateMockSpawner struct {
 	lastCfg SubTurnConfig
 	result  *ToolResult
 	err     error
+	calls   int
 }
 
 type delegateMockCollaborationRuntime struct {
 	lastParams AgentRequestParams
 	response   *AgentRequestResponse
 	err        error
+	calls      int
 }
 
 func (m *delegateMockSpawner) SpawnSubTurn(_ context.Context, cfg SubTurnConfig) (*ToolResult, error) {
+	m.calls++
 	m.lastCfg = cfg
 	if m.err != nil {
 		return nil, m.err
@@ -40,6 +43,7 @@ func (m *delegateMockCollaborationRuntime) Request(
 	_ context.Context,
 	params AgentRequestParams,
 ) (*AgentRequestResponse, error) {
+	m.calls++
 	m.lastParams = params
 	if m.err != nil {
 		return nil, m.err
@@ -159,6 +163,67 @@ func TestDelegateTool_Execute_UsesCollaborationRuntimeWhenConfigured(t *testing.
 	}
 	if !strings.Contains(result.ForLLM, `[Response from agent "researcher"]`) {
 		t.Fatalf("result.ForLLM = %q", result.ForLLM)
+	}
+}
+
+func TestDelegateTool_Execute_PrefersSpawnerWhenBothPathsAreAllowed(t *testing.T) {
+	spawner := &delegateMockSpawner{}
+	runtime := &delegateMockCollaborationRuntime{}
+	tool := NewDelegateTool()
+	tool.SetSpawner(spawner)
+	tool.SetRuntime(runtime)
+	tool.SetAllowlistChecker(func(targetAgentID string) bool {
+		return targetAgentID == "researcher"
+	})
+	tool.SetCollaborationAllowlistChecker(func(targetAgentID string) bool {
+		return targetAgentID == "researcher"
+	})
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"agent_id": "researcher",
+		"task":     "summarize the logs",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.ForLLM)
+	}
+	if spawner.calls != 1 {
+		t.Fatalf("spawner.calls = %d, want 1", spawner.calls)
+	}
+	if runtime.calls != 0 {
+		t.Fatalf("runtime.calls = %d, want 0", runtime.calls)
+	}
+}
+
+func TestDelegateTool_Execute_FallsBackToCollaborationWhenSpawnNotAllowed(t *testing.T) {
+	spawner := &delegateMockSpawner{}
+	runtime := &delegateMockCollaborationRuntime{}
+	tool := NewDelegateTool()
+	tool.SetSpawner(spawner)
+	tool.SetRuntime(runtime)
+	tool.SetAllowlistChecker(func(targetAgentID string) bool {
+		return false
+	})
+	tool.SetCollaborationAllowlistChecker(func(targetAgentID string) bool {
+		return targetAgentID == "researcher"
+	})
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"agent_id": "researcher",
+		"task":     "summarize the logs",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.ForLLM)
+	}
+	if spawner.calls != 0 {
+		t.Fatalf("spawner.calls = %d, want 0", spawner.calls)
+	}
+	if runtime.calls != 1 {
+		t.Fatalf("runtime.calls = %d, want 1", runtime.calls)
+	}
+	if runtime.lastParams.ToAgentID != "researcher" {
+		t.Fatalf("ToAgentID = %q, want researcher", runtime.lastParams.ToAgentID)
 	}
 }
 

--- a/pkg/tools/delegate_test.go
+++ b/pkg/tools/delegate_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/sipeed/picoclaw/pkg/collab"
 )
 
 // delegateMockSpawner records the config and returns a canned result.
@@ -12,6 +14,12 @@ type delegateMockSpawner struct {
 	lastCfg SubTurnConfig
 	result  *ToolResult
 	err     error
+}
+
+type delegateMockCollaborationRuntime struct {
+	lastParams AgentRequestParams
+	response   *AgentRequestResponse
+	err        error
 }
 
 func (m *delegateMockSpawner) SpawnSubTurn(_ context.Context, cfg SubTurnConfig) (*ToolResult, error) {
@@ -26,6 +34,40 @@ func (m *delegateMockSpawner) SpawnSubTurn(_ context.Context, cfg SubTurnConfig)
 		ForLLM:  "completed: " + cfg.SystemPrompt,
 		ForUser: "completed",
 	}, nil
+}
+
+func (m *delegateMockCollaborationRuntime) Request(
+	_ context.Context,
+	params AgentRequestParams,
+) (*AgentRequestResponse, error) {
+	m.lastParams = params
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.response != nil {
+		return m.response, nil
+	}
+	return &AgentRequestResponse{
+		ThreadID:    "thread_1",
+		MessageID:   "msg_1",
+		FromAgentID: params.ToAgentID,
+		Content:     "completed: " + params.Content,
+		Status:      "replied",
+	}, nil
+}
+
+func (m *delegateMockCollaborationRuntime) Reply(
+	context.Context,
+	AgentReplyParams,
+) (*AgentReplyResponse, error) {
+	return nil, fmt.Errorf("unexpected Reply call")
+}
+
+func (m *delegateMockCollaborationRuntime) Inbox(
+	context.Context,
+	AgentInboxParams,
+) (*AgentInboxResponse, error) {
+	return nil, fmt.Errorf("unexpected Inbox call")
 }
 
 func TestDelegateTool_Name(t *testing.T) {
@@ -90,6 +132,33 @@ func TestDelegateTool_Execute_Success(t *testing.T) {
 	}
 	if spawner.lastCfg.SystemPrompt != "summarize the logs" {
 		t.Errorf("SystemPrompt = %q, want %q", spawner.lastCfg.SystemPrompt, "summarize the logs")
+	}
+}
+
+func TestDelegateTool_Execute_UsesCollaborationRuntimeWhenConfigured(t *testing.T) {
+	runtime := &delegateMockCollaborationRuntime{}
+	tool := NewDelegateTool()
+	tool.SetRuntime(runtime)
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"agent_id": "researcher",
+		"task":     "summarize the logs",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.ForLLM)
+	}
+	if runtime.lastParams.ToAgentID != "researcher" {
+		t.Fatalf("ToAgentID = %q, want researcher", runtime.lastParams.ToAgentID)
+	}
+	if !runtime.lastParams.Wait {
+		t.Fatal("delegate should wait for collaboration reply")
+	}
+	if runtime.lastParams.ContextPolicy != collab.ContextPolicyTaskOnly {
+		t.Fatalf("ContextPolicy = %q, want task_only", runtime.lastParams.ContextPolicy)
+	}
+	if !strings.Contains(result.ForLLM, `[Response from agent "researcher"]`) {
+		t.Fatalf("result.ForLLM = %q", result.ForLLM)
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

This PR introduces a first-class internal Agent Collaboration Bus for PicoClaw.

It adds durable inter-agent communication with:
- per-agent mailboxes
- collaboration threads with isolated session history
- structured message envelopes and delivery state
- permission-aware routing between agents
- runtime observability events for message flow
- new internal tools: `agent_request`, `agent_reply`, and `agent_inbox`

It also routes synchronous `delegate` calls through the new collaboration runtime when available, while keeping existing multi-agent primitives backward-compatible.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Issue: [#2929](https://github.com/sipeed/picoclaw/issues/2929)

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/2929
- **Reasoning:** The existing `delegate` / `spawn` / `subagent` flow worked well for one-shot delegation, but it did not provide a durable peer-to-peer communication layer between agents. This PR adds a collaboration bus scoped by `target_agent_id + thread_id`, persists mailbox/thread state, isolates collaboration history from user-facing sessions, enforces communication permissions, and emits runtime events for observability.

## 🧪 Test Environment
- **Hardware:** 
- **OS:**
- **Model/Provider:** 
- **Channels:**

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Validated with targeted tests and linting, including:
- `go test ./pkg/collab ./pkg/config ./pkg/tools ./pkg/agent -run 'TestStore_PersistsThreadsMessagesAndMailboxes|TestCollaborationBus_|TestCollaborationSessionAliases_|TestDelegateTool_Execute_UsesCollaborationRuntimeWhenConfigured|TestAgentConfig_FullParse|TestAgentRegistry_CanCollaborate_RequiresSendAndReceive|TestAgentRegistry_CommunicationDefaults' -count=1`
- `golangci-lint run -E govet -E unused ./... --build-tags=goolm,stdjson`

Key coverage includes:
- durable mailbox/thread persistence
- permission enforcement (`allow_send_to` / `allow_receive_from`)
- explicit replies and async durable replies
- thread isolation and anti-hijack checks
- closed-thread rejection
- `delegate` migration to the collaboration bus
- formatting/lint cleanup for the new code paths

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.