### PR TITLE
fix(config): use canonical hyphenated model ID for default claude-sonnet entry

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -88,7 +88,7 @@ func DefaultConfig() *Config {
 			{
 				ModelName: "claude-sonnet-4.6",
 				Provider:  "anthropic",
-				Model:     "claude-sonnet-4.6",
+				Model:     "claude-sonnet-4-6",
 				APIBase:   "https://api.anthropic.com/v1",
 			},
 


### PR DESCRIPTION
## Summary

The seeded default Anthropic entry in `pkg/config/defaults.go` writes `"claude-sonnet-4.6"` (dotted) into the `Model` field. `Model` is sent verbatim to the API; Anthropic's canonical ID uses hyphens. A fresh launcher install therefore fails on the very first message with:

```
{"error":{"code":"not_found_error","message":"model: claude-sonnet-4.6 was not found. Did you mean claude-sonnet-4-6?","type":"invalid_request_error"}}
```

The fix changes only `Model` (`claude-sonnet-4-6`). `ModelName` stays `claude-sonnet-4.6` so the user-facing alias is unchanged — UX preserved, wire ID corrected.

Fixes #2941.

## Why this was masked for some users

The OAuth-based Anthropic provider at `pkg/providers/anthropic/provider.go:217-219` already normalizes dots to hyphens before calling the SDK:

```go
// Normalize model ID: Anthropic API uses hyphens (claude-sonnet-4-6),
// but config may use dots (claude-sonnet-4.6).
apiModel := strings.ReplaceAll(model, ".", "-")
```

So installs that authenticate via `auth_method: "oauth"` / `"token"` never hit the bug. API-key users (which route through `openai_compat` and `anthropic_messages`, neither of which normalizes) reproduce it immediately.

## Test plan

- [x] `go test ./pkg/config/...` — green.
- [x] Manual: confirmed the issue with a freshly-spun second instance against the launcher image built from current `main`. After applying this patch in a rebuilt image, the same fresh-install flow succeeds.

## Optional follow-up (not in this PR)

Worth considering whether `openai_compat` and `anthropic_messages` should also normalize dots → hyphens for the Anthropic protocol family, to harden against the same footgun if a user pastes a dotted ID elsewhere. Left out here because it's a wider judgment call.