### PR TITLE
fix(deps): bump go from 1.25.10 to 1.25.11 (GO-2026-5039)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sipeed/picoclaw
 
-go 1.25.10
+go 1.25.11
 
 require (
 	fyne.io/systray v1.12.1


### PR DESCRIPTION
## 📝 Description

Bump Go from 1.25.10 to 1.25.11 to fix **GO-2026-5039**: header names are not escaped in error messages in `net/textproto`. Arbitrary inputs in errors without escaping.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## 🔗 Related Issue

Fixes **GO-2026-5039** — `net/textproto`: arbitrary inputs in errors without escaping.
- Affects: go < 1.25.11
- Fixed in: go 1.25.11

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://pkg.go.dev/vuln/GO-2026-5039
- **Reasoning:** The project currently uses go 1.25.10, which is affected by this vulnerability. No source code changes required — only the Go directive in `go.mod` needs updating.

## 🧪 Test Environment
- **Hardware:** Raspberry Pi 2 Model B
- **OS:** Debian 12 (Bookworm)
- **Model/Provider:** DeepSeek-V4-Flash
- **Channels:** Telegram

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.