### PR TITLE
fix: health check always returning not ready

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -222,6 +222,11 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) (runEr
 	if err != nil {
 		return err
 	}
+	// All services (channels + shared HTTP server) are up; mark the health
+	// server ready so GET /ready reports "ready". The health endpoints are
+	// mounted on the shared gateway mux, so Health.Server.Start() (which would
+	// otherwise set this) is never called — we flip the flag explicitly here.
+	runningServices.HealthServer.SetReady(true)
 	publishGatewayEvent(agentLoop, runtimeevents.KindGatewayReady, startedAt, nil)
 	closeListeners = false
 


### PR DESCRIPTION
## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

When starting the gateway, if i curl /health it shows ready:false, this is because the gateway is started using the shared http which never galls SetReady(true). This patch solves the confusing health check.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** Jetson thor
- **OS:** Ubuntu 24
- **Model/Provider:** Ollama + Nemoton3
- **Channels:** Deltachat (not yet public)


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.