### PR TITLE
fix(openai_compat): add ok check for native_search type assertion

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -155,7 +155,14 @@ func (p *Provider) buildRequestBody(
 
 	// When fallback uses a different provider (e.g. DeepSeek), that provider must not inject web_search_preview.
 	nativeSearch, ok := options["native_search"].(bool)
-	_ = ok
+	if !ok {
+		// If the option is present but not a bool, log a warning and
+		// treat it as false — web_search_preview must not be injected
+		// when the caller cannot express a well-typed intent.
+		if _, present := options["native_search"]; present {
+			log.Printf("[openai_compat] native_search option has unexpected type %T, ignoring", options["native_search"])
+		}
+	}
 	nativeSearch = nativeSearch && isNativeSearchHost(p.apiBase)
 	if len(tools) > 0 || nativeSearch {
 		requestBody["tools"] = buildToolsList(tools, nativeSearch)

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -160,7 +160,10 @@ func (p *Provider) buildRequestBody(
 		// treat it as false — web_search_preview must not be injected
 		// when the caller cannot express a well-typed intent.
 		if _, present := options["native_search"]; present {
-			log.Printf("[openai_compat] native_search option has unexpected type %T, ignoring", options["native_search"])
+			log.Printf(
+				"[openai_compat] native_search option has unexpected type %T, ignoring",
+				options["native_search"],
+			)
 		}
 	}
 	nativeSearch = nativeSearch && isNativeSearchHost(p.apiBase)

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -154,7 +154,8 @@ func (p *Provider) buildRequestBody(
 	}
 
 	// When fallback uses a different provider (e.g. DeepSeek), that provider must not inject web_search_preview.
-	nativeSearch, _ := options["native_search"].(bool)
+	nativeSearch, ok := options["native_search"].(bool)
+	_ = ok
 	nativeSearch = nativeSearch && isNativeSearchHost(p.apiBase)
 	if len(tools) > 0 || nativeSearch {
 		requestBody["tools"] = buildToolsList(tools, nativeSearch)


### PR DESCRIPTION
## Problem
`pkg/providers/openai_compat/provider.go:157` discards the `ok` from a type assertion on `options["native_search"]`. A non-bool value silently becomes `false`, which can disable native search without any diagnostic.

## Fix
Capture `ok` and explicitly ignore it with `_ = ok`, consistent with the `maxTokens` pattern on line 164.

## Verification
- `go build ./pkg/providers/openai_compat/...` passes