### PR TITLE
fix(channels): prevent tool_calls from being dropped during streaming

### DIFF
--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -169,6 +169,13 @@ func outboundMessageIsToolFeedback(msg bus.OutboundMessage) bool {
 	return strings.EqualFold(strings.TrimSpace(msg.Context.Raw["message_kind"]), "tool_feedback")
 }
 
+func outboundMessageIsToolCalls(msg bus.OutboundMessage) bool {
+	if len(msg.Context.Raw) == 0 {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(msg.Context.Raw["message_kind"]), "tool_calls")
+}
+
 func outboundMessageHasAuxiliaryKind(msg bus.OutboundMessage) bool {
 	if len(msg.Context.Raw) == 0 {
 		return false
@@ -379,6 +386,7 @@ func (m *Manager) preSend(ctx context.Context, name string, msg bus.OutboundMess
 	}
 
 	isToolFeedback := outboundMessageIsToolFeedback(msg)
+	isToolCalls := outboundMessageIsToolCalls(msg)
 	isAuxiliaryMessage := outboundMessageHasAuxiliaryKind(msg)
 	isFinalMessage := outboundMessageIsFinal(msg)
 	separateToolFeedbackMessages := m.toolFeedbackSeparateMessagesEnabled()
@@ -388,7 +396,9 @@ func (m *Manager) preSend(ctx context.Context, name string, msg bus.OutboundMess
 	// finalization bypasses the worker queue, so older queued feedback/thoughts
 	// can arrive before the normal final outbound message that cleans up the
 	// marker and placeholder.
-	if isAuxiliaryMessage {
+	// Note: tool_calls messages must NOT be dropped as they represent new tool
+	// invocations for the current turn that must be delivered to the UI.
+	if isAuxiliaryMessage && !isToolCalls {
 		if _, loaded := m.streamActive.Load(streamKey); loaded {
 			return nil, true
 		}


### PR DESCRIPTION
## Summary

- Fix tool_calls messages being incorrectly filtered as auxiliary messages during streaming
- Add `outboundMessageIsToolCalls()` helper function
- Exclude tool_calls from auxiliary message filtering in `preSend()`

## Problem

The auxiliary message filtering introduced in #2892 incorrectly drops `tool_calls` messages when:
1. There is an active stream for the chat
2. There is a tombstone from a recently finished stream (30-second window)

This causes tool_calls to not be delivered to the pico channel UI when users make consecutive requests, as the second request's tool_calls message arrives while the first request's stream is still active or within the tombstone window.

## Root Cause

`outboundMessageHasAuxiliaryKind()` returns `true` for any message with `message_kind` set, which includes `tool_calls`. The filtering logic in `preSend()` then drops these messages to prevent stale feedback/thoughts from leaking after streaming.

However, `tool_calls` messages represent new tool invocations for the current turn - they are not stale auxiliary content and must be delivered to the UI.

## Fix

Exclude `tool_calls` from auxiliary message filtering:
```go
isToolCalls := outboundMessageIsToolCalls(msg)
if isAuxiliaryMessage && !isToolCalls {
    // filtering logic
}
```

## Test plan

- [x] Send consecutive tool-invoking requests via pico channel
- [x] Verify all tool_calls messages are delivered to the UI
- [x] Verify stale feedback/thoughts are still correctly filtered

🤖 Generated with [Claude Code](https://claude.ai/code)