### PR TITLE
fix: verify process identity in singleton PID check

### DIFF
--- a/pkg/pid/pidfile.go
+++ b/pkg/pid/pidfile.go
@@ -58,7 +58,12 @@ func WritePidFile(homePath, host string, port int) (*PidFileData, error) {
 	if data, err := readPidFileUnlocked(pidPath); err == nil {
 		if os.Getpid() != data.PID {
 			logger.Infof("found pid file (PID: %d, version: %s)", data.PID, data.Version)
-			if isProcessRunning(data.PID) {
+			// PID 1 is typically init/systemd on the host or the entrypoint
+			// inside a container. When a container stops and leaves behind a
+			// PID file on a shared volume, the host's PID 1 (init) would
+			// pass the isProcessRunning check, blocking new gateway starts.
+			// Treat recorded PID 1 as always stale.
+			if data.PID != 1 && isProcessRunning(data.PID) && isPicoclawProcess(data.PID) {
 				return nil, fmt.Errorf("gateway is already running (PID: %d, version: %s)", data.PID, data.Version)
 			}
 			logger.Warnf("not running (PID: %d) so will remove the pid file: %s", data.PID, pidPath)
@@ -124,11 +129,24 @@ func ReadPidFileWithCheck(homePath string) *PidFileData {
 		return nil
 	}
 
-	if !isProcessRunning(data.PID) {
-		logger.Debugf("process not running, remove pid file: %s", pidPath)
+	// Treat PID 1 as stale when we are not PID 1 ourselves (container
+	// leftover on a shared volume — host PID 1 is init, not gateway).
+	if data.PID == 1 && os.Getpid() != 1 {
+		logger.Debugf("stale container PID 1, remove pid file: %s", pidPath)
 		os.Remove(pidPath)
 		return nil
 	}
+
+	// Check if process is running AND is actually a picoclaw process.
+	// This prevents stale PID files from blocking gateway startup when
+	// the PID has been reused by an unrelated process (e.g. systemd-resolved).
+	if isProcessRunning(data.PID) && isPicoclawProcess(data.PID) {
+		return data
+	}
+
+	logger.Debugf("process not running or not a picoclaw process, remove pid file: %s", pidPath)
+	os.Remove(pidPath)
+	return nil
 
 	return data
 }

--- a/pkg/pid/pidfile_unix.go
+++ b/pkg/pid/pidfile_unix.go
@@ -27,3 +27,63 @@ func isProcessRunning(pid int) bool {
 	// EPERM means the process exists but we are not allowed to signal it.
 	return errors.As(err, &errno) && errno == syscall.EPERM
 }
+
+// isPicoclawProcess checks whether the process with the given PID is actually
+// a picoclaw gateway process by reading /proc/<pid>/comm.
+func isPicoclawProcess(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	// Read /proc/<pid>/comm to get the process name
+	comm, err := os.ReadFile(procCommPath(pid))
+	if err != nil {
+		return false
+	}
+	// Check if the process name contains "picoclaw"
+	return containsString(string(comm), "picoclaw")
+}
+
+// procCommPath returns the path to the comm file for a given PID.
+func procCommPath(pid int) string {
+	return "/proc/" + itoa(pid) + "/comm"
+}
+
+// itoa converts an integer to its string representation.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	negative := n < 0
+	if negative {
+		n = -n
+	}
+	digits := make([]byte, 0, 10)
+	for n > 0 {
+		digits = append(digits, byte('0'+n%10))
+		n /= 10
+	}
+	// Reverse the digits
+	for i, j := 0, len(digits)-1; i < j; i, j = i+1, j-1 {
+		digits[i], digits[j] = digits[j], digits[i]
+	}
+	if negative {
+		digits = append([]byte{'-'}, digits...)
+	}
+	return string(digits)
+}
+
+// containsString checks if s contains substr.
+func containsString(s, substr string) bool {
+	if len(substr) == 0 {
+		return true
+	}
+	if len(substr) > len(s) {
+		return false
+	}
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## 📝 Description

Fix startup failure when the PID file contains a PID that has been reused by an unrelated process (e.g. `systemd-resolved`). The singleton check only verified that a process with the recorded PID exists, but did not verify that it is actually a picoclaw gateway process.

This PR adds a check for `/proc/<pid>/comm` to verify the process name contains "picoclaw" before considering the PID file valid. If the PID belongs to a different process, the stale PID file is cleaned up and startup proceeds normally.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)

## 🔗 Related Issue

Closes #2720

## 📚 Technical Context
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/2720
- **Reasoning:** The `isProcessRunning` function uses `signal(0)` which only checks if a process exists. By adding `isPicoclawProcess` that reads `/proc/<pid>/comm`, we can verify the process is actually a picoclaw instance.

## 🧪 Test Environment
- **Hardware:** PC / Server
- **OS:** Linux (Unix-like systems)
- **Model/Provider:** N/A

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.