### PR TITLE
fix os.Root api on windows issue

### DIFF
--- a/pkg/tools/fs/filesystem.go
+++ b/pkg/tools/fs/filesystem.go
@@ -1064,6 +1064,9 @@ func (r *sandboxFs) execute(path string, fn func(root *os.Root, relPath string) 
 		return err
 	}
 
+	// os.Root api on windows only accept forward slashes (/)
+	relPath = filepath.ToSlash(relPath)
+
 	return fn(root, relPath)
 }
 


### PR DESCRIPTION
## 📝 Description

fix issue #2472 

file system tools returns "invalid argument" on Windows due to path separator mismatch with os.Root


## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

fix issue #2472 


## 📚 Technical Context (Skip for Docs)
- **Reference URL:** I can not find them, but I using same api at my own project (a sftp server) got same issue when run on windows.
- **Reasoning:** here is a PoC test code in Evidence section


## 🧪 Test Environment
- **Hardware:** pc
- **OS:** win11
- **Model/Provider:** local gemma 4 12B QAT
- **Channels:** web UI


## 📸 Evidence (Optional)
<details>
<summary>Click to view PoC code</summary>

```golang
package main

import (
	"bytes"
	"fmt"
	"io"
	"io/fs"
	"os"
	"path/filepath"
	"strings"
)

var (
	testFiles = []struct {
		p string
		d string
	}{
		{p: "file1.txt", d: "001\n"},
		{p: "aaa/file2.txt", d: "002\n"},
		{p: "aaa/bbb/file3.txt", d: "003\n"},
		{p: "aaa/bbb/ccc/file4.txt", d: "004\n"},
		{p: `aaa\bbb\ccc\file4.txt`, d: "004\n"},
	}
)

func main() {
	if !initTestFiles() {
		fmt.Println(`init test files error, exit!`)
		return
	}
	fmt.Println(`init test files end`)

	pwd, err := os.Getwd()
	if err != nil {
		fmt.Println(`os.Getwd err:`, err)
		return
	}

	fmt.Println(`workspace root:`, pwd)
	root, err := os.OpenRoot(pwd)
	if err != nil {
		fmt.Println(`os.OpenRoot err:`, err)
		return
	}

	// read file test
	for _, f := range testFiles {
		fp, err := getSafeRelPath(pwd, f.p)
		if err != nil {
			fmt.Printf("getSafeRelPath %v err: %v\n", fp, err)
			continue
		}
		fmt.Println(`test read`, f.p, fp)
		readFile(root, fp, f.d)
	}

	// read dir test
	for _, f := range testFiles {
		fp := filepath.Dir(f.p)
		fp, err := getSafeRelPath(pwd, fp)
		if err != nil {
			fmt.Printf("getSafeRelPath %v err: %v\n", fp, err)
			continue
		}

		// need use slash ('/') character on windows
		// fp = filepath.ToSlash(fp)

		fmt.Println(`test read dir`, filepath.Dir(f.p), fp)
		readDir(root, fp)
	}
}

func readFile(root *os.Root, fp string, ref string) {
	fd, err := root.OpenFile(fp, os.O_RDONLY, 0o444)
	if err != nil {
		fmt.Printf("root.OpenFile %v err: %v\n", fp, err)
		return
	}
	defer fd.Close()
	data, err := io.ReadAll(fd)
	if err != nil {
		fmt.Printf(`read data in "%v" err:%v\n`, fp, err)
		return
	}
	if !bytes.Equal(data, []byte(ref)) {
		fmt.Printf(`read data in "%v" not same\n`, fp)
	}
}

func readDir(root *os.Root, fp string) {
	dirEntries, err := fs.ReadDir(root.FS(), fp)
	if err != nil {
		fmt.Printf("fs.ReadDir %v err: %v\n", fp, err)
		return
	}
	if len(dirEntries) == 0 {
		fmt.Printf("fs.ReadDir %v should have file, got %v\n", fp, len(dirEntries))
	}

	fileCount := 0
	for _, ent := range dirEntries {
		if ent.IsDir() {
			continue
		}
		fname := ent.Name()
		if strings.HasPrefix(fname, "file") && strings.HasSuffix(fname, ".txt") {
			fileCount += 1
		}
	}
	if fileCount != 1 {
		fmt.Printf("fs.ReadDir %v should have only 1 file*.txt, got %v\n", fp, fileCount)
	}
}

func initTestFiles() bool {
	err := os.MkdirAll("aaa/bbb/ccc", 0o755)
	if err != nil {
		fmt.Println(`MkdirAll "aaa/bbb/ccc" err:`, err)
		return false
	}

	for _, f := range testFiles {
		err := os.WriteFile(f.p, []byte(f.d), 0o644)
		if err != nil {
			fmt.Printf("create %v err: %v\n", f.p, err)
			return false
		}
	}
	return true
}

// from sipeed/picoclaw pkg/tools/fs/filesystem.go
// Helper to get a safe relative path for os.Root usage
func getSafeRelPath(workspace, path string) (string, error) {
	if workspace == "" {
		return "", fmt.Errorf("workspace is not defined")
	}

	rel := filepath.Clean(path)
	if filepath.IsAbs(rel) {
		var err error
		rel, err = filepath.Rel(workspace, rel)
		if err != nil {
			return "", fmt.Errorf("failed to calculate relative path: %w", err)
		}
	}

	if !filepath.IsLocal(rel) {
		return "", fmt.Errorf("path escapes workspace: %s", path)
	}

	return rel, nil
}
```

</details>

without `fp = filepath.ToSlash(fp)`
```
$ go run rootapi.go
init test files end
workspace root: C:\Users\user\source\repos\poc
test read file1.txt file1.txt
test read aaa/file2.txt aaa\file2.txt
test read aaa/bbb/file3.txt aaa\bbb\file3.txt
test read aaa/bbb/ccc/file4.txt aaa\bbb\ccc\file4.txt
test read aaa\bbb\ccc\file4.txt aaa\bbb\ccc\file4.txt
test read dir . .
test read dir aaa aaa
test read dir aaa\bbb aaa\bbb
fs.ReadDir aaa\bbb err: readdir aaa\bbb: invalid argument
test read dir aaa\bbb\ccc aaa\bbb\ccc
fs.ReadDir aaa\bbb\ccc err: readdir aaa\bbb\ccc: invalid argument
test read dir aaa\bbb\ccc aaa\bbb\ccc
fs.ReadDir aaa\bbb\ccc err: readdir aaa\bbb\ccc: invalid argument
```


with `fp = filepath.ToSlash(fp)`
```
$ go run rootapi.go
init test files end
workspace root: C:\Users\user\source\repos\poc
test read file1.txt file1.txt
test read aaa/file2.txt aaa\file2.txt
test read aaa/bbb/file3.txt aaa\bbb\file3.txt
test read aaa/bbb/ccc/file4.txt aaa\bbb\ccc\file4.txt
test read aaa\bbb\ccc\file4.txt aaa\bbb\ccc\file4.txt
test read dir . .
test read dir aaa aaa
test read dir aaa\bbb aaa/bbb
test read dir aaa\bbb\ccc aaa/bbb/ccc
test read dir aaa\bbb\ccc aaa/bbb/ccc
```

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.