### PR TITLE
fix: check strconv.Atoi and json.Unmarshal errors

### DIFF
--- a/pkg/config/gateway.go
+++ b/pkg/config/gateway.go
@@ -88,7 +88,12 @@ func ResolveGatewayLogLevel(path string) string {
 
 	data, err := os.ReadFile(path)
 	if err == nil {
-		_ = json.Unmarshal(data, &cfg)
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			logger.WarnCF("config", "failed to parse gateway config, using defaults", map[string]any{
+				"path":  path,
+				"error": err.Error(),
+			})
+		}
 	}
 
 	if envLevel := os.Getenv("PICOCLAW_LOG_LEVEL"); envLevel != "" {

--- a/pkg/seahorse/short_retrieval.go
+++ b/pkg/seahorse/short_retrieval.go
@@ -22,7 +22,10 @@ func ParseLastDuration(s string) (time.Duration, error) {
 		return 0, fmt.Errorf("invalid duration format: %q (use format like 6h, 7d, 2w, 1m)", s)
 	}
 
-	value, _ := strconv.Atoi(matches[1])
+	value, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration value: %q", matches[1])
+	}
 	unit := matches[2]
 
 	switch unit {


### PR DESCRIPTION
## Problem

Two places silently discard errors that should not be ignored:

1. **`pkg/seahorse/short_retrieval.go:25`** — `strconv.Atoi` result discarded with `_`. While a regex guarantees numeric input today, any future regex change could silently return a zero value instead of reporting the parse failure.

2. **`pkg/config/gateway.go:91`** — `json.Unmarshal` error silently discarded with `_`. If the gateway config file contains malformed JSON, the user gets default values with no indication that their config was ignored.

## Fix

1. Check `Atoi` error and return a clear error message.
2. Log a warning when gateway config JSON cannot be parsed, including the file path and parse error.

## Changes

- `pkg/seahorse/short_retrieval.go`: +3/-1
- `pkg/config/gateway.go`: +5/-1

## Verification

- `go build ./pkg/seahorse/... ./pkg/config/...` passes
