### PR TITLE
fix: check Close() error after downloading media file

### DIFF
--- a/pkg/utils/media.go
+++ b/pkg/utils/media.go
@@ -146,7 +146,6 @@ func DownloadFile(urlStr, filename string, opts DownloadOptions) string {
 		})
 		return ""
 	}
-	defer out.Close()
 
 	if _, err := io.Copy(out, resp.Body); err != nil {
 		out.Close()
@@ -154,6 +153,13 @@ func DownloadFile(urlStr, filename string, opts DownloadOptions) string {
 		logger.ErrorCF(opts.LoggerPrefix, "Failed to write file", map[string]any{
 			"error": err.Error(),
 		})
+		return ""
+	}
+	if err := out.Close(); err != nil {
+		logger.ErrorCF(opts.LoggerPrefix, "Failed to close downloaded file", map[string]any{
+			"error": err.Error(),
+		})
+		os.Remove(localPath)
 		return ""
 	}
 


### PR DESCRIPTION
After downloading a media file via io.Copy, out.Close() errors were
silently ignored. A failed Close() can indicate a write/flush failure
(disk full, I/O error), which would silently return a truncated or
corrupted file path to callers for further use.

Replace defer out.Close() with explicit error checking. On Close()
failure, log the error and clean up the partial file.