### PR TITLE
fix: explicitly ignore Close() errors in error paths and retry loops

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -558,7 +558,7 @@ func (t *ExecTool) runBackground(ctx context.Context, command, cwd string, ptyEn
 	// with synchronous exec runs.
 	if err := isolation.Start(cmd); err != nil {
 		if session.ptyMaster != nil {
-			session.ptyMaster.Close()
+			_ = session.ptyMaster.Close()
 		}
 		return ErrorResult(fmt.Sprintf("failed to start command: %v", err))
 	}
@@ -657,7 +657,7 @@ func (t *ExecTool) runBackground(ctx context.Context, command, cwd string, ptyEn
 
 			// All pipes closed, get exit status
 			if stdinWriter != nil {
-				stdinWriter.Close()
+				_ = stdinWriter.Close()
 			}
 			cmd.Wait()
 

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -576,16 +576,16 @@ func extractZip(archivePath, destDir string) error {
 		}
 		out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, f.FileInfo().Mode())
 		if err != nil {
-			rc.Close()
+			_ = rc.Close()
 			return err
 		}
 		if _, err := io.Copy(out, rc); err != nil {
-			rc.Close()
-			out.Close()
+			_ = rc.Close()
+			_ = out.Close()
 			return err
 		}
 		if err := rc.Close(); err != nil {
-			out.Close()
+			_ = out.Close()
 			return fmt.Errorf("close zip entry reader: %w", err)
 		}
 		if err := out.Close(); err != nil {

--- a/pkg/utils/http_retry.go
+++ b/pkg/utils/http_retry.go
@@ -26,7 +26,7 @@ func DoRequestWithRetry(client *http.Client, req *http.Request) (*http.Response,
 
 	for i := range maxRetries {
 		if i > 0 && resp != nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 		}
 
 		resp, err = client.Do(req)
@@ -42,7 +42,7 @@ func DoRequestWithRetry(client *http.Client, req *http.Request) (*http.Response,
 		if i < maxRetries-1 {
 			if err = sleepWithCtx(req.Context(), retryDelayForAttempt(resp, i)); err != nil {
 				if resp != nil {
-					resp.Body.Close()
+					_ = resp.Body.Close()
 				}
 				return nil, fmt.Errorf("failed to sleep: %w", err)
 			}

--- a/pkg/utils/media.go
+++ b/pkg/utils/media.go
@@ -148,7 +148,7 @@ func DownloadFile(urlStr, filename string, opts DownloadOptions) string {
 	}
 
 	if _, err := io.Copy(out, resp.Body); err != nil {
-		out.Close()
+		_ = out.Close()
 		os.Remove(localPath)
 		logger.ErrorCF(opts.LoggerPrefix, "Failed to write file", map[string]any{
 			"error": err.Error(),


### PR DESCRIPTION
## Problem
Several files ignore `Close()` return values on resources (files, HTTP bodies, PTY) in error paths, triggering linter warnings.

## Fix
Use `_ =` to explicitly acknowledge the ignored error in:
- `pkg/tools/shell.go`: PTY and stdin writer Close()
- `pkg/utils/http_retry.go`: HTTP body Close() in retry loop
- `pkg/utils/media.go`: file Close() on copy error
- `pkg/updater/updater.go`: zip entry reader/writer Close() on error

## Verification
- `go build ./pkg/...` passes