### PR TITLE
fix(utils): add ok checks for http.Transport type assertions in CreateHTTPClient

### DIFF
--- a/pkg/utils/http_client.go
+++ b/pkg/utils/http_client.go
@@ -39,9 +39,17 @@ func CreateHTTPClient(proxyURL string, timeout time.Duration) (*http.Client, err
 		if proxy.Host == "" {
 			return nil, fmt.Errorf("invalid proxy URL: missing host")
 		}
-		client.Transport.(*http.Transport).Proxy = http.ProxyURL(proxy)
+		tr, ok := client.Transport.(*http.Transport)
+		if !ok {
+			return nil, fmt.Errorf("internal error: transport is not *http.Transport")
+		}
+		tr.Proxy = http.ProxyURL(proxy)
 	} else {
-		client.Transport.(*http.Transport).Proxy = http.ProxyFromEnvironment
+		tr, ok := client.Transport.(*http.Transport)
+		if !ok {
+			return nil, fmt.Errorf("internal error: transport is not *http.Transport")
+		}
+		tr.Proxy = http.ProxyFromEnvironment
 	}
 
 	return client, nil


### PR DESCRIPTION
## Problem
`CreateHTTPClient` in `pkg/utils/http_client.go` uses unchecked type assertions on `client.Transport.(*http.Transport)` at lines 42 and 44. If a non-`*http.Transport` `RoundTripper` is used, this panics.

## Fix
Add `ok` checks with error returns, matching the pattern already used in `http_client_test.go`.

## Verification
- `go build ./pkg/utils/...` passes