### PR TITLE
fix(config): use canonical Anthropic default model ID

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -907,6 +907,29 @@ func TestDefaultConfig_WorkspacePath(t *testing.T) {
 	}
 }
 
+// TestDefaultConfig_AnthropicModelsUseClaudeAPIIDs verifies that first-party
+// Anthropic defaults use Claude API model IDs, not dotted display names or
+// Bedrock-style provider prefixes. See:
+// https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions
+func TestDefaultConfig_AnthropicModelsUseClaudeAPIIDs(t *testing.T) {
+	cfg := DefaultConfig()
+
+	checked := 0
+	for _, model := range cfg.ModelList {
+		if model.Provider != "anthropic" {
+			continue
+		}
+		checked++
+		if strings.Contains(model.Model, ".") {
+			t.Fatalf("Anthropic default model %q uses dotted ID %q", model.ModelName, model.Model)
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("DefaultConfig() missing Anthropic models")
+	}
+}
+
 // TestDefaultConfig_MaxTokens verifies max tokens has default value
 func TestDefaultConfig_MaxTokens(t *testing.T) {
 	cfg := DefaultConfig()

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -88,7 +88,7 @@ func DefaultConfig() *Config {
 			{
 				ModelName: "claude-sonnet-4.6",
 				Provider:  "anthropic",
-				Model:     "claude-sonnet-4.6",
+				Model:     "claude-sonnet-4-6",
 				APIBase:   "https://api.anthropic.com/v1",
 			},
 

--- a/pkg/providers/factory_provider_test.go
+++ b/pkg/providers/factory_provider_test.go
@@ -1081,6 +1081,21 @@ func TestModelProviderOptions(t *testing.T) {
 	} else if option.DefaultAPIBase != "https://api.anthropic.com/v1" {
 		t.Fatalf("anthropic default_api_base = %q, want %q", option.DefaultAPIBase, "https://api.anthropic.com/v1")
 	}
+	// First-party Claude API model IDs use hyphenated formats such as
+	// claude-{name}-{major}-{minor} or claude-{name}-{major}-{minor}-{YYYYMMDD};
+	// dotted provider prefixes are for platform-specific IDs such as Bedrock.
+	// https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions
+	for _, provider := range []string{"anthropic", "anthropic-messages"} {
+		option, ok := seen[provider]
+		if !ok {
+			t.Fatalf("%s option missing", provider)
+		}
+		for _, model := range option.CommonModels {
+			if strings.Contains(model, ".") {
+				t.Fatalf("%s common_model %q uses dotted ID", provider, model)
+			}
+		}
+	}
 	if _, ok := seen["azure"]; !ok {
 		t.Fatal("azure option missing")
 	}


### PR DESCRIPTION
## Summary

- keep the seeded Anthropic ModelName as the user-facing claude-sonnet-4.6 alias
- change the actual default Model sent to Anthropic from claude-sonnet-4.6 to claude-sonnet-4-6
- add regression coverage that first-party Anthropic default models and Anthropic common models do not use dotted Claude API IDs

Fixes #2941.

## Reference

Anthropic documents Claude API model IDs as hyphenated formats such as claude-{name}-{major}-{minor} for the 4.6 generation and later, while dotted prefixes are platform-specific IDs such as Bedrock:
https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions

## Test plan

- go test ./pkg/config/...
- go test ./pkg/providers/...