### PR TITLE
fix(mcp): reject unknown pre-positional flags in add

### DIFF
--- a/cmd/picoclaw/internal/mcp/add.go
+++ b/cmd/picoclaw/internal/mcp/add.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/sipeed/picoclaw/pkg/config"
 )
@@ -25,6 +26,10 @@ func newAddCommand() *cobra.Command {
 		Short:              "Add or update an MCP server",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			args, err := stripInheritedFlagsBeforeTarget(cmd.InheritedFlags(), args)
+			if err != nil {
+				return err
+			}
 			opts, name, target, targetArgs, showHelp, err := parseAddArgs(args)
 			if showHelp {
 				return cmd.Help()
@@ -80,6 +85,108 @@ func newAddCommand() *cobra.Command {
 	flags.Bool("no-deferred", false, "Mark server as non-deferred (tools always active)")
 
 	return cmd
+}
+
+// With DisableFlagParsing enabled, inherited persistent flags can leak into this
+// command's raw args. Strip only the flags that appear before <name> and
+// <command-or-url> so server command args remain untouched.
+func stripInheritedFlagsBeforeTarget(flags *pflag.FlagSet, args []string) ([]string, error) {
+	if flags == nil || len(args) == 0 {
+		return append([]string(nil), args...), nil
+	}
+
+	filtered := make([]string, 0, len(args))
+	positionals := 0
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		if arg == "--" || positionals >= 2 {
+			filtered = append(filtered, args[i:]...)
+			break
+		}
+
+		if arg == "-" || !strings.HasPrefix(arg, "-") {
+			filtered = append(filtered, arg)
+			positionals++
+			continue
+		}
+
+		consumed, err := consumeInheritedFlag(flags, args[i:])
+		if err != nil {
+			return nil, err
+		}
+		if consumed > 0 {
+			i += consumed - 1
+			continue
+		}
+
+		filtered = append(filtered, arg)
+	}
+
+	return filtered, nil
+}
+
+func consumeInheritedFlag(flags *pflag.FlagSet, args []string) (int, error) {
+	if len(args) == 0 {
+		return 0, nil
+	}
+
+	arg := args[0]
+	if arg == "--help" || arg == "-h" {
+		return 0, nil
+	}
+
+	if strings.HasPrefix(arg, "--") {
+		name, value, hasValue := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+		flag := flags.Lookup(name)
+		if flag == nil {
+			return 0, nil
+		}
+		if hasValue {
+			return 1, setInheritedFlag(flags, flag, value, arg)
+		}
+		if flag.NoOptDefVal != "" {
+			return 1, setInheritedFlag(flags, flag, flag.NoOptDefVal, arg)
+		}
+		if len(args) < 2 {
+			return 0, fmt.Errorf("missing value for %s", arg)
+		}
+		return 2, setInheritedFlag(flags, flag, args[1], arg)
+	}
+
+	if len(arg) < 2 || arg[0] != '-' || arg[1] == '-' {
+		return 0, nil
+	}
+
+	flag := flags.ShorthandLookup(string(arg[1]))
+	if flag == nil {
+		return 0, nil
+	}
+	if len(arg) == 2 {
+		if flag.NoOptDefVal != "" {
+			return 1, setInheritedFlag(flags, flag, flag.NoOptDefVal, arg)
+		}
+		if len(args) < 2 {
+			return 0, fmt.Errorf("missing value for %s", arg)
+		}
+		return 2, setInheritedFlag(flags, flag, args[1], arg)
+	}
+	if arg[2] == '=' {
+		return 1, setInheritedFlag(flags, flag, arg[3:], arg)
+	}
+	if flag.NoOptDefVal == "" {
+		return 1, setInheritedFlag(flags, flag, arg[2:], arg)
+	}
+
+	return 0, nil
+}
+
+func setInheritedFlag(flags *pflag.FlagSet, flag *pflag.Flag, value string, arg string) error {
+	if err := flags.Set(flag.Name, value); err != nil {
+		return fmt.Errorf("invalid value %q for %s: %w", value, arg, err)
+	}
+	return nil
 }
 
 func parseAddArgs(args []string) (addOptions, string, string, []string, bool, error) {
@@ -139,9 +246,11 @@ func parseAddArgs(args []string) (addOptions, string, string, []string, bool, er
 			opts.Headers = append(opts.Headers, args[i])
 		case strings.HasPrefix(arg, "--header="):
 			opts.Headers = append(opts.Headers, strings.TrimPrefix(arg, "--header="))
-		case strings.HasPrefix(arg, "-") && len(positional) >= 2:
+		case arg != "-" && strings.HasPrefix(arg, "-") && len(positional) >= 2:
 			serverArgs = append(serverArgs, args[i:]...)
 			i = len(args)
+		case arg != "-" && strings.HasPrefix(arg, "-"):
+			return addOptions{}, "", "", nil, false, fmt.Errorf("unknown flag %q for mcp add", arg)
 		default:
 			positional = append(positional, arg)
 		}

--- a/cmd/picoclaw/internal/mcp/command_test.go
+++ b/cmd/picoclaw/internal/mcp/command_test.go
@@ -191,12 +191,17 @@ func TestMCPAddSupportsEnvFileForStdio(t *testing.T) {
 }
 
 func TestParseAddArgsRejectsUnknownFlagBeforePositionals(t *testing.T) {
-	_, _, _, _, _, err := parseAddArgs([]string{
+	opts, name, target, targetArgs, showHelp, err := parseAddArgs([]string{
 		"--bogus",
 		"context7",
 		"https://mcp.context7.com/mcp",
 	})
 	require.Error(t, err)
+	assert.Equal(t, addOptions{}, opts)
+	assert.Empty(t, name)
+	assert.Empty(t, target)
+	assert.Nil(t, targetArgs)
+	assert.False(t, showHelp)
 	assert.Equal(t, `unknown flag "--bogus" for mcp add`, err.Error())
 }
 

--- a/cmd/picoclaw/internal/mcp/command_test.go
+++ b/cmd/picoclaw/internal/mcp/command_test.go
@@ -113,6 +113,34 @@ func TestMCPAddSupportsTransportBeforeName(t *testing.T) {
 	assert.Equal(t, "https://api.fiscal.ai/mcp/sse", server.URL)
 }
 
+func TestMCPAddAllowsInheritedFlagBeforeSubcommandPositionals(t *testing.T) {
+	configPath := setupMCPConfigEnv(t)
+
+	root := &cobra.Command{Use: "picoclaw"}
+	var noColor bool
+	root.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colors")
+	root.AddCommand(NewMCPCommand())
+
+	output, err := executeCommand(root, []string{
+		"--no-color",
+		"mcp",
+		"add",
+		"-t",
+		"http",
+		"-f",
+		"deviantix",
+		"http://127.0.0.1:19090",
+	}, "")
+	require.NoError(t, err)
+	assert.True(t, noColor)
+	assert.Contains(t, output, `MCP server "deviantix" saved`)
+
+	cfg := readMCPConfig(t, configPath)
+	server := cfg.Tools.MCP.Servers["deviantix"]
+	assert.Equal(t, "http", server.Type)
+	assert.Equal(t, "http://127.0.0.1:19090", server.URL)
+}
+
 func TestMCPAddSupportsExplicitStdioCommandAfterSeparator(t *testing.T) {
 	configPath := setupMCPConfigEnv(t)
 
@@ -160,6 +188,16 @@ func TestMCPAddSupportsEnvFileForStdio(t *testing.T) {
 	assert.Equal(t, "npx", server.Command)
 	assert.Equal(t, []string{"-y", "@modelcontextprotocol/server-filesystem"}, server.Args)
 	assert.Equal(t, ".env.mcp", server.EnvFile)
+}
+
+func TestParseAddArgsRejectsUnknownFlagBeforePositionals(t *testing.T) {
+	_, _, _, _, _, err := parseAddArgs([]string{
+		"--bogus",
+		"context7",
+		"https://mcp.context7.com/mcp",
+	})
+	require.Error(t, err)
+	assert.Equal(t, `unknown flag "--bogus" for mcp add`, err.Error())
 }
 
 func TestMCPAddRejectsEnvFileForHTTP(t *testing.T) {


### PR DESCRIPTION

## 📝 Description

Fixes `mcp add` argument parsing when root-level persistent flags are passed before the subcommand, such as `--no-color`.

`mcp add` uses `DisableFlagParsing: true`, so inherited root flags could leak into the custom parser and be misinterpreted as positional arguments. In practice this broke `http`/`sse` server registration and could also silently save incorrect stdio server names.

This PR:
- strips inherited root flags before `mcp add` parses its own arguments
- returns an explicit error for unknown `-`-prefixed arguments seen before the required positional arguments
- adds regression tests for the reported repro and the unknown-flag case

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

Fixes #3041

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/3041
- **Reasoning:** `mcp add` disables Cobra flag parsing and parses raw args manually. When a root persistent flag like `--no-color` appears before `mcp add`, it can arrive unconsumed in `parseAddArgs` and be incorrectly treated as the server name. This change filters inherited flags before custom parsing and rejects unknown pre-positional flags instead of silently demoting them to positionals.

## 🧪 Test Environment
- **Hardware:** Local development machine
- **OS:** macOS
- **Model/Provider:**
- **Channels:** CLI

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```bash
GOCACHE=/tmp/picoclaw-gocache go test ./cmd/picoclaw/internal/mcp -count=1
ok  	github.com/sipeed/picoclaw/cmd/picoclaw/internal/mcp	1.162s
```

Regression coverage added for:
- inherited root flag before `mcp add` positionals (`--no-color`)
- unknown flag before required positionals returns a clear error

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
