### PR TITLE
fix(providers): add Zhipu API error code 1210 to format error patterns

### DIFF
--- a/pkg/providers/error_classifier.go
+++ b/pkg/providers/error_classifier.go
@@ -111,6 +111,10 @@ var (
 		substr("tool_use_id"),
 		substr("messages.1.content.1.tool_use.id"),
 		substr("invalid request format"),
+		// Zhipu API error code 1210: parameter error (e.g., image format incompatible)
+		substr("error code: 1210"),
+		substr("error code 1210"),
+		substr("zhipu api error code: 1210"),
 	}
 	contextOverflowPatterns = []errorPattern{
 		rxp(`context[_ ]?length[_ ]?exceeded`),


### PR DESCRIPTION
## Summary

This PR fixes issue #2943 where WeChat channel image requests to Zhipu GLM-5-Turbo vision API failed with error code 1210 (parameter error) without triggering the fallback mechanism.

## Root Cause

The error classifier in `pkg/providers/error_classifier.go` did not recognize Zhipu API's error code 1210 as a format error, so the fallback mechanism was not triggered.

## Changes

- Added error code 1210 pattern matching to `formatPatterns`
- This allows the fallback mechanism to recognize Zhipu API parameter errors and fall back to alternative vision models

## Related Issue

Fixes #2943

## Testing

- Added pattern matching for error code 1210 variations
- The fallback mechanism will now properly trigger when this error is encountered