### PR TITLE
fix: add ok check for singleflight type assertion in model probe

### DIFF
--- a/web/backend/api/model_status.go
+++ b/web/backend/api/model_status.go
@@ -208,7 +208,10 @@ func (s *modelProbeCacheState) probe(cacheKey string, probeFunc func() bool) boo
 		return result, nil
 	})
 
-	result, _ := v.(bool)
+	result, ok := v.(bool)
+	if !ok {
+		return false
+	}
 	return result
 }
 


### PR DESCRIPTION
## Problem

In `runCachedModelProbe`, `singleflight.Group.Do()` returns `any`, and the result is directly type-asserted as `bool` without an `ok` check:

```go
result, _ := v.(bool)
return result
```

If a non-bool value is ever returned (e.g. `nil` from a shared/cache edge case), this panics at runtime.

## Fix

Add `ok` check and return `false` (probe failed) as a safe default when the type assertion fails: +3 lines.

## Changes

- `web/backend/api/model_status.go`: +3/-1

## Verification

- `go build ./web/backend/api/...` passes
