### PR TITLE
fix: use %w instead of %v for error wrapping in channels and mcp

### DIFF
--- a/pkg/channels/errutil.go
+++ b/pkg/channels/errutil.go
@@ -11,11 +11,11 @@ import (
 func ClassifySendError(statusCode int, rawErr error) error {
 	switch {
 	case statusCode == http.StatusTooManyRequests:
-		return fmt.Errorf("%w: %v", ErrRateLimit, rawErr)
+		return fmt.Errorf("%w: %w", ErrRateLimit, rawErr)
 	case statusCode >= 500:
-		return fmt.Errorf("%w: %v", ErrTemporary, rawErr)
+		return fmt.Errorf("%w: %w", ErrTemporary, rawErr)
 	case statusCode >= 400:
-		return fmt.Errorf("%w: %v", ErrSendFailed, rawErr)
+		return fmt.Errorf("%w: %w", ErrSendFailed, rawErr)
 	default:
 		return rawErr
 	}
@@ -26,5 +26,5 @@ func ClassifyNetError(err error) error {
 	if err == nil {
 		return nil
 	}
-	return fmt.Errorf("%w: %v", ErrTemporary, err)
+	return fmt.Errorf("%w: %w", ErrTemporary, err)
 }

--- a/pkg/mcp/isolated_command_transport.go
+++ b/pkg/mcp/isolated_command_transport.go
@@ -62,7 +62,7 @@ func (s *isolatedPipeRWC) Write(p []byte) (n int, err error) {
 
 func (s *isolatedPipeRWC) Close() error {
 	if err := s.stdin.Close(); err != nil {
-		return fmt.Errorf("closing stdin: %v", err)
+		return fmt.Errorf("closing stdin: %w", err)
 	}
 	resChan := make(chan error, 1)
 	go func() {
@@ -205,7 +205,7 @@ func (c *isolatedIOConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 	defer c.writeMu.Unlock()
 	data, err := jsonrpc.EncodeMessage(msg)
 	if err != nil {
-		return fmt.Errorf("marshaling message: %v", err)
+		return fmt.Errorf("marshaling message: %w", err)
 	}
 	data = append(data, '\n')
 	_, err = c.rwc.Write(data)


### PR DESCRIPTION
## Problem

Several error wrapping sites use `%v` instead of `%w` in `fmt.Errorf`, which breaks `errors.Is()`/`errors.As()` introspection for callers:

- `pkg/channels/errutil.go` — `ClassifySendError` and `ClassifyNetError` wrap the sentinel with `%w` but the underlying error with `%v`, so callers cannot inspect the original HTTP/network error.
- `pkg/mcp/isolated_command_transport.go` — `Close()` and `Write()` error paths use `%v`, making the underlying stdin/JSON errors invisible to `errors.Is`.

## Fix

Change `%v` → `%w` so the underlying errors are preserved in the error chain. This is backward-compatible: `Error()` output is unchanged.

## Changes

- `pkg/channels/errutil.go`: 4x `%v` → `%w`
- `pkg/mcp/isolated_command_transport.go`: 2x `%v` → `%w`

## Verification

- `go build github.com/sipeed/picoclaw/pkg/channels github.com/sipeed/picoclaw/pkg/mcp` passes
