### PR TITLE
fix(agent): handle os.Getwd error in NewContextBuilder

### DIFF
--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -102,7 +102,13 @@ func NewContextBuilder(workspace string) *ContextBuilder {
 	// Use the skills/ directory under the current working directory
 	builtinSkillsDir := strings.TrimSpace(os.Getenv(config.EnvBuiltinSkills))
 	if builtinSkillsDir == "" {
-		wd, _ := os.Getwd()
+		wd, err := os.Getwd()
+		if err != nil {
+			// os.Getwd failure is extremely rare; fall back to empty
+			// string so that filepath.Join produces a relative "skills"
+			// path, preserving the original lookup behavior.
+			wd = ""
+		}
 		builtinSkillsDir = filepath.Join(wd, "skills")
 	}
 	globalSkillsDir := filepath.Join(getGlobalConfigDir(), "skills")


### PR DESCRIPTION
## Problem
`NewContextBuilder` silently ignores `os.Getwd()` error.

## Fix
Check the error. On failure, use empty string so `filepath.Join("", "skills")` = `"skills"` - same relative-path lookup as before, no behavior regression.

Intentionally minimal: we do NOT fall back to `getGlobalConfigDir()` to avoid changing builtin skills lookup semantics.

## Verification
- `go build ./pkg/agent/...` passes

## Related
Split from #3018. Addresses @afjcjsbx review about regression risk.