### PR TITLE
fix: check Close() errors in updater extraction functions

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -584,8 +584,13 @@ func extractZip(archivePath, destDir string) error {
 			out.Close()
 			return err
 		}
-		rc.Close()
-		out.Close()
+		if err := rc.Close(); err != nil {
+			out.Close()
+			return fmt.Errorf("close zip entry reader: %w", err)
+		}
+		if err := out.Close(); err != nil {
+			return fmt.Errorf("close extracted file %q: %w", target, err)
+		}
 	}
 	return nil
 }
@@ -649,7 +654,9 @@ func extractTarFromReader(tr *tar.Reader, destDir string) error {
 				out.Close()
 				return err
 			}
-			out.Close()
+			if err := out.Close(); err != nil {
+				return fmt.Errorf("close extracted file %q: %w", target, err)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
In extractZip and extractTarFromReader, Close() errors on files opened
with O_WRONLY|O_CREATE|O_TRUNC were silently ignored. A failed Close()
can indicate a write/flush failure (disk full, I/O error), which would
silently produce a corrupted or truncated extracted file.

In the self-update path, this could result in a broken binary being
installed.

Check and propagate Close() errors in both success paths.