### PR TITLE
fix(pico): complete turn.done lifecycle signaling

### DIFF
--- a/pkg/agent/adapters/channelmanager.go
+++ b/pkg/agent/adapters/channelmanager.go
@@ -49,3 +49,10 @@ func (a *channelManagerAdapter) DismissToolFeedback(
 ) {
 	a.inner.DismissToolFeedback(ctx, channel, chatID, outboundCtx)
 }
+
+func (a *channelManagerAdapter) NotifyTurnDone(
+	ctx context.Context,
+	channel, chatID, requestID, status string,
+) {
+	a.inner.NotifyTurnDone(ctx, channel, chatID, requestID, status)
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -189,11 +189,16 @@ func (al *AgentLoop) Run(ctx context.Context) error {
 				msg = al.prepareInboundMessageForAgent(ctx, msg)
 
 				// Another turn is already active (or reserved) for this session — enqueue
-				if err := al.enqueueSteeringMessage(sessionKey, agentID, providers.Message{
-					Role:    "user",
-					Content: msg.Content,
-					Media:   append([]string(nil), msg.Media...),
-				}); err != nil {
+				if err := al.enqueueSteeringMessage(
+					sessionKey,
+					agentID,
+					providers.Message{
+						Role:    "user",
+						Content: msg.Content,
+						Media:   append([]string(nil), msg.Media...),
+					},
+					&msg.Context,
+				); err != nil {
 					logger.WarnCF("agent", "Failed to enqueue steering message",
 						map[string]any{
 							"error":       err.Error(),
@@ -235,6 +240,7 @@ func (al *AgentLoop) Run(ctx context.Context) error {
 
 				defer func() {
 					if r := recover(); r != nil {
+						al.invokeTypingStop(m)
 						logger.RecoverPanicNoExit(r)
 						logger.ErrorCF("agent", "Worker goroutine panicked",
 							map[string]any{
@@ -247,12 +253,10 @@ func (al *AgentLoop) Run(ctx context.Context) error {
 				}()
 				defer func() { <-al.workerSem }() // Release slot
 
-				if al.channelManager != nil {
-					defer al.channelManager.InvokeTypingStop(m.Channel, m.ChatID)
-				}
-
 				if al.takePendingStop(sessionKey) {
 					al.activeTurnStates.Delete(sessionKey)
+					al.invokeTypingStop(m)
+					al.notifyTurnDone(ctx, m, turnDoneStatusCanceled)
 					target := &continuationTarget{
 						SessionKey: sessionKey,
 						Channel:    m.Channel,
@@ -534,11 +538,26 @@ func (al *AgentLoop) runAgentLoop(
 	agent *AgentInstance,
 	opts processOptions,
 ) (string, error) {
+	response, status, err := al.runAgentLoopWithStatus(ctx, agent, opts)
+	if err != nil {
+		return "", err
+	}
+	if status == TurnEndStatusAborted {
+		return "", nil
+	}
+	return response, nil
+}
+
+func (al *AgentLoop) runAgentLoopWithStatus(
+	ctx context.Context,
+	agent *AgentInstance,
+	opts processOptions,
+) (string, TurnEndStatus, error) {
 	opts = normalizeProcessOptions(opts)
 	var err error
 	opts, err = resolveTurnProfileOptions(al.GetConfig(), opts)
 	if err != nil {
-		return "", err
+		return "", TurnEndStatusError, err
 	}
 
 	// Record last channel for heartbeat notifications (skip internal channels and cli)
@@ -571,10 +590,7 @@ func (al *AgentLoop) runAgentLoop(
 	pipeline := NewPipeline(al)
 	result, err := al.runTurn(ctx, ts, pipeline)
 	if err != nil {
-		return "", err
-	}
-	if result.status == TurnEndStatusAborted {
-		return "", nil
+		return "", TurnEndStatusError, err
 	}
 
 	for _, followUp := range result.followUps {
@@ -627,7 +643,7 @@ func (al *AgentLoop) runAgentLoop(
 			})
 	}
 
-	return result.finalContent, nil
+	return result.finalContent, result.status, nil
 }
 
 // selectCandidates returns the model candidates and resolved model name to use

--- a/pkg/agent/agent_command.go
+++ b/pkg/agent/agent_command.go
@@ -278,7 +278,8 @@ func (al *AgentLoop) buildCommandsRuntime(
 		if opts == nil {
 			return commands.StopResult{}, fmt.Errorf("process options not available")
 		}
-		return al.stopActiveTurnForSession(opts.Dispatch.SessionKey)
+		result, _, err := al.stopActiveTurnForSession(opts.Dispatch.SessionKey)
+		return result, err
 	}
 	if agent != nil && agent.ContextBuilder != nil {
 		rt.ListSkillNames = agent.ContextBuilder.ListSkillNames

--- a/pkg/agent/agent_message.go
+++ b/pkg/agent/agent_message.go
@@ -121,6 +121,20 @@ func (al *AgentLoop) prepareInboundMessageForAgent(
 }
 
 func (al *AgentLoop) processMessage(ctx context.Context, msg bus.InboundMessage) (string, error) {
+	response, turnStatus, err := al.processMessageWithStatus(ctx, msg)
+	if err != nil {
+		return "", err
+	}
+	if turnStatus == TurnEndStatusAborted {
+		return "", nil
+	}
+	return response, nil
+}
+
+func (al *AgentLoop) processMessageWithStatus(
+	ctx context.Context,
+	msg bus.InboundMessage,
+) (string, TurnEndStatus, error) {
 	msg = al.prepareInboundMessageForAgent(ctx, msg)
 
 	// Add message preview to log (show full content for error messages)
@@ -143,12 +157,13 @@ func (al *AgentLoop) processMessage(ctx context.Context, msg bus.InboundMessage)
 
 	// Route system messages to processSystemMessage
 	if msg.Channel == "system" {
-		return al.processSystemMessage(ctx, msg)
+		response, err := al.processSystemMessage(ctx, msg)
+		return response, TurnEndStatusCompleted, err
 	}
 
 	route, agent, routeErr := al.resolveMessageRoute(msg)
 	if routeErr != nil {
-		return "", routeErr
+		return "", TurnEndStatusError, routeErr
 	}
 
 	allocation := al.allocateRouteSession(route, msg)
@@ -196,13 +211,13 @@ func (al *AgentLoop) processMessage(ctx context.Context, msg bus.InboundMessage)
 	var err error
 	opts, err = resolveTurnProfileOptions(al.GetConfig(), opts)
 	if err != nil {
-		return "", err
+		return "", TurnEndStatusError, err
 	}
 
 	// context-dependent commands check their own Runtime fields and report
 	// "unavailable" when the required capability is nil.
 	if response, handled := al.handleCommand(ctx, msg, agent, &opts); handled {
-		return response, nil
+		return response, TurnEndStatusCompleted, nil
 	}
 
 	if pending := al.takePendingSkills(opts.Dispatch.SessionKey); len(pending) > 0 {
@@ -214,7 +229,7 @@ func (al *AgentLoop) processMessage(ctx context.Context, msg bus.InboundMessage)
 			})
 	}
 
-	return al.runAgentLoop(ctx, agent, opts)
+	return al.runAgentLoopWithStatus(ctx, agent, opts)
 }
 
 func (al *AgentLoop) resolveMessageRoute(msg bus.InboundMessage) (routing.ResolvedRoute, *AgentInstance, error) {

--- a/pkg/agent/agent_steering.go
+++ b/pkg/agent/agent_steering.go
@@ -4,34 +4,120 @@ package agent
 
 import (
 	"context"
+	"errors"
 
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
-func (al *AgentLoop) processMessageSync(ctx context.Context, msg bus.InboundMessage) {
-	if al.channelManager != nil {
-		defer al.channelManager.InvokeTypingStop(msg.Channel, msg.ChatID)
-	}
+const (
+	turnDoneStatusOK       = "ok"
+	turnDoneStatusError    = "error"
+	turnDoneStatusCanceled = "canceled"
+)
 
-	response, err := al.processMessage(ctx, msg)
+func turnDoneStatusFromError(err error) string {
+	if err == nil {
+		return turnDoneStatusOK
+	}
+	if errors.Is(err, context.Canceled) {
+		return turnDoneStatusCanceled
+	}
+	return turnDoneStatusError
+}
+
+func turnDoneStatusFromTurnResult(turnStatus TurnEndStatus, err error) string {
+	if err != nil {
+		return turnDoneStatusFromError(err)
+	}
+	if turnStatus == TurnEndStatusAborted {
+		return turnDoneStatusCanceled
+	}
+	return turnDoneStatusOK
+}
+
+func (al *AgentLoop) notifyTurnDone(ctx context.Context, msg bus.InboundMessage, status string) {
+	if al == nil || al.channelManager == nil {
+		return
+	}
+	msg = bus.NormalizeInboundMessage(msg)
+	al.channelManager.NotifyTurnDone(ctx, msg.Channel, msg.ChatID, msg.MessageID, status)
+}
+
+func (al *AgentLoop) invokeTypingStop(msg bus.InboundMessage) {
+	if al == nil || al.channelManager == nil {
+		return
+	}
+	msg = bus.NormalizeInboundMessage(msg)
+	al.channelManager.InvokeTypingStop(msg.Channel, msg.ChatID)
+}
+
+func (al *AgentLoop) invokeTypingStopForTarget(channel, chatID string) {
+	if al == nil || al.channelManager == nil {
+		return
+	}
+	al.channelManager.InvokeTypingStop(channel, chatID)
+}
+
+func (al *AgentLoop) notifyTurnDoneForSteeringEntries(
+	ctx context.Context,
+	entries []steeringQueueEntry,
+	status string,
+) {
+	if al == nil || al.channelManager == nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.inboundCtx == nil {
+			continue
+		}
+		msg := bus.NormalizeInboundMessage(bus.InboundMessage{
+			Context: *cloneInboundContext(entry.inboundCtx),
+		})
+		al.notifyTurnDone(ctx, msg, status)
+	}
+}
+
+func (al *AgentLoop) processMessageSync(ctx context.Context, msg bus.InboundMessage) {
+	status := turnDoneStatusOK
+	defer func() {
+		al.invokeTypingStop(msg)
+		al.notifyTurnDone(ctx, msg, status)
+	}()
+
+	response, turnStatus, err := al.processMessageWithStatus(ctx, msg)
+	status = turnDoneStatusFromTurnResult(turnStatus, err)
+	if turnStatus == TurnEndStatusAborted {
+		response = ""
+	}
 	al.publishResponseOrError(ctx, msg.Channel, msg.ChatID, msg.SessionKey, response, err)
 }
 
 func (al *AgentLoop) runTurnWithSteering(ctx context.Context, initialMsg bus.InboundMessage) {
+	status := turnDoneStatusOK
+	defer func() {
+		al.invokeTypingStop(initialMsg)
+		al.notifyTurnDone(ctx, initialMsg, status)
+	}()
+
 	// Process the initial message
-	response, err := al.processMessage(ctx, initialMsg)
+	response, turnStatus, err := al.processMessageWithStatus(ctx, initialMsg)
+	status = turnDoneStatusFromTurnResult(turnStatus, err)
 	if err != nil {
 		if !al.maybePublishError(ctx, initialMsg.Channel, initialMsg.ChatID, initialMsg.SessionKey, err) {
 			return // context canceled
 		}
 		response = ""
 	}
+	if turnStatus == TurnEndStatusAborted {
+		return
+	}
 	finalResponse := response
 
 	// Build continuation target
 	target, targetErr := al.buildContinuationTarget(initialMsg)
 	if targetErr != nil {
+		status = turnDoneStatusError
 		logger.WarnCF("agent", "Failed to build steering continuation target",
 			map[string]any{
 				"channel": initialMsg.Channel,
@@ -46,6 +132,7 @@ func (al *AgentLoop) runTurnWithSteering(ctx context.Context, initialMsg bus.Inb
 
 	continued, continueErr := al.drainQueuedSteeringContinuations(ctx, target)
 	if continueErr != nil {
+		status = turnDoneStatusFromError(continueErr)
 		logger.WarnCF("agent", "Failed to continue queued steering",
 			map[string]any{
 				"channel": target.Channel,

--- a/pkg/agent/agent_stop.go
+++ b/pkg/agent/agent_stop.go
@@ -19,7 +19,7 @@ func (al *AgentLoop) tryHandleStopCommand(
 		return false
 	}
 
-	result, err := al.stopActiveTurnForSession(sessionKey)
+	result, canceledEntries, err := al.stopActiveTurnForSession(sessionKey)
 
 	// This function is only called when loaded=true (another turn already
 	// claimed this session). If stopActiveTurnForSession found a pending
@@ -46,23 +46,34 @@ func (al *AgentLoop) tryHandleStopCommand(
 	}
 	al.resetMessageToolRound(sessionKey)
 	al.PublishResponseIfNeeded(ctx, msg.Channel, msg.ChatID, sessionKey, reply)
+
+	stopStatus := turnDoneStatusOK
+	if err != nil {
+		stopStatus = turnDoneStatusError
+	} else if result.Stopped || len(canceledEntries) > 0 {
+		stopStatus = turnDoneStatusCanceled
+	}
+	al.notifyTurnDone(ctx, msg, stopStatus)
+	al.notifyTurnDoneForSteeringEntries(ctx, canceledEntries, turnDoneStatusCanceled)
 	return true
 }
 
-func (al *AgentLoop) stopActiveTurnForSession(sessionKey string) (commands.StopResult, error) {
+func (al *AgentLoop) stopActiveTurnForSession(
+	sessionKey string,
+) (commands.StopResult, []steeringQueueEntry, error) {
 	sessionKey = strings.TrimSpace(sessionKey)
 	if sessionKey == "" {
-		return commands.StopResult{}, fmt.Errorf("session key is required")
+		return commands.StopResult{}, nil, fmt.Errorf("session key is required")
 	}
 
 	result := commands.StopResult{}
-	cleared := al.clearSteeringMessagesForScope(sessionKey)
+	clearedEntries := al.clearSteeringQueueEntriesForScope(sessionKey)
 	al.clearPendingSkills(sessionKey)
 
 	ts := al.getActiveTurnState(sessionKey)
 	if ts == nil {
-		result.Stopped = cleared > 0
-		return result, nil
+		result.Stopped = len(clearedEntries) > 0
+		return result, clearedEntries, nil
 	}
 
 	snap := ts.snapshot()
@@ -74,19 +85,19 @@ func (al *AgentLoop) stopActiveTurnForSession(sessionKey string) (commands.StopR
 		// hasn't started yet. In both cases, we don't arm a pending stop here;
 		// the caller (tryHandleStopCommand) handles the "another message queued"
 		// case explicitly, since it knows loaded=true.
-		return result, nil
+		return result, clearedEntries, nil
 	}
 
 	if err := al.HardAbort(sessionKey); err != nil {
 		if al.getActiveTurnState(sessionKey) == nil {
-			result.Stopped = cleared > 0
-			return result, nil
+			result.Stopped = len(clearedEntries) > 0
+			return result, clearedEntries, nil
 		}
-		return commands.StopResult{}, err
+		return commands.StopResult{}, clearedEntries, err
 	}
 
 	result.Stopped = true
-	return result, nil
+	return result, clearedEntries, nil
 }
 
 func (al *AgentLoop) markPendingStop(sessionKey string) {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -59,7 +59,10 @@ func (f *fakeMediaChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaM
 }
 
 type recordingChannelManager struct {
+	mu        sync.Mutex
 	dismissed []string
+	turnDone  []string
+	order     []string
 }
 
 func (m *recordingChannelManager) GetChannel(name string) (channels.Channel, bool) {
@@ -70,7 +73,11 @@ func (m *recordingChannelManager) GetEnabledChannels() []string {
 	return nil
 }
 
-func (m *recordingChannelManager) InvokeTypingStop(channel, chatID string) {}
+func (m *recordingChannelManager) InvokeTypingStop(channel, chatID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.order = append(m.order, fmt.Sprintf("typing:%s:%s", channel, chatID))
+}
 
 func (m *recordingChannelManager) SendMessage(ctx context.Context, msg bus.OutboundMessage) error {
 	return nil
@@ -87,7 +94,25 @@ func (m *recordingChannelManager) SendPlaceholder(ctx context.Context, channel, 
 func (m *recordingChannelManager) DismissToolFeedback(
 	ctx context.Context, channel, chatID string, outboundCtx *bus.InboundContext,
 ) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.dismissed = append(m.dismissed, fmt.Sprintf("%s:%s", channel, chatID))
+}
+
+func (m *recordingChannelManager) NotifyTurnDone(
+	ctx context.Context,
+	channel, chatID, requestID, status string,
+) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.turnDone = append(m.turnDone, fmt.Sprintf("%s:%s:%s:%s", channel, chatID, requestID, status))
+	m.order = append(m.order, fmt.Sprintf("done:%s:%s:%s:%s", channel, chatID, requestID, status))
+}
+
+func (m *recordingChannelManager) snapshotOrder() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.order...)
 }
 
 func newStartedTestChannelManager(
@@ -424,6 +449,37 @@ func TestPublishResponseIfNeeded_MarksFinalOutbound(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("expected final outbound")
+	}
+}
+
+func TestProcessMessageSync_NotifiesTurnDone(t *testing.T) {
+	al, _, _, provider, cleanup := newTestAgentLoop(t)
+	defer cleanup()
+	_ = provider
+
+	cm := &recordingChannelManager{}
+	al.channelManager = cm
+
+	msg := bus.NormalizeInboundMessage(bus.InboundMessage{
+		Context: bus.InboundContext{
+			Channel:   "pico",
+			ChatID:    "pico:sess-1",
+			ChatType:  "direct",
+			SenderID:  "pico-user",
+			MessageID: "req-1",
+		},
+		Content:    "hello",
+		SessionKey: "sess-1",
+	})
+	al.processMessageSync(context.Background(), msg)
+
+	if got := cm.turnDone; len(got) != 1 || got[0] != "pico:pico:sess-1:req-1:ok" {
+		t.Fatalf("turnDone = %v, want [pico:pico:sess-1:req-1:ok]", got)
+	}
+	if got := cm.snapshotOrder(); len(got) != 2 ||
+		got[0] != "typing:pico:pico:sess-1" ||
+		got[1] != "done:pico:pico:sess-1:req-1:ok" {
+		t.Fatalf("order = %v, want [typing:pico:pico:sess-1 done:pico:pico:sess-1:req-1:ok]", got)
 	}
 }
 

--- a/pkg/agent/interfaces/interfaces.go
+++ b/pkg/agent/interfaces/interfaces.go
@@ -54,4 +54,8 @@ type ChannelManager interface {
 	// outboundCtx carries topic/thread info needed for channels that use
 	// scoped tracker keys (e.g., Telegram forum topics); may be nil.
 	DismissToolFeedback(ctx context.Context, channel, chatID string, outboundCtx *bus.InboundContext)
+
+	// NotifyTurnDone emits a best-effort terminal signal for channels that
+	// support explicit per-request completion events (for example Pico).
+	NotifyTurnDone(ctx context.Context, channel, chatID, requestID, status string)
 }

--- a/pkg/agent/steering.go
+++ b/pkg/agent/steering.go
@@ -44,13 +44,18 @@ func parseSteeringMode(s string) SteeringMode {
 // into a running agent loop to interrupt it between tool calls.
 type steeringQueue struct {
 	mu     sync.Mutex
-	queues map[string][]providers.Message
+	queues map[string][]steeringQueueEntry
 	mode   SteeringMode
+}
+
+type steeringQueueEntry struct {
+	message    providers.Message
+	inboundCtx *bus.InboundContext
 }
 
 func newSteeringQueue(mode SteeringMode) *steeringQueue {
 	return &steeringQueue{
-		queues: make(map[string][]providers.Message),
+		queues: make(map[string][]steeringQueueEntry),
 		mode:   mode,
 	}
 }
@@ -65,11 +70,11 @@ func normalizeSteeringScope(scope string) string {
 
 // push enqueues a steering message in the legacy fallback scope.
 func (sq *steeringQueue) push(msg providers.Message) error {
-	return sq.pushScope(manualSteeringScope, msg)
+	return sq.pushScope(manualSteeringScope, steeringQueueEntry{message: msg})
 }
 
 // pushScope enqueues a steering message for the provided scope.
-func (sq *steeringQueue) pushScope(scope string, msg providers.Message) error {
+func (sq *steeringQueue) pushScope(scope string, msg steeringQueueEntry) error {
 	sq.mu.Lock()
 	defer sq.mu.Unlock()
 
@@ -85,12 +90,16 @@ func (sq *steeringQueue) pushScope(scope string, msg providers.Message) error {
 // dequeue removes and returns pending steering messages from the legacy
 // fallback scope according to the configured mode.
 func (sq *steeringQueue) dequeue() []providers.Message {
-	return sq.dequeueScope(manualSteeringScope)
+	return steeringQueueMessages(sq.dequeueScopeEntries(manualSteeringScope))
 }
 
 // dequeueScope removes and returns pending steering messages for the provided
 // scope according to the configured mode.
 func (sq *steeringQueue) dequeueScope(scope string) []providers.Message {
+	return steeringQueueMessages(sq.dequeueScopeEntries(scope))
+}
+
+func (sq *steeringQueue) dequeueScopeEntries(scope string) []steeringQueueEntry {
 	sq.mu.Lock()
 	defer sq.mu.Unlock()
 
@@ -100,6 +109,10 @@ func (sq *steeringQueue) dequeueScope(scope string) []providers.Message {
 // dequeueScopeWithFallback drains the scoped queue first and falls back to the
 // legacy manual scope for backwards compatibility.
 func (sq *steeringQueue) dequeueScopeWithFallback(scope string) []providers.Message {
+	return steeringQueueMessages(sq.dequeueScopeEntriesWithFallback(scope))
+}
+
+func (sq *steeringQueue) dequeueScopeEntriesWithFallback(scope string) []steeringQueueEntry {
 	sq.mu.Lock()
 	defer sq.mu.Unlock()
 
@@ -113,7 +126,7 @@ func (sq *steeringQueue) dequeueScopeWithFallback(scope string) []providers.Mess
 	return sq.dequeueLocked(manualSteeringScope)
 }
 
-func (sq *steeringQueue) dequeueLocked(scope string) []providers.Message {
+func (sq *steeringQueue) dequeueLocked(scope string) []steeringQueueEntry {
 	queue := sq.queues[scope]
 	if len(queue) == 0 {
 		return nil
@@ -121,20 +134,31 @@ func (sq *steeringQueue) dequeueLocked(scope string) []providers.Message {
 
 	switch sq.mode {
 	case SteeringAll:
-		msgs := append([]providers.Message(nil), queue...)
+		msgs := append([]steeringQueueEntry(nil), queue...)
 		delete(sq.queues, scope)
 		return msgs
 	default:
 		msg := queue[0]
-		queue[0] = providers.Message{} // Clear reference for GC
+		queue[0] = steeringQueueEntry{} // Clear reference for GC
 		queue = queue[1:]
 		if len(queue) == 0 {
 			delete(sq.queues, scope)
 		} else {
 			sq.queues[scope] = queue
 		}
-		return []providers.Message{msg}
+		return []steeringQueueEntry{msg}
 	}
+}
+
+func steeringQueueMessages(entries []steeringQueueEntry) []providers.Message {
+	if len(entries) == 0 {
+		return nil
+	}
+	msgs := make([]providers.Message, len(entries))
+	for i, entry := range entries {
+		msgs[i] = entry.message
+	}
+	return msgs
 }
 
 // len returns the number of queued messages across all scopes.
@@ -156,16 +180,16 @@ func (sq *steeringQueue) lenScope(scope string) int {
 	return len(sq.queues[normalizeSteeringScope(scope)])
 }
 
-func (sq *steeringQueue) clearScope(scope string) int {
+func (sq *steeringQueue) clearScopeEntries(scope string) []steeringQueueEntry {
 	sq.mu.Lock()
 	defer sq.mu.Unlock()
 
 	scope = normalizeSteeringScope(scope)
-	count := len(sq.queues[scope])
-	if count > 0 {
+	queue := sq.queues[scope]
+	if len(queue) > 0 {
 		delete(sq.queues, scope)
 	}
-	return count
+	return append([]steeringQueueEntry(nil), queue...)
 }
 
 // setMode updates the steering mode.
@@ -192,16 +216,24 @@ func (al *AgentLoop) Steer(msg providers.Message) error {
 		scope = ts.sessionKey
 		agentID = ts.agentID
 	}
-	return al.enqueueSteeringMessage(scope, agentID, msg)
+	return al.enqueueSteeringMessage(scope, agentID, msg, nil)
 }
 
-func (al *AgentLoop) enqueueSteeringMessage(scope, agentID string, msg providers.Message) error {
+func (al *AgentLoop) enqueueSteeringMessage(
+	scope, agentID string,
+	msg providers.Message,
+	inboundCtx *bus.InboundContext,
+) error {
 	if al.steering == nil {
 		return fmt.Errorf("steering queue is not initialized")
 	}
 
 	msg = steeringPromptMessage(msg)
-	if err := al.steering.pushScope(scope, msg); err != nil {
+	entry := steeringQueueEntry{
+		message:    msg,
+		inboundCtx: cloneInboundContext(inboundCtx),
+	}
+	if err := al.steering.pushScope(scope, entry); err != nil {
 		logger.WarnCF("agent", "Failed to enqueue steering message", map[string]any{
 			"error": err.Error(),
 			"role":  msg.Role,
@@ -295,6 +327,15 @@ func (al *AgentLoop) dequeueSteeringMessagesForScopeWithFallback(scope string) [
 	return al.steering.dequeueScopeWithFallback(scope)
 }
 
+func (al *AgentLoop) dequeueSteeringQueueEntriesForScopeWithFallback(
+	scope string,
+) []steeringQueueEntry {
+	if al.steering == nil {
+		return nil
+	}
+	return al.steering.dequeueScopeEntriesWithFallback(scope)
+}
+
 func (al *AgentLoop) pendingSteeringCountForScope(scope string) int {
 	if al.steering == nil {
 		return 0
@@ -302,11 +343,11 @@ func (al *AgentLoop) pendingSteeringCountForScope(scope string) int {
 	return al.steering.lenScope(scope)
 }
 
-func (al *AgentLoop) clearSteeringMessagesForScope(scope string) int {
+func (al *AgentLoop) clearSteeringQueueEntriesForScope(scope string) []steeringQueueEntry {
 	if al.steering == nil {
-		return 0
+		return nil
 	}
-	return al.steering.clearScope(scope)
+	return al.steering.clearScopeEntries(scope)
 }
 
 func (al *AgentLoop) continueWithSteeringMessages(
@@ -315,7 +356,7 @@ func (al *AgentLoop) continueWithSteeringMessages(
 	sessionKey, channel, chatID string,
 	scope *session.SessionScope,
 	steeringMsgs []providers.Message,
-) (string, error) {
+) (string, TurnEndStatus, error) {
 	dispatch := DispatchRequest{
 		SessionKey:   sessionKey,
 		SessionScope: session.CloneScope(scope),
@@ -327,7 +368,7 @@ func (al *AgentLoop) continueWithSteeringMessages(
 			ChatType: inferChatTypeFromSessionScope(scope),
 		}
 	}
-	return al.runAgentLoop(ctx, agent, processOptions{
+	return al.runAgentLoopWithStatus(ctx, agent, processOptions{
 		Dispatch:                dispatch,
 		DefaultResponse:         defaultResponse,
 		EnableSummary:           true,
@@ -368,7 +409,7 @@ func (al *AgentLoop) agentForSession(sessionKey string) *AgentInstance {
 // user has since enqueued steering messages.
 //
 // If no steering messages are pending, it returns an empty string.
-func (al *AgentLoop) Continue(ctx context.Context, sessionKey, channel, chatID string) (string, error) {
+func (al *AgentLoop) Continue(ctx context.Context, sessionKey, channel, chatID string) (resp string, err error) {
 	// Claim the session with a unique placeholder to prevent a TOCTOU race where two
 	// concurrent Continue calls for the same session both pass the active-turn
 	// check and create parallel turns. The placeholder is replaced by the real
@@ -385,20 +426,25 @@ func (al *AgentLoop) Continue(ctx context.Context, sessionKey, channel, chatID s
 		return "", nil
 	}
 
-	if err := al.ensureHooksInitialized(ctx); err != nil {
+	if err = al.ensureHooksInitialized(ctx); err != nil {
 		al.activeTurnStates.Delete(sessionKey)
 		return "", err
 	}
-	if err := al.ensureMCPInitialized(ctx); err != nil {
+	if err = al.ensureMCPInitialized(ctx); err != nil {
 		al.activeTurnStates.Delete(sessionKey)
 		return "", err
 	}
 
-	steeringMsgs := al.dequeueSteeringMessagesForScopeWithFallback(sessionKey)
-	if len(steeringMsgs) == 0 {
+	steeringEntries := al.dequeueSteeringQueueEntriesForScopeWithFallback(sessionKey)
+	if len(steeringEntries) == 0 {
 		al.activeTurnStates.Delete(sessionKey)
 		return "", nil
 	}
+	turnStatus := TurnEndStatusCompleted
+	defer func() {
+		al.invokeTypingStopForTarget(channel, chatID)
+		al.notifyTurnDoneForSteeringEntries(ctx, steeringEntries, turnDoneStatusFromTurnResult(turnStatus, err))
+	}()
 
 	agent := al.agentForSession(sessionKey)
 	if agent == nil {
@@ -417,7 +463,22 @@ func (al *AgentLoop) Continue(ctx context.Context, sessionKey, channel, chatID s
 		scope = metaStore.GetSessionScope(sessionKey)
 	}
 
-	return al.continueWithSteeringMessages(ctx, agent, sessionKey, channel, chatID, scope, steeringMsgs)
+	resp, turnStatus, err = al.continueWithSteeringMessages(
+		ctx,
+		agent,
+		sessionKey,
+		channel,
+		chatID,
+		scope,
+		steeringQueueMessages(steeringEntries),
+	)
+	if err != nil {
+		return "", err
+	}
+	if turnStatus == TurnEndStatusAborted {
+		return "", nil
+	}
+	return resp, nil
 }
 
 func (al *AgentLoop) InterruptGraceful(hint string) error {

--- a/pkg/agent/steering_test.go
+++ b/pkg/agent/steering_test.go
@@ -851,6 +851,139 @@ func TestAgentLoop_Run_AutoContinuesLateSteeringMessage(t *testing.T) {
 	}
 }
 
+func TestAgentLoop_Run_QueuedPicoMessageReceivesTurnDone(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "agent-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				ModelName:         "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+			},
+		},
+	}
+
+	msgBus := bus.NewMessageBus()
+	provider := &lateSteeringProvider{
+		firstCallStarted: make(chan struct{}),
+		releaseFirstCall: make(chan struct{}),
+	}
+	al := NewAgentLoop(cfg, msgBus, provider)
+	cm := &recordingChannelManager{}
+	al.channelManager = cm
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	defer cancelRun()
+
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- al.Run(runCtx)
+	}()
+
+	first := testInboundMessage(bus.InboundMessage{
+		Context: bus.InboundContext{
+			Channel:   "pico",
+			ChatID:    "pico:sess-1",
+			ChatType:  "direct",
+			SenderID:  "user1",
+			MessageID: "req-1",
+		},
+		Content: "first message",
+	})
+	late := testInboundMessage(bus.InboundMessage{
+		Context: bus.InboundContext{
+			Channel:   "pico",
+			ChatID:    "pico:sess-1",
+			ChatType:  "direct",
+			SenderID:  "user1",
+			MessageID: "req-2",
+		},
+		Content: "late append",
+	})
+
+	sessionKey, _, ok := al.resolveSteeringTarget(first)
+	if !ok {
+		t.Fatal("expected pico inbound to resolve to a steering target")
+	}
+
+	pubCtx, pubCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer pubCancel()
+	if err := msgBus.PublishInbound(pubCtx, first); err != nil {
+		t.Fatalf("publish first inbound: %v", err)
+	}
+
+	select {
+	case <-provider.firstCallStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for first provider call to start")
+	}
+
+	if err := msgBus.PublishInbound(pubCtx, late); err != nil {
+		t.Fatalf("publish late inbound: %v", err)
+	}
+
+	close(provider.releaseFirstCall)
+
+	select {
+	case outbound := <-msgBus.OutboundChan():
+		if outbound.Content != "continued response" {
+			t.Fatalf("expected continued response, got %q", outbound.Content)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected outbound response")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if al.GetActiveTurnBySession(sessionKey) == nil &&
+			al.pendingSteeringCountForScope(sessionKey) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timeout waiting for continuation turn to finish")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancelRun()
+	select {
+	case err := <-runErrCh:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Run to stop")
+	}
+
+	want := "pico:pico:sess-1:req-2:ok"
+	count := 0
+	for _, got := range cm.turnDone {
+		if got == want {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("turnDone = %v, want queued request %q exactly once", cm.turnDone, want)
+	}
+	order := cm.snapshotOrder()
+	doneIdx := -1
+	for i, got := range order {
+		if got == "done:"+want {
+			doneIdx = i
+			break
+		}
+	}
+	if doneIdx <= 0 || order[doneIdx-1] != "typing:pico:pico:sess-1" {
+		t.Fatalf("order = %v, want typing stop immediately before queued turn.done", order)
+	}
+}
+
 func TestAgentLoop_Run_QueuedVoiceMessageIsTranscribedBeforeSteering(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := &config.Config{
@@ -1605,6 +1738,8 @@ func TestAgentLoop_InterruptHard_RestoresSession(t *testing.T) {
 	al := NewAgentLoop(cfg, msgBus, provider)
 	started := make(chan struct{})
 	al.RegisterTool(&interruptibleTool{name: "cancel_tool", started: started})
+	cm := &recordingChannelManager{}
+	al.channelManager = cm
 	sessionKey := session.BuildMainSessionKey(routing.DefaultAgentID)
 
 	defaultAgent := al.registry.GetDefaultAgent()
@@ -1744,6 +1879,8 @@ func TestAgentLoop_StopCommand_AbortsActiveTurnAndClearsQueuedSteering(t *testin
 	al := NewAgentLoop(cfg, msgBus, provider)
 	started := make(chan struct{})
 	al.RegisterTool(&interruptibleTool{name: "cancel_tool", started: started})
+	cm := &recordingChannelManager{}
+	al.channelManager = cm
 	sessionKey := session.BuildMainSessionKey(routing.DefaultAgentID)
 
 	runCtx, cancelRun := context.WithCancel(context.Background())
@@ -1767,10 +1904,11 @@ func TestAgentLoop_StopCommand_AbortsActiveTurnAndClearsQueuedSteering(t *testin
 
 	baseMsg := testInboundMessage(bus.InboundMessage{
 		Context: bus.InboundContext{
-			Channel:  "test",
-			ChatID:   "chat1",
-			ChatType: "direct",
-			SenderID: "user1",
+			Channel:   "test",
+			ChatID:    "chat1",
+			ChatType:  "direct",
+			SenderID:  "user1",
+			MessageID: "req-1",
 		},
 		SessionKey: sessionKey,
 	})
@@ -1790,7 +1928,13 @@ func TestAgentLoop_StopCommand_AbortsActiveTurnAndClearsQueuedSteering(t *testin
 	}
 
 	if err := msgBus.PublishInbound(context.Background(), bus.InboundMessage{
-		Context:    baseMsg.Context,
+		Context: bus.InboundContext{
+			Channel:   baseMsg.Context.Channel,
+			ChatID:    baseMsg.Context.ChatID,
+			ChatType:  baseMsg.Context.ChatType,
+			SenderID:  baseMsg.Context.SenderID,
+			MessageID: "req-2",
+		},
 		Content:    "follow up after cancel",
 		SessionKey: sessionKey,
 	}); err != nil {
@@ -1806,7 +1950,13 @@ func TestAgentLoop_StopCommand_AbortsActiveTurnAndClearsQueuedSteering(t *testin
 	}
 
 	if err := msgBus.PublishInbound(context.Background(), bus.InboundMessage{
-		Context:    baseMsg.Context,
+		Context: bus.InboundContext{
+			Channel:   baseMsg.Context.Channel,
+			ChatID:    baseMsg.Context.ChatID,
+			ChatType:  baseMsg.Context.ChatType,
+			SenderID:  baseMsg.Context.SenderID,
+			MessageID: "req-3",
+		},
 		Content:    "/stop",
 		SessionKey: sessionKey,
 	}); err != nil {
@@ -1846,6 +1996,22 @@ func TestAgentLoop_StopCommand_AbortsActiveTurnAndClearsQueuedSteering(t *testin
 	provider.mu.Unlock()
 	if calls != 1 {
 		t.Fatalf("expected provider to stop before follow-up turn, got %d calls", calls)
+	}
+
+	expectedTurnDone := map[string]int{
+		"test:chat1:req-1:canceled": 0,
+		"test:chat1:req-2:canceled": 0,
+		"test:chat1:req-3:canceled": 0,
+	}
+	for _, got := range cm.turnDone {
+		if _, ok := expectedTurnDone[got]; ok {
+			expectedTurnDone[got]++
+		}
+	}
+	for want, count := range expectedTurnDone {
+		if count != 1 {
+			t.Fatalf("turnDone = %v, want %q exactly once", cm.turnDone, want)
+		}
 	}
 }
 

--- a/pkg/channels/interfaces.go
+++ b/pkg/channels/interfaces.go
@@ -60,6 +60,12 @@ type StreamingCapable interface {
 	BeginStream(ctx context.Context, chatID string) (Streamer, error)
 }
 
+// TurnCompletionCapable emits an explicit terminal signal once a user turn is
+// fully complete and no more outbound updates are expected for that request.
+type TurnCompletionCapable interface {
+	SendTurnDone(ctx context.Context, chatID, requestID, status string) error
+}
+
 // Streamer is defined in pkg/bus to avoid circular imports.
 // This alias keeps channel implementations using channels.Streamer unchanged.
 type Streamer = bus.Streamer

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -43,6 +43,10 @@ const (
 	placeholderTTL  = 10 * time.Minute
 
 	streamAuxiliaryTombstoneTTL = 30 * time.Second
+
+	internalRawKeyTurnDone          = "_picoclaw_turn_done"
+	internalRawKeyTurnDoneRequestID = "_picoclaw_turn_done_request_id"
+	internalRawKeyTurnDoneStatus    = "_picoclaw_turn_done_status"
 )
 
 // typingEntry wraps a typing stop function with a creation timestamp for TTL eviction.
@@ -209,6 +213,24 @@ func outboundMessageEditPayload(msg bus.OutboundMessage, content string) map[str
 		payload["model_name"] = modelName
 	}
 	return payload
+}
+
+func turnDoneControlMessage(msg bus.OutboundMessage) (requestID, status string, ok bool) {
+	if len(msg.Context.Raw) == 0 {
+		return "", "", false
+	}
+	if !strings.EqualFold(strings.TrimSpace(msg.Context.Raw[internalRawKeyTurnDone]), "true") {
+		return "", "", false
+	}
+	requestID = strings.TrimSpace(msg.Context.Raw[internalRawKeyTurnDoneRequestID])
+	if requestID == "" {
+		return "", "", false
+	}
+	status = strings.TrimSpace(msg.Context.Raw[internalRawKeyTurnDoneStatus])
+	if status == "" {
+		status = "ok"
+	}
+	return requestID, status, true
 }
 
 func outboundMediaChannel(msg bus.OutboundMediaMessage) string {
@@ -1518,6 +1540,16 @@ func (m *Manager) sendWithRetry(
 		return nil, false
 	}
 
+	if requestID, status, ok := turnDoneControlMessage(msg); ok {
+		err := m.sendTurnDoneWithRetry(ctx, name, w, msg, requestID, status)
+		if err == nil {
+			m.publishOutboundSent(name, msg, nil)
+			return nil, true
+		}
+		m.publishOutboundFailed(name, msg, err, false)
+		return nil, false
+	}
+
 	// Pre-send: stop typing and try to edit placeholder
 	if msgIDs, handled := m.preSend(ctx, name, msg, w.ch); handled {
 		m.publishOutboundSent(name, msg, msgIDs)
@@ -1572,6 +1604,62 @@ func (m *Manager) sendWithRetry(
 	m.publishOutboundFailed(name, msg, lastErr, false)
 
 	return nil, false
+}
+
+func (m *Manager) sendTurnDoneWithRetry(
+	ctx context.Context,
+	name string,
+	w *channelWorker,
+	msg bus.OutboundMessage,
+	requestID string,
+	status string,
+) error {
+	sender, ok := w.ch.(TurnCompletionCapable)
+	if !ok {
+		return nil
+	}
+
+	chatID := outboundMessageChatID(msg)
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		lastErr = sender.SendTurnDone(ctx, chatID, requestID, status)
+		if lastErr == nil {
+			return nil
+		}
+
+		if errors.Is(lastErr, ErrNotRunning) || errors.Is(lastErr, ErrSendFailed) {
+			break
+		}
+		if attempt == maxRetries {
+			break
+		}
+
+		if errors.Is(lastErr, ErrRateLimit) {
+			select {
+			case <-time.After(rateLimitDelay):
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		backoff := min(time.Duration(float64(baseBackoff)*math.Pow(2, float64(attempt))), maxBackoff)
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	logger.ErrorCF("channels", "SendTurnDone failed", map[string]any{
+		"channel":    name,
+		"chat_id":    chatID,
+		"request_id": requestID,
+		"status":     status,
+		"error":      lastErr.Error(),
+		"retries":    maxRetries,
+	})
+	return lastErr
 }
 
 func dispatchLoop[M any](
@@ -2036,6 +2124,51 @@ func (m *Manager) SendMedia(ctx context.Context, msg bus.OutboundMediaMessage) e
 
 	_, err := m.sendMediaWithRetry(ctx, channelName, w, msg)
 	return err
+}
+
+// NotifyTurnDone enqueues a best-effort terminal event for channels that
+// support explicit per-request completion signaling.
+func (m *Manager) NotifyTurnDone(ctx context.Context, channel, chatID, requestID, status string) {
+	if m == nil || m.bus == nil {
+		return
+	}
+	channel = strings.TrimSpace(channel)
+	chatID = strings.TrimSpace(chatID)
+	requestID = strings.TrimSpace(requestID)
+	status = strings.TrimSpace(status)
+	if channel == "" || chatID == "" || requestID == "" {
+		return
+	}
+
+	m.mu.RLock()
+	ch, exists := m.channels[channel]
+	m.mu.RUnlock()
+	if !exists {
+		return
+	}
+	if _, ok := ch.(TurnCompletionCapable); !ok {
+		return
+	}
+
+	if status == "" {
+		status = "ok"
+	}
+
+	pubCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_ = m.bus.PublishOutbound(pubCtx, bus.OutboundMessage{
+		Context: bus.InboundContext{
+			Channel:   channel,
+			ChatID:    chatID,
+			MessageID: requestID,
+			Raw: map[string]string{
+				internalRawKeyTurnDone:          "true",
+				internalRawKeyTurnDoneRequestID: requestID,
+				internalRawKeyTurnDoneStatus:    status,
+			},
+		},
+	})
 }
 
 func (m *Manager) SendToChannel(ctx context.Context, channelName, chatID, content string) error {

--- a/pkg/channels/manager_test.go
+++ b/pkg/channels/manager_test.go
@@ -103,6 +103,39 @@ func (m *mockDeletingMediaChannel) DismissToolFeedbackMessage(_ context.Context,
 	m.dismissedChatID = chatID
 }
 
+type mockTurnDoneChannel struct {
+	mockChannel
+	mu         sync.Mutex
+	order      []string
+	lastTurnID string
+	lastStatus string
+}
+
+func (m *mockTurnDoneChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]string, error) {
+	m.mu.Lock()
+	m.order = append(m.order, "send:"+msg.Content)
+	m.mu.Unlock()
+	return m.mockChannel.Send(ctx, msg)
+}
+
+func (m *mockTurnDoneChannel) SendTurnDone(
+	_ context.Context,
+	chatID, requestID, status string,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.order = append(m.order, "done:"+requestID+":"+status)
+	m.lastTurnID = requestID
+	m.lastStatus = status
+	return nil
+}
+
+func (m *mockTurnDoneChannel) snapshotOrder() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.order...)
+}
+
 type mockStreamer struct {
 	finalizeFn            func(context.Context, string) error
 	finalizeWithContextFn func(context.Context, string, *bus.ContextUsage) error
@@ -3344,6 +3377,52 @@ func TestSendMessage_PreservesOrdering(t *testing.T) {
 	}
 	if order[0] != "first" || order[1] != "second" {
 		t.Fatalf("expected [first, second], got %v", order)
+	}
+}
+
+func TestNotifyTurnDone_PreservesOutboundOrdering(t *testing.T) {
+	msgBus := bus.NewMessageBus()
+	mgr, err := NewManager(&config.Config{}, msgBus, nil)
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	ch := &mockTurnDoneChannel{}
+	mgr.RegisterChannel("pico", ch)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := mgr.StartAll(ctx); err != nil {
+		t.Fatalf("StartAll() error = %v", err)
+	}
+	defer func() {
+		if err := mgr.StopAll(context.Background()); err != nil {
+			t.Fatalf("StopAll() error = %v", err)
+		}
+	}()
+
+	if err := msgBus.PublishOutbound(context.Background(), testOutboundMessage(bus.OutboundMessage{
+		Context: bus.NewOutboundContext("pico", "pico:sess-1", ""),
+		Content: "final reply",
+	})); err != nil {
+		t.Fatalf("PublishOutbound() error = %v", err)
+	}
+
+	mgr.NotifyTurnDone(context.Background(), "pico", "pico:sess-1", "req-1", "ok")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		order := ch.snapshotOrder()
+		if len(order) >= 2 {
+			if order[0] != "send:final reply" || order[1] != "done:req-1:ok" {
+				t.Fatalf("unexpected send order: %v", order)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for turn.done, order=%v", order)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/pkg/channels/pico/pico.go
+++ b/pkg/channels/pico/pico.go
@@ -486,6 +486,15 @@ func (c *PicoChannel) StartTyping(ctx context.Context, chatID string) (func(), e
 	}, nil
 }
 
+// SendTurnDone emits an explicit terminal event for a completed user turn.
+func (c *PicoChannel) SendTurnDone(ctx context.Context, chatID, requestID, status string) error {
+	doneMsg := newMessage(TypeTurnDone, map[string]any{
+		"request_id": requestID,
+		"status":     status,
+	})
+	return c.broadcastToSession(chatID, doneMsg)
+}
+
 // SendPlaceholder implements channels.PlaceholderCapable.
 // It sends a placeholder message via the Pico Protocol that will later be
 // edited to the actual response via EditMessage (channels.MessageEditor).

--- a/pkg/channels/pico/pico_test.go
+++ b/pkg/channels/pico/pico_test.go
@@ -288,6 +288,37 @@ func TestSend_ToolCallsMessageIncludesModelName(t *testing.T) {
 	}
 }
 
+func TestSendTurnDone_BroadcastsTerminalEvent(t *testing.T) {
+	ch := newTestPicoChannel(t)
+
+	if err := ch.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer ch.Stop(context.Background())
+
+	clientConn, received, cleanup := newTestPicoWebSocket(t)
+	defer cleanup()
+	ch.addConnForTest(&picoConn{id: "conn-1", conn: clientConn, sessionID: "sess-1"})
+
+	if err := ch.SendTurnDone(context.Background(), "pico:sess-1", "req-1", "ok"); err != nil {
+		t.Fatalf("SendTurnDone() error = %v", err)
+	}
+
+	msg := mustReceivePicoMessage(t, received)
+	if msg.Type != TypeTurnDone {
+		t.Fatalf("type = %q, want %q", msg.Type, TypeTurnDone)
+	}
+	if msg.SessionID != "sess-1" {
+		t.Fatalf("session_id = %q, want %q", msg.SessionID, "sess-1")
+	}
+	if got := msg.Payload["request_id"]; got != "req-1" {
+		t.Fatalf("request_id = %#v, want %q", got, "req-1")
+	}
+	if got := msg.Payload["status"]; got != "ok" {
+		t.Fatalf("status = %#v, want %q", got, "ok")
+	}
+}
+
 func TestSendPlaceholder_EmitsNormalMessageWithoutKind(t *testing.T) {
 	ch := newTestPicoChannel(t)
 	ch.bc.Placeholder.Enabled = true

--- a/pkg/channels/pico/protocol.go
+++ b/pkg/channels/pico/protocol.go
@@ -19,6 +19,7 @@ const (
 	TypeMediaCreate   = "media.create"
 	TypeTypingStart   = "typing.start"
 	TypeTypingStop    = "typing.stop"
+	TypeTurnDone      = "turn.done"
 	TypeError         = "error"
 	TypePong          = "pong"
 


### PR DESCRIPTION
## 📝 Description

This PR completes the Pico `turn.done` lifecycle for [issue #2984](https://github.com/sipeed/picoclaw/issues/2984).

It fixes three gaps in the initial implementation:
- preserves `request_id` for queued steering/follow-up messages so every inbound Pico request can receive its own `turn.done`
- reports `status: "canceled"` for aborted turns and `/stop`-driven cancellations instead of incorrectly reporting `ok`
- guarantees `typing.stop` is emitted before `turn.done`, so the terminal event really marks the end of the full turn lifecycle

It also adds regression coverage for queued Pico messages, stop/cancel flows, and ordering between `typing.stop` and `turn.done`.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #2984

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/2984
- **Reasoning:** Pico clients need a reliable terminal event per inbound request. The previous implementation could lose `request_id` for queued messages, report `ok` for aborted turns, and emit `turn.done` before `typing.stop`. This PR aligns the runtime behavior with the lifecycle semantics expected by the issue.

## 🧪 Test Environment
- **Hardware:** 
- **OS:**
- **Model/Provider:** 
- **Channels:** Pico

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Validated with targeted Go tests:

```bash
go test ./pkg/agent -run 'TestProcessMessageSync_NotifiesTurnDone|TestAgentLoop_Run_QueuedPicoMessageReceivesTurnDone|TestAgentLoop_StopCommand_AbortsActiveTurnAndClearsQueuedSteering|TestAgentLoop_Run_PendingStopStillContinuesQueuedFollowUp'
go test ./pkg/agent -run 'TestSteeringQueue_PushDequeue_OneAtATime|TestSteeringQueue_PushDequeue_All|TestAgentLoop_Run_AutoContinuesLateSteeringMessage|TestAgentLoop_Run_QueuedVoiceMessageIsTranscribedBeforeSteering|TestAgentLoop_Steering_DirectResponseContinuesWithQueuedMessage|TestAgentLoop_InterruptHard_CancelsContextAndRollsBackSession'
```

Both test runs passed.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.