### PR TITLE
fix(launcher): hide console flashes in all Windows child processes

### DIFF
--- a/web/backend/api/exec_nonwindows.go
+++ b/web/backend/api/exec_nonwindows.go
@@ -2,10 +2,16 @@
 
 package api
 
-import "os/exec"
+import (
+	"os/exec"
+
+	"github.com/sipeed/picoclaw/web/backend/utils"
+)
 
 func launcherExecCommand(name string, args ...string) *exec.Cmd {
-	return exec.Command(name, args...)
+	return utils.LauncherExecCommand(name, args...)
 }
 
-func applyLauncherProcAttrs(_ *exec.Cmd) {}
+func applyLauncherProcAttrs(cmd *exec.Cmd) {
+	utils.ApplyLauncherProcAttrs(cmd)
+}

--- a/web/backend/api/exec_windows.go
+++ b/web/backend/api/exec_windows.go
@@ -4,21 +4,14 @@ package api
 
 import (
 	"os/exec"
-	"syscall"
+
+	"github.com/sipeed/picoclaw/web/backend/utils"
 )
 
 func launcherExecCommand(name string, args ...string) *exec.Cmd {
-	cmd := exec.Command(name, args...)
-	applyLauncherProcAttrs(cmd)
-	return cmd
+	return utils.LauncherExecCommand(name, args...)
 }
 
 func applyLauncherProcAttrs(cmd *exec.Cmd) {
-	if cmd == nil {
-		return
-	}
-	if cmd.SysProcAttr == nil {
-		cmd.SysProcAttr = &syscall.SysProcAttr{}
-	}
-	cmd.SysProcAttr.HideWindow = true
+	utils.ApplyLauncherProcAttrs(cmd)
 }

