### PR TITLE
fix: type-switch capture, nil guard, check LastInsertId errors

### DIFF
--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -269,9 +269,9 @@ func (c *WhatsAppNativeChannel) Stop(ctx context.Context) error {
 }
 
 func (c *WhatsAppNativeChannel) eventHandler(evt any) {
-	switch evt.(type) {
+	switch v := evt.(type) {
 	case *events.Message:
-		c.handleIncoming(evt.(*events.Message))
+		c.handleIncoming(v)
 	case *events.Disconnected:
 		logger.InfoCF("whatsapp", "WhatsApp disconnected, will attempt reconnection", nil)
 		c.reconnectMu.Lock()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -194,6 +194,9 @@ type ExposePath struct {
 // Uses strings.Replacer for O(n+m) performance (computed once per SecurityConfig).
 // Short content (below FilterMinLength) is returned unchanged for performance.
 func (c *Config) FilterSensitiveData(content string) string {
+	if c == nil {
+		return content
+	}
 	// Check if filtering is enabled (default: true)
 	if !c.Tools.IsFilterSensitiveDataEnabled() {
 		return content

--- a/pkg/seahorse/store.go
+++ b/pkg/seahorse/store.go
@@ -56,7 +56,10 @@ func (s *Store) GetOrCreateConversation(ctx context.Context, sessionKey string) 
 		}
 		return nil, fmt.Errorf("create conversation: %w", err)
 	}
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("get last insert id: %w", err)
+	}
 	return &Conversation{
 		ConversationID: id,
 		SessionKey:     sessionKey,
@@ -193,7 +196,10 @@ func (s *Store) AddMessageWithReasoning(
 	if err != nil {
 		return nil, fmt.Errorf("add message: %w", err)
 	}
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("get last insert id: %w", err)
+	}
 	return &Message{
 		ID:               id,
 		ConversationID:   convID,
@@ -282,7 +288,10 @@ func (s *Store) AddMessageWithPartsAndReasoning(
 	if err != nil {
 		return nil, fmt.Errorf("add message: %w", err)
 	}
-	msgID, _ := result.LastInsertId()
+	msgID, err := result.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("get last insert id: %w", err)
+	}
 
 	for i, p := range parts {
 		_, err = tx.ExecContext(


### PR DESCRIPTION
## Problem

Three defensive fixes:

1. **WhatsApp channel** (`whatsapp_native.go:272`): `switch evt.(type)` type-switch followed by redundant unchecked `evt.(*events.Message)` assertion. Should use type-switch capture pattern `switch v := evt.(type)`.

2. **Config** (`config.go:196`): `FilterSensitiveData` has no nil receiver guard. Called on nil `*Config` the method panics.

3. **Seahorse store** (`store.go:59,196,285`): `result.LastInsertId()` error discarded with `_` in 3 locations. On unexpected failure, `id` is 0 which could cause subtle bugs (ID 0 indistinguishable from zero-value).

## Fix

1. Use `switch v := evt.(type)` to capture typed value.
2. Add `if c == nil { return content }` guard.
3. Check and return `LastInsertId()` errors with wrapped error messages.

## Changes

- `pkg/channels/whatsapp_native/whatsapp_native.go`: +2/-2
- `pkg/config/config.go`: +3
- `pkg/seahorse/store.go`: +12/-3

## Verification

- `go build ./pkg/channels/whatsapp_native/... ./pkg/config/... ./pkg/seahorse/...` passes