### PR TITLE
fix(tools): stop workspace guard misreading scheme-less URLs

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -1155,6 +1155,21 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 				}
 			}
 
+			// Skip a "/path" match that is the path component of a scheme-less
+			// URL (e.g. "wttr.in/Beijing" — curl accepts URLs without an explicit
+			// http:// prefix), which is a URL token, not an absolute-path argument
+			// (issue #1042). We skip ONLY when the run of characters immediately
+			// before the "/" parses as a hostname/authority. This deliberately
+			// does NOT skip flag-glued absolute paths like "tar -xC/etc/cron.d"
+			// (preceding token "-xC" starts with "-") or "cat $x/etc/passwd"
+			// (token "x" has no dot), so genuine sandbox escapes stay blocked.
+			// A skipped match is always glued to its host with no separator, so
+			// the shell treats it as one token (a URL or relative path), never as
+			// a standalone absolute path. ".." traversal is caught earlier.
+			if hostLikeBeforeSlash(cmd, loc[0]) {
+				continue
+			}
+
 			p, err := filepath.Abs(raw)
 			if err != nil {
 				continue
@@ -1195,6 +1210,43 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 	}
 
 	return ""
+}
+
+// hostLikeBeforeSlash reports whether the characters immediately preceding the
+// byte at index i (which the caller guarantees is a '/') form a hostname such
+// as "wttr.in" or "192.168.0.1". It lets the workspace guard recognise the path
+// component of a scheme-less URL and not mistake it for an absolute-path
+// argument (issue #1042).
+//
+// To avoid whitelisting real escapes the preceding token must:
+//   - consist solely of host-legal bytes [A-Za-z0-9.-]. ':' is deliberately
+//     excluded so a path-list / remote spec like "java -cp app.jar:/etc/passwd"
+//     or "scp host:/etc/passwd" is not mistaken for a host and stays blocked;
+//   - not start with '-' (that would be a command flag, e.g. "tar -xC/etc");
+//   - contain a '.' (a bare domain or IPv4 literal; excludes "/etc", "x/etc");
+//   - not start or end with '.' (host labels cannot).
+func hostLikeBeforeSlash(cmd string, i int) bool {
+	start := i
+	for start > 0 {
+		c := cmd[start-1]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '.' || c == '-' {
+			start--
+			continue
+		}
+		break
+	}
+	token := cmd[start:i]
+	if len(token) == 0 || token[0] == '-' {
+		return false
+	}
+	if !strings.Contains(token, ".") {
+		return false
+	}
+	if token[0] == '.' || token[len(token)-1] == '.' {
+		return false
+	}
+	return true
 }
 
 func (t *ExecTool) SetTimeout(timeout time.Duration) {

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -1214,7 +1214,7 @@ func (t *ExecTool) guardCommand(command, cwd string) string {
 
 // hostLikeBeforeSlash reports whether the characters immediately preceding the
 // byte at index i (which the caller guarantees is a '/') form a hostname such
-// as "wttr.in" or "192.168.0.1". It lets the workspace guard recognise the path
+// as "wttr.in" or "192.168.0.1". It lets the workspace guard recognize the path
 // component of a scheme-less URL and not mistake it for an absolute-path
 // argument (issue #1042).
 //

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -634,6 +634,52 @@ func TestShellTool_URLsNotBlocked(t *testing.T) {
 	}
 }
 
+// TestShellTool_SchemelessURLGuard verifies the workspace guard for issue #1042:
+// scheme-less URL path components (curl accepts URLs without an explicit
+// http:// prefix) are not mistaken for absolute paths, while flag-glued and
+// other genuine out-of-workspace absolute paths stay blocked. It calls
+// guardCommand directly so it exercises the guard deterministically without
+// running the command (no network).
+func TestShellTool_SchemelessURLGuard(t *testing.T) {
+	tmpDir := t.TempDir()
+	tool, err := NewExecTool(tmpDir, true)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+
+	// Scheme-less URLs: the "/path" belongs to the host token, not a real path.
+	allowed := []string{
+		`curl -s "wttr.in/Beijing?T"`,
+		"curl wttr.in/Beijing",
+		"curl -s wttr.in/Taipei?format=3",
+		"curl ifconfig.me/ip",
+		"curl 192.168.1.1/status",
+	}
+	for _, cmd := range allowed {
+		if got := tool.guardCommand(cmd, tmpDir); got != "" {
+			t.Errorf("scheme-less URL should not be blocked: %q\n  guard: %s", cmd, got)
+		}
+	}
+
+	// Genuine out-of-workspace absolute paths must stay blocked, including ones
+	// glued to a flag (-C) or a shell variable, which must not be whitelisted as
+	// hosts. Regression guard against the host-detection bypass class.
+	blocked := []string{
+		"tar -xC/etc/cron.d -f payload.tar", // flag-glued -C path
+		"git -C/etc/foo status",             // flag-glued -C path
+		"cat $x/etc/passwd",                 // var-prefixed; "x" has no dot
+		"cat /etc/passwd",                   // plain absolute path
+		"cp secret //etc/passwd",            // "//" not after a web scheme
+		"java -cp app.jar:/etc/passwd Main", // ':' path-list, not a host:port
+		"scp host:/etc/passwd dest",         // remote spec with absolute path
+	}
+	for _, cmd := range blocked {
+		if got := tool.guardCommand(cmd, tmpDir); got == "" {
+			t.Errorf("out-of-workspace path should be blocked: %q", cmd)
+		}
+	}
+}
+
 // TestShellTool_FileURISandboxing verifies that file:// URIs that escape the
 // workspace are still blocked, even though other URLs are allowed (issue #1254).
 func TestShellTool_FileURISandboxing(t *testing.T) {


### PR DESCRIPTION
## Description

When `restrict_to_workspace` is enabled, the `exec` tool's `guardCommand`
extracted every `/...`-led run from the command and treated each as an absolute
path. A **scheme-less URL** — which `curl` accepts without an explicit `http://`
prefix, e.g. `curl -s "wttr.in/Beijing?T"` — had its `/Beijing?T` component
matched, resolved with `filepath.Abs`, and `filepath.Rel(cwd, …)` turned it into
`../../Beijing?T`, tripping the `..` "path outside working dir" check. Reporters
note this makes **most curl-based skills unusable**.

## Fix

Skip a `/path` match **only** when the run of characters immediately before the
slash parses as a hostname: host-legal bytes `[A-Za-z0-9.-]`, not starting with
`-`, containing a `.`, not starting/ending with `.`.

Because a skipped match is glued to its host with **no separator**, the shell
treats the whole word as a single URL/relative token — never a standalone
absolute path. The skip therefore cannot whitelist a real escape:

| Command | Left token | Skipped? | Result |
|---|---|---|---|
| `curl wttr.in/Beijing` | `wttr.in` | ✅ host | allowed |
| `curl 192.168.1.1/status` | `192.168.1.1` | ✅ host | allowed |
| `tar -xC/etc/cron.d …` | `-xC` (starts `-`) | ❌ | **blocked** |
| `cat $x/etc/passwd` | `x` (no dot) | ❌ | **blocked** |
| `java -cp app.jar:/etc/passwd` | empty (walk stops at `:`) | ❌ | **blocked** |
| `scp host:/etc/passwd` | empty (stops at `:`) | ❌ | **blocked** |
| `cat /etc/passwd` | empty (stops at space) | ❌ | **blocked** |

`..` traversal is still caught by the existing pre-loop check; the existing
web-scheme (`//host` after `http:`/`https:`/…) skip is unchanged.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## AI Code Generation
- [x] 🤖 Fully AI-generated (AI-written, human-reviewed + validated)

The fix approach was human-selected and the security boundary was hardened
across three independent adversarial review passes — two of which found and
closed sandbox-escape classes (flag-glued `-C` paths, and `:` path-lists) before
this PR was opened.

## Related Issue
Fixes #1042

## Technical Context
- Root cause: `pkg/tools/shell.go` `absolutePathPattern` (`/[^\s"']+`) matches a
  URL's host-relative path component; the prior exemption only covered `//` after
  a web scheme, not scheme-less hosts.
- New helper `hostLikeBeforeSlash` gates the skip on a hostname check.
- `:` is deliberately excluded from the host-character walk so classpath /
  remote-spec path-lists (`java -cp a.jar:/abs`, `scp host:/abs`) are not mistaken
  for `host:port` and stay blocked.

## Test Environment
- OS: macOS (Darwin) · Go 1.25
- `go test ./pkg/tools/`: new `TestShellTool_SchemelessURLGuard` passes (5
  scheme-less URLs allowed + 5 escape regressions blocked); existing
  `TestShellTool_URLsNotBlocked` / `URLBypassPrevented` / `PathTraversalVariants`
  / `RestrictToWorkspace` / `SafePaths` all pass.
- `TestShellTool_DevNullAllowed` and `TestShellTool_FileURISandboxing` fail
  locally **only** due to the macOS `/tmp`→`/private/tmp` symlink (pre-existing on
  `main`, unrelated to this change); they pass on Linux CI.

## Checklist
- [x] I have read and tested the AI-generated code
- [x] gofmt-clean and `go vet` passes
- [x] Added test coverage (both directions, incl. escape regressions)
- [x] No new shell-injection / path-traversal surface
