### PR TITLE
fix(tools): handle json.Marshal error in toolloop tool call arguments

### DIFF
--- a/pkg/tools/toolloop.go
+++ b/pkg/tools/toolloop.go
@@ -132,7 +132,11 @@ func RunToolLoop(
 			Content: response.Content,
 		}
 		for _, tc := range normalizedToolCalls {
-			argumentsJSON, _ := json.Marshal(tc.Arguments)
+			argumentsJSON, err := json.Marshal(tc.Arguments)
+			if err != nil {
+				logger.Warnf("toolloop: failed to marshal tool call arguments for %s: %v", tc.Name, err)
+				argumentsJSON = []byte("{}")
+			}
 			assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, providers.ToolCall{
 				ID:        tc.ID,
 				Type:      "function",


### PR DESCRIPTION
## Problem
In `pkg/tools/toolloop.go`, `json.Marshal(tc.Arguments)` errors are silently discarded with `_`. If marshaling fails (e.g. non-serializable values in tool call arguments), the `Function.Arguments` field silently becomes an empty string, losing tool call data in the conversation history.

## Fix
- Check the `json.Marshal` error
- Log a warning via `logger.Warnf` with the tool name and error details
- Fall back to `"{}"` as the serialized arguments, preserving the tool call structure

## Verification
- `go build ./pkg/tools/...` passes