### PR TITLE
refactor: replace log.Printf/fmt.Printf with structured logger

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -414,7 +413,10 @@ func compilePatterns(patterns []string) []*regexp.Regexp {
 	for _, p := range patterns {
 		re, err := regexp.Compile(p)
 		if err != nil {
-			fmt.Printf("Warning: invalid path pattern %q: %v\n", p, err)
+			logger.WarnCF("agent", "invalid path pattern in compilePatterns", map[string]any{
+				"pattern": p,
+				"error":   err.Error(),
+			})
 			continue
 		}
 		compiled = append(compiled, re)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3,13 +3,13 @@ package state
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/sipeed/picoclaw/pkg/fileutil"
+	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
 // State represents the persistent state for a workspace.
@@ -41,7 +41,10 @@ func NewManager(workspace string) *Manager {
 
 	// Create state directory if it doesn't exist
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		log.Printf("[WARN] state: failed to create state directory %s: %v", stateDir, err)
+		logger.WarnCF("state", "failed to create state directory", map[string]any{
+			"dir":   stateDir,
+			"error": err.Error(),
+		})
 	}
 
 	sm := &Manager{
@@ -57,15 +60,22 @@ func NewManager(workspace string) *Manager {
 			if err := json.Unmarshal(data, sm.state); err == nil {
 				// Migrate to new location
 				if err := sm.saveAtomic(); err != nil {
-					log.Printf("[WARN] state: failed to save state: %v", err)
+					logger.WarnCF("state", "failed to save state", map[string]any{
+						"error": err.Error(),
+					})
 				}
-				log.Printf("[INFO] state: migrated state from %s to %s", oldStateFile, stateFile)
+				logger.InfoCF("state", "migrated state", map[string]any{
+					"from": oldStateFile,
+					"to":   stateFile,
+				})
 			}
 		}
 	} else {
 		// Load from new location
 		if err := sm.load(); err != nil {
-			log.Printf("[WARN] state: failed to load state: %v", err)
+			logger.WarnCF("state", "failed to load state", map[string]any{
+				"error": err.Error(),
+			})
 		}
 	}
 

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/config"
 	"github.com/sipeed/picoclaw/pkg/constants"
 	"github.com/sipeed/picoclaw/pkg/isolation"
+	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
 var (
@@ -162,7 +163,9 @@ func NewExecToolWithConfig(
 				denyPatterns = append(denyPatterns, windowsDenyPatterns...)
 			}
 			if len(execConfig.CustomDenyPatterns) > 0 {
-				fmt.Printf("Using custom deny patterns: %v\n", execConfig.CustomDenyPatterns)
+				logger.InfoCF("tools", "using custom deny patterns", map[string]any{
+					"patterns": execConfig.CustomDenyPatterns,
+				})
 				for _, pattern := range execConfig.CustomDenyPatterns {
 					re, err := regexp.Compile(pattern)
 					if err != nil {
@@ -173,7 +176,7 @@ func NewExecToolWithConfig(
 			}
 		} else {
 			// If deny patterns are disabled, we won't add any patterns, allowing all commands.
-			fmt.Println("Warning: deny patterns are disabled. All commands will be allowed.")
+			logger.WarnCF("tools", "deny patterns are disabled, all commands will be allowed", nil)
 		}
 		for _, pattern := range execConfig.CustomAllowPatterns {
 			re, err := regexp.Compile(pattern)


### PR DESCRIPTION
## Problem

Multiple places in production code use `log.Printf` or `fmt.Printf` to emit warnings, bypassing the configured structured logging infrastructure. These messages go to raw stderr/stdout instead of the log backend.

Affected:
- `pkg/state/state.go` — 4x `log.Printf` for directory creation, save, load, and migration errors
- `pkg/agent/instance.go` — `fmt.Printf` for invalid path pattern warning
- `pkg/tools/shell.go` — 2x `fmt.Printf`/`fmt.Println` for deny pattern info

## Fix

Replace all raw print calls with structured logger calls (`logger.WarnCF`/`logger.InfoCF`) so warnings are routed through the same logging backend as the rest of the application.

## Changes

- `pkg/state/state.go`: replace 4 `log.Printf` → `logger.WarnCF`/`logger.InfoCF`; remove `"log"` import
- `pkg/agent/instance.go`: replace `fmt.Printf` → `logger.WarnCF`; remove unused `"fmt"` import
- `pkg/tools/shell.go`: replace 2 `fmt.Printf`/`fmt.Println` → `logger.InfoCF`/`logger.WarnCF`; add `logger` import

## Verification

- `go build ./pkg/state/... ./pkg/agent/... ./pkg/tools/...` passes
