### PR TITLE
fix: check Close() error after io.Copy to writable files

### DIFF
--- a/cmd/picoclaw/internal/skills/helpers.go
+++ b/cmd/picoclaw/internal/skills/helpers.go
@@ -345,9 +345,11 @@ func copyDirectory(src, dst string) error {
 		if err != nil {
 			return err
 		}
-		defer dstFile.Close()
 
-		_, err = io.Copy(dstFile, srcFile)
-		return err
+		_, copyErr := io.Copy(dstFile, srcFile)
+		if closeErr := dstFile.Close(); closeErr != nil && copyErr == nil {
+			return fmt.Errorf("close destination file %s: %w", dstPath, closeErr)
+		}
+		return copyErr
 	})
 }

--- a/pkg/migrate/internal/common.go
+++ b/pkg/migrate/internal/common.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -149,8 +150,10 @@ func CopyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer dstFile.Close()
 
-	_, err = io.Copy(dstFile, srcFile)
-	return err
+	_, copyErr := io.Copy(dstFile, srcFile)
+	if closeErr := dstFile.Close(); closeErr != nil && copyErr == nil {
+		return fmt.Errorf("close destination file %s: %w", dst, closeErr)
+	}
+	return copyErr
 }


### PR DESCRIPTION
In two file copy functions, defer dstFile.Close() was used after io.Copy,
silently swallowing Close() errors on writable destination files. A
failed Close() can indicate a write/flush failure (full disk, I/O
error), producing a truncated file without any error signal to callers.

Replace defer with explicit Close() after io.Copy. Only return the
Close() error when io.Copy itself succeeded, to avoid masking the
original copy error.