--- a/web/backend/api/startup.go
+++ b/web/backend/api/startup.go
@@ -277,7 +277,11 @@ func windowsCommandLine(exePath string, args []string) string {
 }
 
 func windowsRunKeyExists() (bool, error) {
-	cmd := exec.Command("reg", "query", `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`, "/v", autoStartEntryName)
+	cmd := launcherExecCommand(
+		"reg", "query",
+		`HKCU\Software\Microsoft\Windows\CurrentVersion\Run`,
+		"/v", autoStartEntryName,
+	)
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -292,11 +296,15 @@ func setWindowsAutoStart(enabled bool, exePath string, args []string) error {
 	key := `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`
 	if enabled {
 		commandLine := windowsCommandLine(exePath, args)
-		cmd := exec.Command("reg", "add", key, "/v", autoStartEntryName, "/t", "REG_SZ", "/d", commandLine, "/f")
+		cmd := launcherExecCommand(
+			"reg", "add", key,
+			"/v", autoStartEntryName,
+			"/t", "REG_SZ", "/d", commandLine, "/f",
+		)
 		return cmd.Run()
 	}
 
-	cmd := exec.Command("reg", "delete", key, "/v", autoStartEntryName, "/f")
+	cmd := launcherExecCommand("reg", "delete", key, "/v", autoStartEntryName, "/f")
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/web/backend/api/version.go
+++ b/web/backend/api/version.go
@@ -259,7 +259,9 @@ func (c *systemVersionCache) resetForTest() {
 // executePicoclawVersion runs the version subcommand against the
 // discovered picoclaw executable.
 func executePicoclawVersion(ctx context.Context, execPath string) (string, error) {
-	out, err := exec.CommandContext(ctx, execPath, "version").CombinedOutput()
+	cmd := exec.CommandContext(ctx, execPath, "version")
+	applyLauncherProcAttrs(cmd)
+	out, err := cmd.CombinedOutput()
 	if err == nil {
 		return string(out), nil
 	}

--- a/web/backend/utils/exec_nonwindows.go
+++ b/web/backend/utils/exec_nonwindows.go
@@ -4,6 +4,11 @@ package utils
 
 import "os/exec"
 
-func launcherExecCommand(name string, args ...string) *exec.Cmd {
+// LauncherExecCommand creates an exec.Cmd. On non-Windows platforms, this is
+// a simple wrapper around exec.Command.
+func LauncherExecCommand(name string, args ...string) *exec.Cmd {
 	return exec.Command(name, args...)
 }
+
+// ApplyLauncherProcAttrs is a no-op on non-Windows platforms.
+func ApplyLauncherProcAttrs(_ *exec.Cmd) {}

--- a/web/backend/utils/exec_nonwindows.go
+++ b/web/backend/utils/exec_nonwindows.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package utils
+
+import "os/exec"
+
+func launcherExecCommand(name string, args ...string) *exec.Cmd {
+	return exec.Command(name, args...)
+}

--- a/web/backend/utils/exec_windows.go
+++ b/web/backend/utils/exec_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package utils
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func launcherExecCommand(name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(name, args...)
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	return cmd
+}

--- a/web/backend/utils/exec_windows.go
+++ b/web/backend/utils/exec_windows.go
@@ -7,11 +7,22 @@ import (
 	"syscall"
 )
 
-func launcherExecCommand(name string, args ...string) *exec.Cmd {
+// LauncherExecCommand creates an exec.Cmd with the HideWindow attribute set
+// to prevent console window flashes on Windows.
+func LauncherExecCommand(name string, args ...string) *exec.Cmd {
 	cmd := exec.Command(name, args...)
+	ApplyLauncherProcAttrs(cmd)
+	return cmd
+}
+
+// ApplyLauncherProcAttrs applies Windows-specific process attributes to hide
+// the console window. It is safe to call with a nil cmd.
+func ApplyLauncherProcAttrs(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.HideWindow = true
-	return cmd
 }

--- a/web/backend/utils/onboard.go
+++ b/web/backend/utils/onboard.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/config"
 )
 
-var execCommand = launcherExecCommand
+var execCommand = LauncherExecCommand
 
 func EnsureOnboarded(configPath string) error {
 	_, err := os.Stat(configPath)

--- a/web/backend/utils/onboard.go
+++ b/web/backend/utils/onboard.go
@@ -3,13 +3,12 @@ package utils
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/sipeed/picoclaw/pkg/config"
 )
 
-var execCommand = exec.Command
+var execCommand = launcherExecCommand
 
 func EnsureOnboarded(configPath string) error {
 	_, err := os.Stat(configPath)

--- a/web/backend/utils/runtime.go
+++ b/web/backend/utils/runtime.go
@@ -150,7 +150,7 @@ func OpenBrowser(url string) error {
 	case "linux":
 		return exec.Command("xdg-open", url).Start()
 	case "windows":
-		return launcherExecCommand("rundll32", "url.dll,FileProtocolHandler", url).Start()
+		return LauncherExecCommand("rundll32", "url.dll,FileProtocolHandler", url).Start()
 	case "darwin":
 		return exec.Command("open", url).Start()
 	default:

--- a/web/backend/utils/runtime.go
+++ b/web/backend/utils/runtime.go
@@ -150,7 +150,7 @@ func OpenBrowser(url string) error {
 	case "linux":
 		return exec.Command("xdg-open", url).Start()
 	case "windows":
-		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+		return launcherExecCommand("rundll32", "url.dll,FileProtocolHandler", url).Start()
 	case "darwin":
 		return exec.Command("open", url).Start()
 	default:


### PR DESCRIPTION
## 📝 Description

Follow-up to PR #2654 which only applied `HideWindow` to child processes in `gateway.go` (powershell, tasklist, ps). Several other files still use `exec.Command` directly, causing visible console window flashes on Windows when the launcher runs as a GUI app.

**Affected call sites:**
- `startup.go`: `reg query/add/delete` for autostart registry operations
- `version.go`: `picoclaw version` subcommand execution
- `runtime.go`: `rundll32` for browser launch
- `onboard.go`: `picoclaw onboard` subcommand execution

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 📚 Technical Context

**What changed:**
- Added `launcherExecCommand` to `web/backend/utils/` package (platform-specific `exec_windows.go` / `exec_nonwindows.go`), matching the existing pattern in `web/backend/api/`
- Replaced all bare `exec.Command` calls on Windows code paths with `launcherExecCommand` which sets `SysProcAttr.HideWindow = true`
- For `version.go` (which needs `exec.CommandContext` for context support), applied `applyLauncherProcAttrs` after creating the command

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] `go build ./backend/api/...` and `go build ./backend/utils/...` pass
- [x] `go vet` passes
- [x] Tests pass (`go test ./backend/api/...` and `go test ./backend/utils/...`)