### PR TITLE
fix(cron): add missing action arg for command job execution

### DIFF
--- a/pkg/tools/cron.go
+++ b/pkg/tools/cron.go
@@ -320,6 +320,7 @@ func (t *CronTool) ExecuteJob(ctx context.Context, job *cron.CronJob) string {
 		}
 
 		args := map[string]any{
+			"action":    "run",
 			"command":   job.Payload.Command,
 			"__channel": channel,
 			"__chat_id": chatID,

--- a/pkg/tools/cron_test.go
+++ b/pkg/tools/cron_test.go
@@ -329,6 +329,31 @@ func TestCronTool_ExecuteJobSkipsWhenMessageToolAlreadySent(t *testing.T) {
 	}
 }
 
+func TestCronTool_ExecuteJobRunsCommand(t *testing.T) {
+	tool := newTestCronToolWithConfig(t, config.DefaultConfig())
+	job := &cron.CronJob{}
+	job.Payload.Channel = "cli"
+	job.Payload.To = "direct"
+	job.Payload.Command = "echo cron-test-ok"
+
+	if got := tool.ExecuteJob(context.Background(), job); got != "ok" {
+		t.Fatalf("ExecuteJob() = %q, want ok", got)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var msg bus.OutboundMessage
+	select {
+	case msg = <-tool.msgBus.OutboundChan():
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for outbound message")
+	}
+	if !strings.Contains(msg.Content, "cron-test-ok") {
+		t.Fatalf("expected command output containing 'cron-test-ok', got: %s", msg.Content)
+	}
+}
+
 func TestCronTool_ExecuteJobReturnsErrorWithoutPublish(t *testing.T) {
 	executor := &stubJobExecutor{
 		response: "this response must not be published",


### PR DESCRIPTION
## 📝 Description

`CronTool.ExecuteJob()` calls `ExecTool.Execute()` without `"action": "run"` in the args map. The exec tool requires that field and returns `ErrorResult("action is required")` immediately. As a result all cron command jobs silently fail :sob: 

This is a regression from 3f1ac297, which refactored the exec tool to require an `action` parameter. The cron caller from 7b9fdaec was never updated though it seems like. 

Fix just adds the missing arg and a test for the command execution path. No need for doc updates. 

## 🗣️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation

- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 📸 Evidence (Optional)

<details>
<summary>Click to view Logs/Screenshots</summary>

Before fix - command jobs complete in ~6ms with no shell execution:

```
[cron] ▶ executing job 'ping-usage-windows' (id: ..., schedule: cron, channel: cli)
[cron] ✓ job 'ping-usage-windows' completed in 6ms, next run: ...
```

After fix - command runs and produces output:

```
[cron] ▶ executing job 'cron-test' (id: ..., schedule: at, channel: cli)
[cron] ✓ job 'cron-test' completed in 142ms, next run: (deleted)
```

Test added: `TestCronTool_ExecuteJobRunsCommand` - fails without fix, passes with it.

</details>

## ☑️ Checklist

- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
