### PR TITLE
fix(config): add ok check for type assertion in migration model name indexing

### DIFF
--- a/pkg/config/migration.go
+++ b/pkg/config/migration.go
@@ -501,7 +501,10 @@ func mergeModelListsWithMap(mainML []any, secML map[string]any) error {
 	for i, m := range mainML {
 		if mVal, ok := m.(map[string]any); ok {
 			if name, hasName := mVal["model_name"]; hasName {
-				nameStr := name.(string)
+				nameStr, ok := name.(string)
+				if !ok {
+					return fmt.Errorf("model_name must be a string, got %T", name)
+				}
 				index := countMap[nameStr]
 				indexedKeys[fmt.Sprintf("%s:%d", nameStr, index)] = i
 				if _, ok := indexedKeys[nameStr]; !ok {


### PR DESCRIPTION
## Problem
`pkg/config/migration.go:504` uses an unchecked type assertion `nameStr := name.(string)` when building indexed model keys. A malformed config entry where `model_name` is not a string would cause a panic.

## Fix
Add `ok` check. On failure, return an error describing the unexpected type.

## Verification
- `go build ./pkg/config/...` passes