### PR TITLE
fix(codex): preserve streamed output text deltas

### DIFF
--- a/pkg/providers/oauth/codex_provider.go
+++ b/pkg/providers/oauth/codex_provider.go
@@ -104,8 +104,12 @@ func (p *CodexProvider) Chat(
 	defer stream.Close()
 
 	var resp *responses.Response
+	var streamedText strings.Builder
 	for stream.Next() {
 		evt := stream.Current()
+		if evt.Type == "response.output_text.delta" {
+			streamedText.WriteString(evt.Delta)
+		}
 		if evt.Type == "response.completed" || evt.Type == "response.failed" || evt.Type == "response.incomplete" {
 			evtResp := evt.Response
 			if evtResp.ID != "" {
@@ -153,7 +157,11 @@ func (p *CodexProvider) Chat(
 		return nil, fmt.Errorf("codex API call: stream ended without completed response")
 	}
 
-	return orc.ParseResponseFromStruct(resp), nil
+	parsed := orc.ParseResponseFromStruct(resp)
+	if parsed.Content == "" && streamedText.Len() > 0 {
+		parsed.Content = streamedText.String()
+	}
+	return parsed, nil
 }
 
 func (p *CodexProvider) GetDefaultModel() string {

--- a/pkg/providers/oauth/codex_provider_test.go
+++ b/pkg/providers/oauth/codex_provider_test.go
@@ -374,6 +374,45 @@ func TestCodexProvider_ChatRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCodexProvider_ChatRoundTrip_OutputTextDeltaFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			http.Error(w, "not found: "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+
+		var reqBody map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		if reqBody["stream"] != true {
+			http.Error(w, "stream must be true", http.StatusBadRequest)
+			return
+		}
+
+		resp := map[string]any{
+			"id":     "resp_test",
+			"object": "response",
+			"status": "completed",
+			"output": nil,
+		}
+		writeOutputTextDeltaSSE(w, "OK", resp)
+	}))
+	defer server.Close()
+
+	provider := NewCodexProvider("test-token", "acc-123")
+	provider.client = createOpenAITestClient(server.URL, "test-token", "acc-123")
+
+	resp, err := provider.Chat(t.Context(), []Message{{Role: "user", Content: "Hello"}}, nil, "gpt-4o", map[string]any{})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+	if resp.Content != "OK" {
+		t.Errorf("Content = %q, want %q", resp.Content, "OK")
+	}
+}
+
 func TestCodexProvider_ChatRoundTrip_WebSearchDisabled(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/responses" {
@@ -645,5 +684,26 @@ func writeCompletedSSE(w http.ResponseWriter, response map[string]any) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	fmt.Fprintf(w, "event: response.completed\n")
 	fmt.Fprintf(w, "data: %s\n\n", string(b))
+	fmt.Fprintf(w, "data: [DONE]\n\n")
+}
+
+func writeOutputTextDeltaSSE(w http.ResponseWriter, delta string, response map[string]any) {
+	deltaEvent := map[string]any{
+		"type":            "response.output_text.delta",
+		"sequence_number": 1,
+		"delta":           delta,
+	}
+	completedEvent := map[string]any{
+		"type":            "response.completed",
+		"sequence_number": 2,
+		"response":        response,
+	}
+	deltaBytes, _ := json.Marshal(deltaEvent)
+	completedBytes, _ := json.Marshal(completedEvent)
+	w.Header().Set("Content-Type", "text/event-stream")
+	fmt.Fprintf(w, "event: response.output_text.delta\n")
+	fmt.Fprintf(w, "data: %s\n\n", string(deltaBytes))
+	fmt.Fprintf(w, "event: response.completed\n")
+	fmt.Fprintf(w, "data: %s\n\n", string(completedBytes))
 	fmt.Fprintf(w, "data: [DONE]\n\n")
 }

--- a/pkg/providers/oauth/codex_provider_test.go
+++ b/pkg/providers/oauth/codex_provider_test.go
@@ -404,7 +404,13 @@ func TestCodexProvider_ChatRoundTrip_OutputTextDeltaFallback(t *testing.T) {
 	provider := NewCodexProvider("test-token", "acc-123")
 	provider.client = createOpenAITestClient(server.URL, "test-token", "acc-123")
 
-	resp, err := provider.Chat(t.Context(), []Message{{Role: "user", Content: "Hello"}}, nil, "gpt-4o", map[string]any{})
+	resp, err := provider.Chat(
+		t.Context(),
+		[]Message{{Role: "user", Content: "Hello"}},
+		nil,
+		"gpt-4o",
+		map[string]any{},
+	)
 	if err != nil {
 		t.Fatalf("Chat() error: %v", err)
 	}


### PR DESCRIPTION
## 📝 Description

Fixes OpenAI/Codex OAuth empty responses when the backend streams valid text through `response.output_text.delta` but sends a final `response.completed` event with `response.output` set to `null`.

The Codex provider now accumulates streamed `output_text` delta events while reading the response stream. If the final parsed response has no content, PicoClaw falls back to the accumulated streamed text instead of reporting a false empty model response.

This also adds a regression test for the issue #2953 stream shape: `response.output_text.delta` contains `OK`, followed by `response.completed` with null output.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

Fixes #2953

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://developers.openai.com/api/docs/guides/streaming-responses?api-mode=responses
- **Reasoning:** OpenAI Responses streaming is event-driven, and text can arrive incrementally in `response.output_text.delta` events. The final `response.completed` event should be treated as stream completion; for Codex OAuth it may not include populated `response.output`, so PicoClaw needs to preserve streamed deltas before parsing the final response.

## � Test Environment
- **Hardware:** Linux development workspace / PC
- **OS:** Linux
- **Model/Provider:** OpenAI/Codex OAuth (`gpt-5.3-codex` issue path; local regression uses mocked Codex Responses stream)
- **Channels:** CLI agent


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```bash
go test ./pkg/providers/oauth -run TestCodexProvider_ChatRoundTrip_OutputTextDeltaFallback -count=1
# ok   github.com/sipeed/picoclaw/pkg/providers/oauth

go test ./pkg/providers/oauth -count=1
# ok   github.com/sipeed/picoclaw/pkg/providers/oauth

make build
# Build complete: build/picoclaw-linux-amd64
# Build complete: build/picoclaw

./build/picoclaw agent -m "hai" --model "gpt-5.4" --no-color
# ██████╗ ██╗ ██████╗ ██████╗  ██████╗██╗      # █████╗ ██╗    ██╗
# ██╔══██╗██║██╔════╝██╔═══██╗██╔════╝██# ║     ██╔══██╗██║    ██║
# ██████╔╝██║██║     ██║   ██║██║     ██║     # ███████║██║ █╗ ██║
# ██╔═══╝ ██║██║     ██║   ██║██║     ██║     # ██╔══██║██║███╗██║
# ██║     # ██║╚██████╗╚██████╔╝╚██████╗███████╗██# ║  ██║╚███╔███╔╝
# ╚═╝     ╚═╝ ╚═════╝ ╚═════╝  # ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝
#
#
# � hai 😄 what’s up?
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.