### PR TITLE
docs: add FUNDING.yml for GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [sipeed]


### PR DESCRIPTION
## 📝 Description

Add FUNDING.yml file to enable GitHub Sponsors button on the repo. This makes it easy for users who benefit from PicoClaw to support the project financially through GitHub.

## 🗣️ Type of Change
- [x] 📖 Documentation update

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)

## 🔗 Related Issue

Closes #2912

## 📚 Technical Context
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/2912
- **Reasoning:** Adding FUNDING.yml is a standard practice for open source projects to receive financial support.

## 🧪 Test Environment
- N/A (metadata file addition)

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.