### PR TITLE
fix: handle os.Getwd() error in evolution skills_recall and drafts

### DIFF
--- a/pkg/evolution/drafts.go
+++ b/pkg/evolution/drafts.go
@@ -67,7 +67,10 @@ type DefaultDraftGenerator struct {
 func NewDefaultDraftGenerator(workspace string) *DefaultDraftGenerator {
 	builtinSkillsDir := strings.TrimSpace(os.Getenv(config.EnvBuiltinSkills))
 	if builtinSkillsDir == "" {
-		wd, _ := os.Getwd()
+		wd, err := os.Getwd()
+		if err != nil {
+			wd = config.GetHome()
+		}
 		builtinSkillsDir = filepath.Join(wd, "skills")
 	}
 

--- a/pkg/evolution/skills_recall.go
+++ b/pkg/evolution/skills_recall.go
@@ -18,7 +18,10 @@ type SkillsRecaller struct {
 func NewSkillsRecaller(workspace string) *SkillsRecaller {
 	builtinSkillsDir := strings.TrimSpace(os.Getenv(config.EnvBuiltinSkills))
 	if builtinSkillsDir == "" {
-		wd, _ := os.Getwd()
+		wd, err := os.Getwd()
+		if err != nil {
+			wd = config.GetHome()
+		}
 		builtinSkillsDir = filepath.Join(wd, "skills")
 	}
 


### PR DESCRIPTION
## Problem

In `SkillsRecaller` and `DefaultDraftGenerator` constructors, `os.Getwd()` errors are silently discarded with `_`. When `Getwd` fails, `wd` is `""` and `builtinSkillsDir` resolves to the relative path `"skills"`, causing confusing downstream errors when the builtin skills directory cannot be found.

This is the same pattern already fixed in `pkg/agent/context.go` (PR #3018).

## Fix

Check `os.Getwd()` error and fall back to `config.GetHome()` on failure, matching the approach in `context.go`.

## Changes

- `pkg/evolution/skills_recall.go`: +4/-1
- `pkg/evolution/drafts.go`: +4/-1

## Verification

- `go build ./pkg/evolution/...` passes
