### PR TITLE
fix: handle space in go env GOVERSION with firstword

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 VERSION?=$(if $(VERSION_RAW),$(VERSION_RAW),dev)
 GIT_COMMIT=$(if $(GIT_COMMIT_RAW),$(GIT_COMMIT_RAW),dev)
 BUILD_TIME=$(if $(BUILD_TIME_RAW),$(BUILD_TIME_RAW),dev)
-GO_VERSION=$(if $(GO_VERSION_RAW),$(GO_VERSION_RAW),unknown)
+GO_VERSION=$(if $(GO_VERSION_RAW),$(firstword $(GO_VERSION_RAW)),unknown)
 CONFIG_PKG=github.com/sipeed/picoclaw/pkg/config
 LDFLAGS=-X $(CONFIG_PKG).Version=$(VERSION) -X $(CONFIG_PKG).GitCommit=$(GIT_COMMIT) -X $(CONFIG_PKG).BuildTime=$(BUILD_TIME) -X $(CONFIG_PKG).GoVersion=$(GO_VERSION) -s -w
 


### PR DESCRIPTION
## Description
go env GOVERSION may return values like go1.25.10 X:nodwarf5 with an embedded space on some Go toolchain distributions. The $(strip ...) function only removes leading/trailing whitespace, so the embedded space survives and breaks the -ldflags linker arguments when passed via -X ...GoVersion=....

## Fix
Use $(firstword ) on line 30 to extract only the first token (the actual Go version), discarding any trailing metadata like X:nodwarf5.

## Type of Change
- [x] Bug fix

## AI Code Generation
Mostly Human-written (Human led; AI provided suggestions)

## Related Issue
Fixes #2976

Related PR from another contributor (stuck on CLA): #2976

## Test Environment
- OS: Windows
- Verification: $(firstword ...) is a standard GNU Make function, available on all platforms. The fix is a single-line change with no runtime implications.