### PR TITLE
fix: explicitly ignore Close() errors on temp file write/sync failure paths

### DIFF
--- a/pkg/channels/wecom/media.go
+++ b/pkg/channels/wecom/media.go
@@ -334,7 +334,7 @@ func (c *WeComChannel) storeRemoteMedia(
 	}
 	tmpPath := tmpFile.Name()
 	if _, writeErr := tmpFile.Write(data); writeErr != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close()
 		_ = os.Remove(tmpPath)
 		return "", fmt.Errorf("write temp file: %w", writeErr)
 	}

--- a/pkg/tools/fs/filesystem.go
+++ b/pkg/tools/fs/filesystem.go
@@ -1108,7 +1108,7 @@ func (r *sandboxFs) WriteFile(path string, data []byte) error {
 		}
 
 		if _, err := tmpFile.Write(data); err != nil {
-			tmpFile.Close()
+			_ = tmpFile.Close()
 			root.Remove(tmpRelPath)
 			return fmt.Errorf("failed to write temp file: %w", err)
 		}
@@ -1116,7 +1116,7 @@ func (r *sandboxFs) WriteFile(path string, data []byte) error {
 		// CRITICAL: Force sync to storage medium before rename.
 		// This ensures data is physically written to disk, not just cached.
 		if err := tmpFile.Sync(); err != nil {
-			tmpFile.Close()
+			_ = tmpFile.Close()
 			root.Remove(tmpRelPath)
 			return fmt.Errorf("failed to sync temp file: %w", err)
 		}

--- a/pkg/tools/normalization.go
+++ b/pkg/tools/normalization.go
@@ -230,7 +230,7 @@ func storeInlineDataURL(
 	}
 	tmpPath := tmpFile.Name()
 	if _, err = tmpFile.Write(decoded); err != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close()
 		_ = os.Remove(tmpPath)
 		return "", fmt.Sprintf("[Tool returned inline media content (%s) but it could not be stored.]", mimeType)
 	}


### PR DESCRIPTION
## Problem
Three files silently ignore `tmpFile.Close()` return values on error paths where writes or syncs fail:
- `pkg/tools/normalization.go:233`
- `pkg/channels/wecom/media.go:337`
- `pkg/tools/fs/filesystem.go:1111,1119`

## Fix
Use `_ = tmpFile.Close()` for consistency with the `_ = os.Remove()` pattern already used on the next line in each case.

## Verification
- `go build ./pkg/tools/... ./pkg/channels/wecom/...` passes