### PR TITLE
fix: handle Telegram location messages

### DIFF
--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -1227,6 +1227,13 @@ func (c *TelegramChannel) collectTelegramMessageParts(
 	if caption := strings.TrimSpace(msg.Caption); caption != "" {
 		parts.content = append(parts.content, caption)
 	}
+	if msg.Location != nil {
+		parts.content = append(parts.content, fmt.Sprintf(
+			"[User location: lat=%.6f, lng=%.6f]",
+			msg.Location.Latitude,
+			msg.Location.Longitude,
+		))
+	}
 	if len(msg.Photo) > 0 {
 		photo := msg.Photo[len(msg.Photo)-1]
 		photoPath := c.downloadPhoto(ctx, photo.FileID)

--- a/pkg/channels/telegram/telegram_test.go
+++ b/pkg/channels/telegram/telegram_test.go
@@ -1497,6 +1497,42 @@ func TestHandleMessage_EmptyContent_Ignored(t *testing.T) {
 	}
 }
 
+func TestHandleMessage_LocationForwardedAsText(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	ch := &TelegramChannel{
+		BaseChannel: channels.NewBaseChannel("telegram", nil, messageBus, nil),
+		chatIDs:     make(map[string]int64),
+		ctx:         context.Background(),
+	}
+
+	msg := &telego.Message{
+		MessageID: 3049,
+		Location: &telego.Location{
+			Latitude:  35.197713,
+			Longitude: 136.885705,
+		},
+		Chat: telego.Chat{
+			ID:   456,
+			Type: "private",
+		},
+		From: &telego.User{
+			ID:        789,
+			FirstName: "User",
+		},
+	}
+
+	err := ch.handleMessage(context.Background(), msg)
+	require.NoError(t, err)
+
+	select {
+	case inbound := <-messageBus.InboundChan():
+		assert.Equal(t, "[User location: lat=35.197713, lng=136.885705]", inbound.Content)
+		assert.Equal(t, "3049", inbound.Context.MessageID)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for location message")
+	}
+}
+
 func TestHandleMessage_MediaGroupCombinesCaptionMessages(t *testing.T) {
 	messageBus, ch := newMediaGroupTestChannel(10 * time.Millisecond)
 	base := testMediaGroupMessage("album-1")


### PR DESCRIPTION
## 📝 Description

Fix Telegram location-only messages being ignored by the channel adapter.

This PR converts `message.location` payloads into text like:

`[User location: lat=35.197713, lng=136.885705]`

so location pins sent from Telegram can reach the agent pipeline instead of being silently dropped. A regression test was added for location-only Telegram messages.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #3049

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Windows
- **Model/Provider:** N/A
- **Channels:** Telegram

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [ ] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.