### PR TITLE
fix(webfetch): add ok check for type assertion in isAllowedFirstHopHost

### DIFF
--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -2419,8 +2419,8 @@ func allowConfiguredProxyFirstHop(req *http.Request, rt http.RoundTripper) {
 }
 
 func isAllowedFirstHopHost(ctx context.Context, host string) bool {
-	allowed, _ := ctx.Value(webFetchAllowedFirstHopHostKey{}).(string)
-	if allowed == "" {
+	allowed, ok := ctx.Value(webFetchAllowedFirstHopHostKey{}).(string)
+	if !ok || allowed == "" {
 		return false
 	}
 	return allowed == normalizeAllowedFirstHopHost(host)


### PR DESCRIPTION
## Problem
`isAllowedFirstHopHost` uses an unchecked type assertion on a context value. A type mismatch would produce an empty string, which happens to be a safe default, but the intent should be explicit.

## Fix
Add `ok` check and consolidate the empty-string guard.

## Verification
- `go build ./pkg/tools/...` passes