### PR TITLE
fix: add ok checks for sync.Map LoadAndDelete/Load type assertions

### DIFF
--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -746,8 +746,8 @@ func (c *FeishuChannel) isBotMentioned(message *larkim.EventMessage) bool {
 		return false
 	}
 
-	knownID, _ := c.botOpenID.Load().(string)
-	if knownID == "" {
+	knownID, ok := c.botOpenID.Load().(string)
+	if !ok || knownID == "" {
 		logger.DebugCF("feishu", "Bot open_id unknown, cannot detect @mention", nil)
 		return false
 	}

--- a/pkg/channels/slack/slack.go
+++ b/pkg/channels/slack/slack.go
@@ -154,7 +154,10 @@ func (c *SlackChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]str
 	}
 
 	if ref, ok := c.pendingAcks.LoadAndDelete(deliveryChatID); ok {
-		msgRef := ref.(slackMessageRef)
+		msgRef, ok := ref.(slackMessageRef)
+		if !ok {
+			return []string{ts}, nil
+		}
 		c.api.AddReaction("white_check_mark", slack.ItemRef{
 			Channel:   msgRef.ChannelID,
 			Timestamp: msgRef.Timestamp,

--- a/pkg/isolation/platform_windows.go
+++ b/pkg/isolation/platform_windows.go
@@ -62,7 +62,10 @@ func postStartPlatformIsolation(cmd *exec.Cmd, isolation config.IsolationConfig,
 	if !isolation.Enabled || cmd == nil || cmd.Process == nil {
 		return nil
 	}
-	resourcesAny, _ := windowsPendingResources.LoadAndDelete(cmd)
+	resourcesAny, loaded := windowsPendingResources.LoadAndDelete(cmd)
+	if !loaded {
+		return nil
+	}
 	resources, _ := resourcesAny.(windowsProcessResources)
 	// Job objects can only be attached after the process exists, so the Windows
 	// backend finishes isolation in this post-start hook.


### PR DESCRIPTION
Add ok checks for sync.Map.Load and sync.Map.LoadAndDelete type assertions
in three files:

- slack.go: unchecked assertion on pendingAcks LoadAndDelete
- platform_windows.go: unchecked assertion on windowsPendingResources
  LoadAndDelete
- feishu_64.go: unchecked assertion on botOpenID atomic.Value.Load