### PR TITLE
fix(agent): close base64 encoder on io.Copy error path

### DIFF
--- a/pkg/agent/agent_media.go
+++ b/pkg/agent/agent_media.go
@@ -161,14 +161,22 @@ func encodeImageToDataURL(localPath, mime string, info os.FileInfo, maxSize int)
 	buf.WriteString(prefix)
 
 	encoder := base64.NewEncoder(base64.StdEncoding, &buf)
-	if _, err := io.Copy(encoder, f); err != nil {
+	_, copyErr := io.Copy(encoder, f)
+	closeErr := encoder.Close()
+	if copyErr != nil {
 		logger.WarnCF("agent", "Failed to encode media file", map[string]any{
 			"path":  localPath,
-			"error": err.Error(),
+			"error": copyErr.Error(),
 		})
 		return ""
 	}
-	encoder.Close()
+	if closeErr != nil {
+		logger.WarnCF("agent", "Failed to close base64 encoder", map[string]any{
+			"path":  localPath,
+			"error": closeErr.Error(),
+		})
+		return ""
+	}
 
 	return buf.String()
 }


### PR DESCRIPTION
## Problem

In `encodeMediaFile`, when `io.Copy` to the base64 encoder fails, `encoder.Close()` is skipped. The `base64.Encoder` buffers internal state (padding) that is never flushed, leaving an incomplete output in the buffer.

## Fix

Always call `encoder.Close()` regardless of `io.Copy` result. Check both errors separately and return on either failure.

## Changes

- `pkg/agent/agent_media.go`: +11/-3

## Verification

- `go build ./pkg/agent/...` passes