### PR TITLE
fix(tools): add ok checks for type assertions in subagent and spawn tools

### DIFF
--- a/pkg/tools/spawn.go
+++ b/pkg/tools/spawn.go
@@ -90,8 +90,14 @@ func (t *SpawnTool) execute(
 		return ErrorResult("task is required and must be a non-empty string")
 	}
 
-	label, _ := args["label"].(string)
-	agentID, _ := args["agent_id"].(string)
+	label, ok := args["label"].(string)
+	if !ok {
+		label = ""
+	}
+	agentID, ok := args["agent_id"].(string)
+	if !ok {
+		agentID = ""
+	}
 	targetAgentID := strings.TrimSpace(agentID)
 
 	// Check allowlist if targeting a specific agent

--- a/pkg/tools/subagent.go
+++ b/pkg/tools/subagent.go
@@ -391,7 +391,10 @@ func (t *SubagentTool) Execute(ctx context.Context, args map[string]any) *ToolRe
 		return ErrorResult("task is required").WithError(fmt.Errorf("task parameter is required"))
 	}
 
-	label, _ := args["label"].(string)
+	label, ok := args["label"].(string)
+	if !ok {
+		label = ""
+	}
 
 	// Build system prompt for subagent
 	systemPrompt := fmt.Sprintf(


### PR DESCRIPTION
## Problem
`subagent.go` and `spawn.go` use unchecked type assertions on `args["label"]` and `args["agent_id"]`.

## Fix
Add `ok` checks. On failure, use empty strings.

## Verification
- `go build ./pkg/tools/...` passes