### PR TITLE
fix: use %w for error wrapping and handle json.MarshalIndent error

### DIFF
--- a/cmd/picoclaw/internal/skills/helpers.go
+++ b/cmd/picoclaw/internal/skills/helpers.go
@@ -79,7 +79,7 @@ func skillsInstallFromRegistry(cfg *config.Config, registryName, target string) 
 	defer cancel()
 
 	if err = os.MkdirAll(filepath.Join(workspace, "skills"), 0o755); err != nil {
-		return fmt.Errorf("\u2717 failed to create skills directory: %v", err)
+		return fmt.Errorf("\u2717 failed to create skills directory: %w", err)
 	}
 
 	result, err := registry.DownloadAndInstall(ctx, target, "", targetDir)

--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -2275,7 +2275,10 @@ func (t *WebFetchTool) Execute(ctx context.Context, args map[string]any) *ToolRe
 		"text":      text,
 	}
 
-	resultJSON, _ := json.MarshalIndent(result, "", "  ")
+	resultJSON, marshalErr := json.MarshalIndent(result, "", "  ")
+	if marshalErr != nil {
+		return ErrorResult(fmt.Sprintf("failed to marshal result: %v", marshalErr))
+	}
 
 	return &ToolResult{
 		ForLLM: string(resultJSON),


### PR DESCRIPTION
## Problem
- `cmd/picoclaw/internal/skills/helpers.go` uses `%v` instead of `%w` for error wrapping, breaking `errors.Is`/`errors.As` chains.
- `pkg/tools/integration/web.go` silently ignores `json.MarshalIndent` error.

## Fix
- Use `%w` for error wrapping
- Handle `json.MarshalIndent` error and return an error result

## Verification
- `go build ./cmd/... ./pkg/tools/...` passes