### PR TITLE
fix(agent): add ok check for LoadAndDelete type assertion

### DIFF
--- a/pkg/agent/legacy_events.go
+++ b/pkg/agent/legacy_events.go
@@ -2,11 +2,13 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
 	"github.com/sipeed/picoclaw/pkg/bus"
 	runtimeevents "github.com/sipeed/picoclaw/pkg/events"
+	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
 const defaultEventSubscriberBuffer = 16
@@ -90,6 +92,10 @@ func (al *AgentLoop) UnsubscribeEvents(id uint64) {
 	}
 	sub, ok := value.(legacyEventSubscription)
 	if !ok {
+		logger.WarnCF("agent", "UnsubscribeEvents: unexpected type in subscription map", map[string]any{
+			"id":   id,
+			"type": fmt.Sprintf("%T", value),
+		})
 		return
 	}
 	sub.cancel()

--- a/pkg/agent/legacy_events.go
+++ b/pkg/agent/legacy_events.go
@@ -88,7 +88,10 @@ func (al *AgentLoop) UnsubscribeEvents(id uint64) {
 	if !ok {
 		return
 	}
-	sub := value.(legacyEventSubscription)
+	sub, ok := value.(legacyEventSubscription)
+	if !ok {
+		return
+	}
 	sub.cancel()
 	if sub.sub != nil {
 		_ = sub.sub.Close()


### PR DESCRIPTION
## Problem

`UnsubscribeEvents` uses `sync.Map.LoadAndDelete` which returns `any`, then directly asserts the value as `legacyEventSubscription` without checking `ok`. If an unexpected type were ever stored under an event ID, this would panic.

## Fix

Add a safe `ok`-checked type assertion:
```go
sub, ok := value.(legacyEventSubscription)
if !ok {
    return
}
```

## Changes

- `pkg/agent/legacy_events.go`: +4/-1

## Verification

- `go build ./pkg/agent/...` passes