### PR TITLE
fix(line): add ok checks for sync.Map type assertions in Send

### DIFF
--- a/pkg/channels/line/line.go
+++ b/pkg/channels/line/line.go
@@ -465,7 +465,9 @@ func (c *LINEChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]stri
 	// Load and consume quote token for this chat
 	var quoteToken string
 	if qt, ok := c.quoteTokens.LoadAndDelete(msg.ChatID); ok {
-		quoteToken = qt.(string)
+		if s, ok := qt.(string); ok {
+			quoteToken = s
+		}
 	}
 
 	textMsg := messaging_api.TextMessage{
@@ -475,8 +477,11 @@ func (c *LINEChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]stri
 
 	// Try reply token first (free, valid for ~25 seconds)
 	if entry, ok := c.replyTokens.LoadAndDelete(msg.ChatID); ok {
-		tokenEntry := entry.(replyTokenEntry)
-		if time.Since(tokenEntry.timestamp) < lineReplyTokenMaxAge {
+		tokenEntry, ok := entry.(replyTokenEntry)
+		if !ok {
+			// Unexpected type; skip reply path and fall through to Push API.
+			// The push path does not depend on the reply token.
+		} else if time.Since(tokenEntry.timestamp) < lineReplyTokenMaxAge {
 			resp, _, err := c.client.WithContext(ctx).ReplyMessageWithHttpInfo(&messaging_api.ReplyMessageRequest{
 				ReplyToken: tokenEntry.token,
 				Messages:   []messaging_api.MessageInterface{&textMsg},


### PR DESCRIPTION
## Problem
`LINEChannel.Send` has two unchecked type assertions on `sync.Map` values. A type mismatch panics.

## Fix
- `quoteTokens`: add `ok` check - missing quote is non-fatal
- `replyTokens`: add `ok` check - on failure, fall through to Push API instead of erroring (message delivery does not depend on reply token type)

## Verification
- `go build ./pkg/channels/line/...` passes

## Related
Split from #3018. Addresses @afjcjsbx review: reply token path was too strict.