### PR TITLE
Add remote Pico WebSocket mode to picoclaw agent

### DIFF
--- a/cmd/picoclaw/internal/agent/command.go
+++ b/cmd/picoclaw/internal/agent/command.go
@@ -20,12 +20,16 @@ func NewAgentCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if remoteURL != "" {
+				remoteSessionKey := sessionKey
+				if !cmd.Flags().Changed("session") {
+					remoteSessionKey = ""
+				}
 				return remoteAgentCmd(
 					cmd.Context(),
 					remoteURL,
 					token,
 					message,
-					sessionKey,
+					remoteSessionKey,
 					cmd.InOrStdin(),
 					cmd.OutOrStdout(),
 				)

--- a/cmd/picoclaw/internal/agent/command.go
+++ b/cmd/picoclaw/internal/agent/command.go
@@ -10,6 +10,8 @@ func NewAgentCommand() *cobra.Command {
 		sessionKey string
 		model      string
 		debug      bool
+		remoteURL  string
+		token      string
 	)
 
 	cmd := &cobra.Command{
@@ -17,6 +19,17 @@ func NewAgentCommand() *cobra.Command {
 		Short: "Interact with the agent directly",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if remoteURL != "" {
+				return remoteAgentCmd(
+					cmd.Context(),
+					remoteURL,
+					token,
+					message,
+					sessionKey,
+					cmd.InOrStdin(),
+					cmd.OutOrStdout(),
+				)
+			}
 			return agentCmd(message, sessionKey, model, debug)
 		},
 	}
@@ -25,6 +38,8 @@ func NewAgentCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Send a single message (non-interactive mode)")
 	cmd.Flags().StringVarP(&sessionKey, "session", "s", "cli:default", "Session key")
 	cmd.Flags().StringVarP(&model, "model", "", "", "Model to use")
+	cmd.Flags().StringVar(&remoteURL, "remote", "", "Connect to a remote Pico WebSocket URL")
+	cmd.Flags().StringVar(&token, "token", "", "Bearer token for remote Pico auth")
 
 	return cmd
 }

--- a/cmd/picoclaw/internal/agent/command.go
+++ b/cmd/picoclaw/internal/agent/command.go
@@ -42,7 +42,12 @@ func NewAgentCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Send a single message (non-interactive mode)")
 	cmd.Flags().StringVarP(&sessionKey, "session", "s", "cli:default", "Session key")
 	cmd.Flags().StringVarP(&model, "model", "", "", "Model to use")
-	cmd.Flags().StringVar(&remoteURL, "remote", "", "Connect to a remote Pico WebSocket URL")
+	cmd.Flags().StringVar(
+		&remoteURL,
+		"remote",
+		"",
+		"Connect to a remote Pico WebSocket URL, e.g. ws://host:18790/pico/ws",
+	)
 	cmd.Flags().StringVar(&token, "token", "", "Bearer token for remote Pico auth")
 
 	return cmd

--- a/cmd/picoclaw/internal/agent/command_test.go
+++ b/cmd/picoclaw/internal/agent/command_test.go
@@ -30,4 +30,6 @@ func TestNewAgentCommand(t *testing.T) {
 	assert.NotNil(t, cmd.Flags().Lookup("message"))
 	assert.NotNil(t, cmd.Flags().Lookup("session"))
 	assert.NotNil(t, cmd.Flags().Lookup("model"))
+	assert.NotNil(t, cmd.Flags().Lookup("remote"))
+	assert.NotNil(t, cmd.Flags().Lookup("token"))
 }

--- a/cmd/picoclaw/internal/agent/remote.go
+++ b/cmd/picoclaw/internal/agent/remote.go
@@ -1,0 +1,695 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/ergochat/readline"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+
+	"github.com/sipeed/picoclaw/cmd/picoclaw/internal"
+	"github.com/sipeed/picoclaw/pkg/channels/pico"
+)
+
+const (
+	defaultRemoteSessionID    = "cli:default"
+	remoteOneShotFirstTimeout = 30 * time.Second
+	remoteOneShotIdleTimeout  = 1500 * time.Millisecond
+)
+
+var errRemoteReadlineUnavailable = errors.New("remote readline unavailable")
+
+type remoteClient struct {
+	conn *websocket.Conn
+	out  *lockedWriter
+	mu   sync.Mutex
+}
+
+type remoteEventResult struct {
+	Displayed bool
+	Err       error
+}
+
+type remoteInputResult struct {
+	Line string
+	Err  error
+}
+
+type lockedWriter struct {
+	mu            sync.Mutex
+	w             io.Writer
+	refreshPrompt func()
+	typingVisible bool
+}
+
+func (w *lockedWriter) Printf(format string, args ...any) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.prepareAsyncOutputLocked()
+	fmt.Fprintf(w.w, format, args...)
+	w.refreshPromptLocked()
+}
+
+func (w *lockedWriter) SetWriter(out io.Writer) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if out != nil {
+		w.w = out
+	}
+}
+
+func (w *lockedWriter) Writer() io.Writer {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.w
+}
+
+func (w *lockedWriter) SetRefreshPrompt(refresh func()) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.refreshPrompt = refresh
+}
+
+func (w *lockedWriter) StartTyping() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.typingVisible {
+		return
+	}
+	w.clearPromptLineLocked()
+	fmt.Fprintln(w.w, "[typing]")
+	w.typingVisible = true
+	w.refreshPromptLocked()
+}
+
+func (w *lockedWriter) StopTyping() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.typingVisible {
+		w.clearTypingLineLocked()
+	}
+	w.refreshPromptLocked()
+}
+
+func (w *lockedWriter) prepareAsyncOutputLocked() {
+	w.clearPromptLineLocked()
+	if w.typingVisible {
+		w.clearTypingLineLocked()
+	}
+}
+
+func (w *lockedWriter) clearPromptLineLocked() {
+	if w.refreshPrompt == nil {
+		return
+	}
+	fmt.Fprint(w.w, "\r\033[2K")
+}
+
+func (w *lockedWriter) clearTypingLineLocked() {
+	if !w.typingVisible {
+		return
+	}
+	if w.refreshPrompt != nil {
+		fmt.Fprint(w.w, "\r\033[2K\033[1A\r\033[2K\033[1M")
+	}
+	w.typingVisible = false
+}
+
+func (w *lockedWriter) refreshPromptLocked() {
+	if w.refreshPrompt != nil {
+		w.refreshPrompt()
+	}
+}
+
+func remoteAgentCmd(
+	parentCtx context.Context,
+	rawURL string,
+	token string,
+	message string,
+	sessionID string,
+	in io.Reader,
+	out io.Writer,
+) error {
+	if sessionID == "" {
+		sessionID = defaultRemoteSessionID
+	}
+	if token == "" {
+		token = os.Getenv("PICO_TOKEN")
+	}
+	if in == nil {
+		in = os.Stdin
+	}
+	if out == nil {
+		out = os.Stdout
+	}
+
+	signalCtx, stopSignals := signal.NotifyContext(parentCtx, os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+	ctx, cancel := context.WithCancel(signalCtx)
+	defer cancel()
+
+	client, err := newRemoteClient(ctx, rawURL, token, sessionID, out)
+	if err != nil {
+		return err
+	}
+	defer client.Close(websocket.CloseNormalClosure)
+
+	go func() {
+		<-ctx.Done()
+		client.Close(websocket.CloseGoingAway)
+	}()
+
+	if message != "" {
+		return client.RunOneShot(ctx, sessionID, message)
+	}
+	return client.RunInteractive(ctx, sessionID, in)
+}
+
+func newRemoteClient(
+	ctx context.Context,
+	rawURL string,
+	token string,
+	sessionID string,
+	out io.Writer,
+) (*remoteClient, error) {
+	wsURL, err := remoteURLWithSession(rawURL, sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsURL, remoteAuthHeader(token))
+	if err != nil {
+		return nil, remoteDialError(err, resp)
+	}
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+
+	return &remoteClient{
+		conn: conn,
+		out:  &lockedWriter{w: out},
+	}, nil
+}
+
+func remoteDialError(err error, resp *http.Response) error {
+	if resp == nil {
+		return fmt.Errorf("connect remote pico websocket: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body := ""
+	if resp.Body != nil {
+		raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		if readErr == nil {
+			body = strings.TrimSpace(string(raw))
+		}
+	}
+	if body == "" || !remoteResponseBodyIsText(resp.Header.Get("Content-Type")) {
+		return fmt.Errorf("connect remote pico websocket: %w: HTTP %s", err, resp.Status)
+	}
+	return fmt.Errorf("connect remote pico websocket: %w: HTTP %s: %s", err, resp.Status, body)
+}
+
+func remoteResponseBodyIsText(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = strings.TrimSpace(strings.ToLower(contentType))
+	}
+	return mediaType == "" ||
+		strings.HasPrefix(mediaType, "text/") ||
+		mediaType == "application/json" ||
+		strings.HasSuffix(mediaType, "+json")
+}
+
+func (c *remoteClient) Close(code int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn == nil {
+		return
+	}
+	_ = c.conn.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(code, ""),
+		time.Now().Add(time.Second),
+	)
+	_ = c.conn.Close()
+	c.conn = nil
+}
+
+func (c *remoteClient) Send(sessionID, text string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn == nil {
+		return fmt.Errorf("remote connection is closed")
+	}
+	return c.conn.WriteJSON(buildRemoteMessageSend(sessionID, text))
+}
+
+func (c *remoteClient) RunOneShot(ctx context.Context, sessionID, message string) error {
+	events := make(chan remoteEventResult, 8)
+	go c.readLoop(ctx, events)
+
+	if err := c.Send(sessionID, message); err != nil {
+		return err
+	}
+
+	timer := time.NewTimer(remoteOneShotFirstTimeout)
+	defer timer.Stop()
+	seenResponse := false
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case evt, ok := <-events:
+			if !ok {
+				return nil
+			}
+			if evt.Err != nil {
+				if seenResponse || errors.Is(evt.Err, io.EOF) {
+					return nil
+				}
+				return evt.Err
+			}
+			if evt.Displayed {
+				seenResponse = true
+				resetTimer(timer, remoteOneShotIdleTimeout)
+			}
+		case <-timer.C:
+			if seenResponse {
+				return nil
+			}
+			return fmt.Errorf("timed out waiting for remote response")
+		}
+	}
+}
+
+func (c *remoteClient) RunInteractive(ctx context.Context, sessionID string, in io.Reader) error {
+	err := c.runReadlineInteractive(ctx, sessionID, in)
+	if errors.Is(err, errRemoteReadlineUnavailable) {
+		return c.runScannerInteractive(ctx, sessionID, in)
+	}
+	return err
+}
+
+func (c *remoteClient) runReadlineInteractive(ctx context.Context, sessionID string, in io.Reader) error {
+	prompt := fmt.Sprintf("%s You: ", internal.Logo)
+	baseOut := c.out.Writer()
+	rl, err := readline.NewEx(&readline.Config{
+		Prompt:          prompt,
+		HistoryFile:     filepath.Join(os.TempDir(), ".picoclaw_history"),
+		HistoryLimit:    100,
+		InterruptPrompt: "^C",
+		EOFPrompt:       "exit",
+		Stdin:           in,
+		Stdout:          baseOut,
+		Stderr:          baseOut,
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %v", errRemoteReadlineUnavailable, err)
+	}
+	defer rl.Close()
+	defer c.out.SetWriter(baseOut)
+	defer c.out.SetRefreshPrompt(nil)
+	c.out.SetWriter(baseOut)
+
+	c.out.Printf("%s Remote mode (Ctrl+C to exit)\n", internal.Logo)
+	c.out.Printf("Connected to remote Pico session %s\n\n", sessionID)
+	c.out.SetRefreshPrompt(rl.Refresh)
+
+	go func() {
+		<-ctx.Done()
+		_ = rl.Close()
+	}()
+
+	events := make(chan remoteEventResult, 8)
+	go c.readLoop(ctx, events)
+
+	inputs := make(chan remoteInputResult, 1)
+	go readRemoteLines(rl, inputs)
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.out.Printf("\nGoodbye!\n")
+			return nil
+		case evt, ok := <-events:
+			if !ok {
+				return nil
+			}
+			if evt.Err != nil {
+				return evt.Err
+			}
+		case input, ok := <-inputs:
+			if !ok {
+				return nil
+			}
+			if input.Err != nil {
+				if input.Err == readline.ErrInterrupt || errors.Is(input.Err, io.EOF) {
+					c.out.Printf("\nGoodbye!\n")
+					return nil
+				}
+				return input.Err
+			}
+			text := strings.TrimSpace(input.Line)
+			if text == "" {
+				continue
+			}
+			if text == "exit" || text == "quit" {
+				c.out.Printf("Goodbye!\n")
+				return nil
+			}
+			if err := c.Send(sessionID, text); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (c *remoteClient) runScannerInteractive(ctx context.Context, sessionID string, in io.Reader) error {
+	events := make(chan remoteEventResult, 8)
+	go c.readLoop(ctx, events)
+
+	lines := make(chan string)
+	readErrs := make(chan error, 1)
+	go scanInput(in, lines, readErrs)
+
+	prompt := fmt.Sprintf("%s You: ", internal.Logo)
+	c.out.Printf("%s Remote mode (Ctrl+C to exit)\n", internal.Logo)
+	c.out.Printf("Connected to remote Pico session %s\n\n", sessionID)
+	c.out.Printf("%s", prompt)
+	for {
+		select {
+		case <-ctx.Done():
+			c.out.Printf("\nGoodbye!\n")
+			return nil
+		case evt, ok := <-events:
+			if !ok {
+				return nil
+			}
+			if evt.Err != nil {
+				return evt.Err
+			}
+		case err := <-readErrs:
+			if err == nil {
+				return nil
+			}
+			return err
+		case line, ok := <-lines:
+			if !ok {
+				return nil
+			}
+			input := strings.TrimSpace(line)
+			if input == "" {
+				c.out.Printf("%s", prompt)
+				continue
+			}
+			if input == "exit" || input == "quit" {
+				c.out.Printf("Goodbye!\n")
+				return nil
+			}
+			if err := c.Send(sessionID, input); err != nil {
+				return err
+			}
+			c.out.Printf("%s", prompt)
+		}
+	}
+}
+
+func readRemoteLines(rl *readline.Instance, inputs chan<- remoteInputResult) {
+	defer close(inputs)
+	for {
+		line, err := rl.Readline()
+		inputs <- remoteInputResult{Line: line, Err: err}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (c *remoteClient) readLoop(ctx context.Context, events chan<- remoteEventResult) {
+	defer close(events)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		c.mu.Lock()
+		conn := c.conn
+		c.mu.Unlock()
+		if conn == nil {
+			return
+		}
+
+		var msg pico.PicoMessage
+		if err := conn.ReadJSON(&msg); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			events <- remoteEventResult{Err: err}
+			return
+		}
+		events <- remoteEventResult{Displayed: renderRemoteEvent(c.out, msg)}
+	}
+}
+
+func scanInput(in io.Reader, lines chan<- string, errs chan<- error) {
+	defer close(lines)
+
+	scanner := bufio.NewScanner(in)
+	for scanner.Scan() {
+		lines <- scanner.Text()
+	}
+	errs <- scanner.Err()
+}
+
+func resetTimer(timer *time.Timer, duration time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(duration)
+}
+
+func remoteURLWithSession(rawURL, sessionID string) (string, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	sessionID = strings.TrimSpace(sessionID)
+	if rawURL == "" {
+		return "", fmt.Errorf("remote URL is required")
+	}
+	if sessionID == "" {
+		return "", fmt.Errorf("session ID is required")
+	}
+	if !strings.Contains(rawURL, "://") && !strings.HasPrefix(rawURL, "//") {
+		rawURL = "ws://" + rawURL
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse remote URL: %w", err)
+	}
+	switch u.Scheme {
+	case "":
+		u.Scheme = "ws"
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	case "ws", "wss":
+	default:
+		return "", fmt.Errorf("unsupported remote URL scheme %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("remote URL must include a host")
+	}
+
+	q := u.Query()
+	q.Set("session_id", sessionID)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func remoteAuthHeader(token string) http.Header {
+	header := http.Header{}
+	token = strings.TrimSpace(token)
+	if token != "" {
+		header.Set("Authorization", "Bearer "+token)
+	}
+	return header
+}
+
+func buildRemoteMessageSend(sessionID, text string) pico.PicoMessage {
+	return pico.PicoMessage{
+		Type:      pico.TypeMessageSend,
+		ID:        uuid.NewString(),
+		SessionID: sessionID,
+		Timestamp: time.Now().UnixMilli(),
+		Payload: map[string]any{
+			pico.PayloadKeyContent:    text,
+			pico.PayloadKeyClientKind: pico.ClientKindRemoteCLI,
+			pico.PayloadKeyClientName: "picoclaw agent --remote",
+			pico.PayloadKeyTransport:  pico.TransportWebSocket,
+			"sender_id":               "picoclaw-cli",
+			"sender_name":             "PicoClaw CLI",
+		},
+	}
+}
+
+func renderRemoteEvent(out interface{ Printf(string, ...any) }, msg pico.PicoMessage) bool {
+	switch msg.Type {
+	case pico.TypeMessageCreate, pico.TypeMessageUpdate:
+		return renderRemoteText(out, msg.Payload)
+	case pico.TypeMessageDelete:
+		messageID := payloadString(msg.Payload, "message_id")
+		if messageID == "" {
+			messageID = msg.ID
+		}
+		out.Printf("[message deleted: %s]\n", messageID)
+		return true
+	case pico.TypeTypingStart:
+		startRemoteTyping(out)
+		return false
+	case pico.TypeTypingStop:
+		stopRemoteTyping(out)
+		return false
+	case pico.TypeMediaCreate:
+		displayed := renderRemoteText(out, msg.Payload)
+		for _, media := range remoteMediaStrings(msg.Payload) {
+			out.Printf("[media] %s\n", media)
+			displayed = true
+		}
+		return displayed
+	case pico.TypeError:
+		code := payloadString(msg.Payload, "code")
+		message := payloadString(msg.Payload, "message")
+		switch {
+		case code != "" && message != "":
+			out.Printf("error[%s]: %s\n", code, message)
+		case message != "":
+			out.Printf("error: %s\n", message)
+		default:
+			out.Printf("error: %s\n", payloadJSON(msg.Payload))
+		}
+		return true
+	case pico.TypePong:
+		out.Printf("[pong]\n")
+		return false
+	default:
+		out.Printf("[event %s] %s\n", msg.Type, payloadJSON(msg.Payload))
+		return false
+	}
+}
+
+func startRemoteTyping(out interface{ Printf(string, ...any) }) {
+	if typingOut, ok := out.(interface{ StartTyping() }); ok {
+		typingOut.StartTyping()
+		return
+	}
+	out.Printf("[typing]\n")
+}
+
+func stopRemoteTyping(out interface{ Printf(string, ...any) }) {
+	if typingOut, ok := out.(interface{ StopTyping() }); ok {
+		typingOut.StopTyping()
+	}
+}
+
+func renderRemoteText(out interface{ Printf(string, ...any) }, payload map[string]any) bool {
+	if isRemoteThoughtPayload(payload) {
+		return false
+	}
+	content := strings.TrimSpace(payloadString(payload, pico.PayloadKeyContent))
+	if content == "" {
+		return false
+	}
+	out.Printf("%s\n", content)
+	return true
+}
+
+func isRemoteThoughtPayload(payload map[string]any) bool {
+	kind, _ := payload[pico.PayloadKeyKind].(string)
+	if strings.EqualFold(strings.TrimSpace(kind), pico.MessageKindThought) {
+		return true
+	}
+	thought, _ := payload[pico.PayloadKeyThought].(bool)
+	return thought
+}
+
+func payloadString(payload map[string]any, key string) string {
+	if payload == nil {
+		return ""
+	}
+	switch value := payload[key].(type) {
+	case string:
+		return value
+	case fmt.Stringer:
+		return value.String()
+	default:
+		return ""
+	}
+}
+
+func payloadJSON(payload map[string]any) string {
+	if len(payload) == 0 {
+		return "{}"
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "{}"
+	}
+	return string(raw)
+}
+
+func remoteMediaStrings(payload map[string]any) []string {
+	var media []string
+	appendString := func(value any) {
+		if s, ok := value.(string); ok && strings.TrimSpace(s) != "" {
+			media = append(media, s)
+		}
+	}
+
+	switch values := payload["media"].(type) {
+	case []any:
+		for _, value := range values {
+			appendString(value)
+		}
+	case []string:
+		for _, value := range values {
+			appendString(value)
+		}
+	case string:
+		appendString(values)
+	}
+
+	if attachments, ok := payload["attachments"].([]any); ok {
+		for _, raw := range attachments {
+			attachment, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			appendString(attachment["url"])
+		}
+	}
+
+	return media
+}

--- a/cmd/picoclaw/internal/agent/remote.go
+++ b/cmd/picoclaw/internal/agent/remote.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	defaultRemoteSessionID    = "cli:default"
-	remoteOneShotFirstTimeout = 30 * time.Second
-	remoteOneShotIdleTimeout  = 1500 * time.Millisecond
+	remoteGeneratedSessionPrefix = "cli:"
+	remoteOneShotFirstTimeout    = 30 * time.Second
+	remoteOneShotIdleTimeout     = 1500 * time.Millisecond
 )
 
 var errRemoteReadlineUnavailable = errors.New("remote readline unavailable")
@@ -146,7 +146,7 @@ func remoteAgentCmd(
 	out io.Writer,
 ) error {
 	if sessionID == "" {
-		sessionID = defaultRemoteSessionID
+		sessionID = newRemoteSessionID()
 	}
 	if token == "" {
 		token = os.Getenv("PICO_TOKEN")
@@ -178,6 +178,10 @@ func remoteAgentCmd(
 		return client.RunOneShot(ctx, sessionID, message)
 	}
 	return client.RunInteractive(ctx, sessionID, in)
+}
+
+func newRemoteSessionID() string {
+	return remoteGeneratedSessionPrefix + uuid.NewString()
 }
 
 func newRemoteClient(

--- a/cmd/picoclaw/internal/agent/remote.go
+++ b/cmd/picoclaw/internal/agent/remote.go
@@ -50,6 +50,10 @@ type remoteInputResult struct {
 	Err  error
 }
 
+type remotePrinter interface {
+	Printf(format string, args ...any)
+}
+
 type lockedWriter struct {
 	mu            sync.Mutex
 	w             io.Writer
@@ -559,7 +563,7 @@ func buildRemoteMessageSend(sessionID, text string) pico.PicoMessage {
 	}
 }
 
-func renderRemoteEvent(out interface{ Printf(string, ...any) }, msg pico.PicoMessage) bool {
+func renderRemoteEvent(out remotePrinter, msg pico.PicoMessage) bool {
 	switch msg.Type {
 	case pico.TypeMessageCreate, pico.TypeMessageUpdate:
 		return renderRemoteText(out, msg.Payload)
@@ -604,7 +608,7 @@ func renderRemoteEvent(out interface{ Printf(string, ...any) }, msg pico.PicoMes
 	}
 }
 
-func startRemoteTyping(out interface{ Printf(string, ...any) }) {
+func startRemoteTyping(out remotePrinter) {
 	if typingOut, ok := out.(interface{ StartTyping() }); ok {
 		typingOut.StartTyping()
 		return
@@ -612,13 +616,13 @@ func startRemoteTyping(out interface{ Printf(string, ...any) }) {
 	out.Printf("[typing]\n")
 }
 
-func stopRemoteTyping(out interface{ Printf(string, ...any) }) {
+func stopRemoteTyping(out remotePrinter) {
 	if typingOut, ok := out.(interface{ StopTyping() }); ok {
 		typingOut.StopTyping()
 	}
 }
 
-func renderRemoteText(out interface{ Printf(string, ...any) }, payload map[string]any) bool {
+func renderRemoteText(out remotePrinter, payload map[string]any) bool {
 	if isRemoteThoughtPayload(payload) {
 		return false
 	}

--- a/cmd/picoclaw/internal/agent/remote.go
+++ b/cmd/picoclaw/internal/agent/remote.go
@@ -28,7 +28,7 @@ import (
 const (
 	remoteGeneratedSessionPrefix = "cli:"
 	remoteOneShotFirstTimeout    = 30 * time.Second
-	remoteOneShotIdleTimeout     = 1500 * time.Millisecond
+	remoteOneShotIdleTimeout     = 5 * time.Second
 )
 
 type remoteClient struct {

--- a/cmd/picoclaw/internal/agent/remote.go
+++ b/cmd/picoclaw/internal/agent/remote.go
@@ -35,9 +35,11 @@ const (
 var errRemoteReadlineUnavailable = errors.New("remote readline unavailable")
 
 type remoteClient struct {
-	conn *websocket.Conn
-	out  *lockedWriter
-	mu   sync.Mutex
+	conn      *websocket.Conn
+	out       *lockedWriter
+	writeMu   sync.Mutex
+	closeOnce sync.Once
+	closed    chan struct{}
 }
 
 type remoteEventResult struct {
@@ -209,8 +211,9 @@ func newRemoteClient(
 	}
 
 	return &remoteClient{
-		conn: conn,
-		out:  &lockedWriter{w: out},
+		conn:   conn,
+		out:    &lockedWriter{w: out},
+		closed: make(chan struct{}),
 	}, nil
 }
 
@@ -245,27 +248,37 @@ func remoteResponseBodyIsText(contentType string) bool {
 }
 
 func (c *remoteClient) Close(code int) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.conn == nil {
-		return
-	}
-	_ = c.conn.WriteControl(
-		websocket.CloseMessage,
-		websocket.FormatCloseMessage(code, ""),
-		time.Now().Add(time.Second),
-	)
-	_ = c.conn.Close()
-	c.conn = nil
+	c.closeOnce.Do(func() {
+		close(c.closed)
+		_ = c.conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(code, ""),
+			time.Now().Add(time.Second),
+		)
+		_ = c.conn.Close()
+	})
 }
 
 func (c *remoteClient) Send(sessionID, text string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.conn == nil {
+	if c.isClosed() {
+		return fmt.Errorf("remote connection is closed")
+	}
+
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if c.isClosed() {
 		return fmt.Errorf("remote connection is closed")
 	}
 	return c.conn.WriteJSON(buildRemoteMessageSend(sessionID, text))
+}
+
+func (c *remoteClient) isClosed() bool {
+	select {
+	case <-c.closed:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *remoteClient) RunOneShot(ctx context.Context, sessionID, message string) error {
@@ -457,25 +470,31 @@ func (c *remoteClient) readLoop(ctx context.Context, events chan<- remoteEventRe
 		select {
 		case <-ctx.Done():
 			return
+		case <-c.closed:
+			return
 		default:
 		}
 
-		c.mu.Lock()
-		conn := c.conn
-		c.mu.Unlock()
-		if conn == nil {
-			return
-		}
-
 		var msg pico.PicoMessage
-		if err := conn.ReadJSON(&msg); err != nil {
-			if ctx.Err() != nil {
+		if err := c.conn.ReadJSON(&msg); err != nil {
+			if ctx.Err() != nil || c.isClosed() {
 				return
 			}
-			events <- remoteEventResult{Err: err}
+			select {
+			case events <- remoteEventResult{Err: err}:
+			case <-ctx.Done():
+			case <-c.closed:
+			}
 			return
 		}
-		events <- remoteEventResult{Displayed: renderRemoteEvent(c.out, msg)}
+		displayed := renderRemoteEvent(c.out, msg)
+		select {
+		case events <- remoteEventResult{Displayed: displayed}:
+		case <-ctx.Done():
+			return
+		case <-c.closed:
+			return
+		}
 	}
 }
 

--- a/cmd/picoclaw/internal/agent/remote.go
+++ b/cmd/picoclaw/internal/agent/remote.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -31,8 +30,6 @@ const (
 	remoteOneShotFirstTimeout    = 30 * time.Second
 	remoteOneShotIdleTimeout     = 1500 * time.Millisecond
 )
-
-var errRemoteReadlineUnavailable = errors.New("remote readline unavailable")
 
 type remoteClient struct {
 	conn      *websocket.Conn
@@ -321,14 +318,6 @@ func (c *remoteClient) RunOneShot(ctx context.Context, sessionID, message string
 }
 
 func (c *remoteClient) RunInteractive(ctx context.Context, sessionID string, in io.Reader) error {
-	err := c.runReadlineInteractive(ctx, sessionID, in)
-	if errors.Is(err, errRemoteReadlineUnavailable) {
-		return c.runScannerInteractive(ctx, sessionID, in)
-	}
-	return err
-}
-
-func (c *remoteClient) runReadlineInteractive(ctx context.Context, sessionID string, in io.Reader) error {
 	prompt := fmt.Sprintf("%s You: ", internal.Logo)
 	baseOut := c.out.Writer()
 	rl, err := readline.NewEx(&readline.Config{
@@ -342,7 +331,7 @@ func (c *remoteClient) runReadlineInteractive(ctx context.Context, sessionID str
 		Stderr:          baseOut,
 	})
 	if err != nil {
-		return fmt.Errorf("%w: %v", errRemoteReadlineUnavailable, err)
+		return fmt.Errorf("remote interactive mode requires readline input; use -m for one-shot mode: %w", err)
 	}
 	defer rl.Close()
 	defer c.out.SetWriter(baseOut)
@@ -402,56 +391,6 @@ func (c *remoteClient) runReadlineInteractive(ctx context.Context, sessionID str
 	}
 }
 
-func (c *remoteClient) runScannerInteractive(ctx context.Context, sessionID string, in io.Reader) error {
-	events := make(chan remoteEventResult, 8)
-	go c.readLoop(ctx, events)
-
-	lines := make(chan string)
-	readErrs := make(chan error, 1)
-	go scanInput(in, lines, readErrs)
-
-	prompt := fmt.Sprintf("%s You: ", internal.Logo)
-	c.out.Printf("%s Remote mode (Ctrl+C to exit)\n", internal.Logo)
-	c.out.Printf("Connected to remote Pico session %s\n\n", sessionID)
-	c.out.Printf("%s", prompt)
-	for {
-		select {
-		case <-ctx.Done():
-			c.out.Printf("\nGoodbye!\n")
-			return nil
-		case evt, ok := <-events:
-			if !ok {
-				return nil
-			}
-			if evt.Err != nil {
-				return evt.Err
-			}
-		case err := <-readErrs:
-			if err == nil {
-				return nil
-			}
-			return err
-		case line, ok := <-lines:
-			if !ok {
-				return nil
-			}
-			input := strings.TrimSpace(line)
-			if input == "" {
-				c.out.Printf("%s", prompt)
-				continue
-			}
-			if input == "exit" || input == "quit" {
-				c.out.Printf("Goodbye!\n")
-				return nil
-			}
-			if err := c.Send(sessionID, input); err != nil {
-				return err
-			}
-			c.out.Printf("%s", prompt)
-		}
-	}
-}
-
 func readRemoteLines(rl *readline.Instance, inputs chan<- remoteInputResult) {
 	defer close(inputs)
 	for {
@@ -496,16 +435,6 @@ func (c *remoteClient) readLoop(ctx context.Context, events chan<- remoteEventRe
 			return
 		}
 	}
-}
-
-func scanInput(in io.Reader, lines chan<- string, errs chan<- error) {
-	defer close(lines)
-
-	scanner := bufio.NewScanner(in)
-	for scanner.Scan() {
-		lines <- scanner.Text()
-	}
-	errs <- scanner.Err()
 }
 
 func resetTimer(timer *time.Timer, duration time.Duration) {

--- a/cmd/picoclaw/internal/agent/remote.go
+++ b/cmd/picoclaw/internal/agent/remote.go
@@ -28,7 +28,7 @@ import (
 const (
 	remoteGeneratedSessionPrefix = "cli:"
 	remoteOneShotFirstTimeout    = 30 * time.Second
-	remoteOneShotIdleTimeout     = 5 * time.Second
+	remoteOneShotIdleTimeout     = 30 * time.Second
 )
 
 type remoteClient struct {
@@ -41,6 +41,8 @@ type remoteClient struct {
 
 type remoteEventResult struct {
 	Displayed bool
+	Activity  bool
+	RemoteErr error
 	Err       error
 }
 
@@ -306,9 +308,18 @@ func (c *remoteClient) RunOneShot(ctx context.Context, sessionID, message string
 				}
 				return evt.Err
 			}
+			if evt.RemoteErr != nil {
+				return evt.RemoteErr
+			}
 			if evt.Displayed {
 				seenResponse = true
-				resetTimer(timer, remoteOneShotIdleTimeout)
+			}
+			if evt.Activity {
+				if seenResponse {
+					resetTimer(timer, remoteOneShotIdleTimeout)
+				} else {
+					resetTimer(timer, remoteOneShotFirstTimeout)
+				}
 			}
 		case <-timer.C:
 			if seenResponse {
@@ -430,7 +441,7 @@ func (c *remoteClient) readLoop(ctx context.Context, events chan<- remoteEventRe
 		}
 		displayed := renderRemoteEvent(c.out, msg)
 		select {
-		case events <- remoteEventResult{Displayed: displayed}:
+		case events <- remoteEventResult{Displayed: displayed, Activity: true, RemoteErr: remoteErrorFromMessage(msg)}:
 		case <-ctx.Done():
 			return
 		case <-c.closed:
@@ -553,6 +564,22 @@ func renderRemoteEvent(out remotePrinter, msg pico.PicoMessage) bool {
 	default:
 		out.Printf("[event %s] %s\n", msg.Type, payloadJSON(msg.Payload))
 		return false
+	}
+}
+
+func remoteErrorFromMessage(msg pico.PicoMessage) error {
+	if msg.Type != pico.TypeError {
+		return nil
+	}
+	code := payloadString(msg.Payload, "code")
+	message := payloadString(msg.Payload, "message")
+	switch {
+	case code != "" && message != "":
+		return fmt.Errorf("remote error[%s]: %s", code, message)
+	case message != "":
+		return fmt.Errorf("remote error: %s", message)
+	default:
+		return fmt.Errorf("remote error: %s", payloadJSON(msg.Payload))
 	}
 }
 

--- a/cmd/picoclaw/internal/agent/remote.go
+++ b/cmd/picoclaw/internal/agent/remote.go
@@ -505,8 +505,6 @@ func buildRemoteMessageSend(sessionID, text string) pico.PicoMessage {
 			pico.PayloadKeyClientKind: pico.ClientKindRemoteCLI,
 			pico.PayloadKeyClientName: "picoclaw agent --remote",
 			pico.PayloadKeyTransport:  pico.TransportWebSocket,
-			"sender_id":               "picoclaw-cli",
-			"sender_name":             "PicoClaw CLI",
 		},
 	}
 }

--- a/cmd/picoclaw/internal/agent/remote.go
+++ b/cmd/picoclaw/internal/agent/remote.go
@@ -128,6 +128,8 @@ func (w *lockedWriter) clearTypingLineLocked() {
 		return
 	}
 	if w.refreshPrompt != nil {
+		// Delete the transient "[typing]" line before redrawing the prompt.
+		// Terminals without Delete Line support may leave a harmless blank row.
 		fmt.Fprint(w.w, "\r\033[2K\033[1A\r\033[2K\033[1M")
 	}
 	w.typingVisible = false

--- a/cmd/picoclaw/internal/agent/remote_test.go
+++ b/cmd/picoclaw/internal/agent/remote_test.go
@@ -456,3 +456,72 @@ func TestRemoteCommandExecutesRemoteMode(t *testing.T) {
 		t.Fatalf("output = %q, want ok", out.String())
 	}
 }
+
+func TestRemoteCommandGeneratesSessionWhenOmitted(t *testing.T) {
+	gotSession := make(chan string, 1)
+	gotMessage := make(chan pico.PicoMessage, 1)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSession <- r.URL.Query().Get("session_id")
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("Upgrade() error = %v", err)
+			return
+		}
+		defer conn.Close()
+
+		var msg pico.PicoMessage
+		if err := conn.ReadJSON(&msg); err != nil {
+			t.Errorf("ReadJSON() error = %v", err)
+			return
+		}
+		gotMessage <- msg
+		_ = conn.WriteJSON(pico.PicoMessage{
+			Type:      pico.TypeMessageCreate,
+			SessionID: msg.SessionID,
+			Payload:   map[string]any{pico.PayloadKeyContent: "ok"},
+		})
+	}))
+	defer srv.Close()
+
+	cmd := NewAgentCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetArgs([]string{
+		"--remote", "ws" + strings.TrimPrefix(srv.URL, "http") + "/pico/ws",
+		"--message", "hello",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+
+	var connectedSession string
+	select {
+	case connectedSession = <-gotSession:
+	default:
+		t.Fatal("server did not receive generated session_id")
+	}
+	if connectedSession == "" {
+		t.Fatal("generated session_id is empty")
+	}
+	if connectedSession == "cli:default" {
+		t.Fatal("remote command used local default session cli:default")
+	}
+	if !strings.HasPrefix(connectedSession, remoteGeneratedSessionPrefix) {
+		t.Fatalf("generated session_id = %q, want %s prefix", connectedSession, remoteGeneratedSessionPrefix)
+	}
+
+	select {
+	case msg := <-gotMessage:
+		if msg.SessionID != connectedSession {
+			t.Fatalf("message session_id = %q, want %q", msg.SessionID, connectedSession)
+		}
+	default:
+		t.Fatal("server did not receive command message")
+	}
+}

--- a/cmd/picoclaw/internal/agent/remote_test.go
+++ b/cmd/picoclaw/internal/agent/remote_test.go
@@ -1,0 +1,458 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/sipeed/picoclaw/pkg/channels/pico"
+)
+
+type testPrinter struct {
+	bytes.Buffer
+}
+
+func (p *testPrinter) Printf(format string, args ...any) {
+	_, _ = fmt.Fprintf(&p.Buffer, format, args...)
+}
+
+func TestRemoteURLWithSession(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		session string
+		want    map[string]string
+	}{
+		{
+			name:    "adds session query",
+			rawURL:  "ws://localhost:18790/pico/ws",
+			session: "abc",
+			want:    map[string]string{"scheme": "ws", "session_id": "abc"},
+		},
+		{
+			name:    "preserves query params",
+			rawURL:  "wss://example.test/pico/ws?foo=bar",
+			session: "abc",
+			want:    map[string]string{"scheme": "wss", "session_id": "abc", "foo": "bar"},
+		},
+		{
+			name:    "replaces stale session",
+			rawURL:  "ws://example.test/pico/ws?session_id=old&foo=bar",
+			session: "new",
+			want:    map[string]string{"scheme": "ws", "session_id": "new", "foo": "bar"},
+		},
+		{
+			name:    "converts http to ws",
+			rawURL:  "http://example.test/pico/ws",
+			session: "abc",
+			want:    map[string]string{"scheme": "ws", "session_id": "abc"},
+		},
+		{
+			name:    "adds missing scheme",
+			rawURL:  "localhost:18790/pico/ws",
+			session: "abc",
+			want:    map[string]string{"scheme": "ws", "session_id": "abc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := remoteURLWithSession(tt.rawURL, tt.session)
+			if err != nil {
+				t.Fatalf("remoteURLWithSession() error = %v", err)
+			}
+			u, err := url.Parse(got)
+			if err != nil {
+				t.Fatalf("url.Parse(%q) error = %v", got, err)
+			}
+			if gotScheme := u.Scheme; gotScheme != tt.want["scheme"] {
+				t.Fatalf("scheme = %q, want %q", gotScheme, tt.want["scheme"])
+			}
+			for key, want := range tt.want {
+				if key == "scheme" {
+					continue
+				}
+				if got := u.Query().Get(key); got != want {
+					t.Fatalf("query %s = %q, want %q in %q", key, got, want, u.String())
+				}
+			}
+		})
+	}
+}
+
+func TestRemoteAuthHeader(t *testing.T) {
+	if got := remoteAuthHeader("").Get("Authorization"); got != "" {
+		t.Fatalf("empty token Authorization = %q, want empty", got)
+	}
+	if got := remoteAuthHeader("secret").Get("Authorization"); got != "Bearer secret" {
+		t.Fatalf("token Authorization = %q, want Bearer secret", got)
+	}
+}
+
+func TestBuildRemoteMessageSend(t *testing.T) {
+	msg := buildRemoteMessageSend("sess-1", "hello")
+	if msg.Type != pico.TypeMessageSend {
+		t.Fatalf("Type = %q, want %q", msg.Type, pico.TypeMessageSend)
+	}
+	if msg.SessionID != "sess-1" {
+		t.Fatalf("SessionID = %q, want sess-1", msg.SessionID)
+	}
+	if got := msg.Payload[pico.PayloadKeyContent]; got != "hello" {
+		t.Fatalf("content = %#v, want hello", got)
+	}
+	if got := msg.Payload[pico.PayloadKeyClientKind]; got != pico.ClientKindRemoteCLI {
+		t.Fatalf("client_kind = %#v, want %s", got, pico.ClientKindRemoteCLI)
+	}
+	if got := msg.Payload[pico.PayloadKeyClientName]; got != "picoclaw agent --remote" {
+		t.Fatalf("client_name = %#v, want picoclaw agent --remote", got)
+	}
+	if got := msg.Payload[pico.PayloadKeyTransport]; got != pico.TransportWebSocket {
+		t.Fatalf("transport = %#v, want %s", got, pico.TransportWebSocket)
+	}
+	if msg.ID == "" {
+		t.Fatal("ID is empty")
+	}
+	if msg.Timestamp == 0 {
+		t.Fatal("Timestamp is empty")
+	}
+}
+
+func TestRenderRemoteEvent(t *testing.T) {
+	tests := []struct {
+		name       string
+		msg        pico.PicoMessage
+		want       string
+		displayed  bool
+		allowEmpty bool
+	}{
+		{
+			name: "message create",
+			msg: pico.PicoMessage{
+				Type:    pico.TypeMessageCreate,
+				Payload: map[string]any{pico.PayloadKeyContent: "hello"},
+			},
+			want:      "hello",
+			displayed: true,
+		},
+		{
+			name: "message update",
+			msg: pico.PicoMessage{
+				Type:    pico.TypeMessageUpdate,
+				Payload: map[string]any{pico.PayloadKeyContent: "updated"},
+			},
+			want:      "updated",
+			displayed: true,
+		},
+		{
+			name: "typing start",
+			msg:  pico.PicoMessage{Type: pico.TypeTypingStart},
+			want: "[typing]",
+		},
+		{
+			name:       "typing stop",
+			msg:        pico.PicoMessage{Type: pico.TypeTypingStop},
+			allowEmpty: true,
+		},
+		{
+			name: "message delete",
+			msg: pico.PicoMessage{
+				Type:    pico.TypeMessageDelete,
+				Payload: map[string]any{"message_id": "msg-1"},
+			},
+			want:      "[message deleted: msg-1]",
+			displayed: true,
+		},
+		{
+			name: "media create",
+			msg: pico.PicoMessage{
+				Type: pico.TypeMediaCreate,
+				Payload: map[string]any{
+					pico.PayloadKeyContent: "media text",
+					"media":                []any{"data:image/png;base64,abc"},
+				},
+			},
+			want:      "[media] data:image/png;base64,abc",
+			displayed: true,
+		},
+		{
+			name: "error",
+			msg: pico.PicoMessage{
+				Type:    pico.TypeError,
+				Payload: map[string]any{"code": "bad", "message": "failed"},
+			},
+			want:      "error[bad]: failed",
+			displayed: true,
+		},
+		{
+			name: "pong",
+			msg:  pico.PicoMessage{Type: pico.TypePong},
+			want: "[pong]",
+		},
+		{
+			name: "unknown",
+			msg: pico.PicoMessage{
+				Type:    "custom.event",
+				Payload: map[string]any{"value": "ok"},
+			},
+			want: "[event custom.event]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out testPrinter
+			displayed := renderRemoteEvent(&out, tt.msg)
+			if displayed != tt.displayed {
+				t.Fatalf("displayed = %v, want %v", displayed, tt.displayed)
+			}
+			if tt.allowEmpty && out.String() == "" {
+				return
+			}
+			if !strings.Contains(out.String(), tt.want) {
+				t.Fatalf("output = %q, want to contain %q", out.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoteTypingLineClears(t *testing.T) {
+	var out bytes.Buffer
+	writer := &lockedWriter{w: &out}
+	refreshes := 0
+	writer.SetRefreshPrompt(func() { refreshes++ })
+
+	renderRemoteEvent(writer, pico.PicoMessage{Type: pico.TypeTypingStart})
+	renderRemoteEvent(writer, pico.PicoMessage{Type: pico.TypeTypingStop})
+
+	got := out.String()
+	if !strings.Contains(got, "[typing]\n") {
+		t.Fatalf("output = %q, want typing line", got)
+	}
+	if !strings.Contains(got, "\033[1A\r\033[2K\033[1M") {
+		t.Fatalf("output = %q, want typing clear sequence", got)
+	}
+	if strings.Contains(got, "[typing stopped]") {
+		t.Fatalf("output = %q, should not contain typing stopped line", got)
+	}
+	if refreshes != 2 {
+		t.Fatalf("refreshes = %d, want 2", refreshes)
+	}
+}
+
+func TestRemoteOneShotWebSocket(t *testing.T) {
+	const sessionID = "test-session"
+	const token = "test-token"
+
+	gotSession := make(chan string, 1)
+	gotMessage := make(chan pico.PicoMessage, 1)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/pico/ws" {
+			t.Errorf("path = %q, want /pico/ws", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Errorf("Authorization = %q, want Bearer %s", got, token)
+		}
+		gotSession <- r.URL.Query().Get("session_id")
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("Upgrade() error = %v", err)
+			return
+		}
+		defer conn.Close()
+
+		var msg pico.PicoMessage
+		if err := conn.ReadJSON(&msg); err != nil {
+			t.Errorf("ReadJSON() error = %v", err)
+			return
+		}
+		gotMessage <- msg
+
+		reply := pico.PicoMessage{
+			Type:      pico.TypeMessageCreate,
+			SessionID: msg.SessionID,
+			Timestamp: time.Now().UnixMilli(),
+			Payload:   map[string]any{pico.PayloadKeyContent: "remote response"},
+		}
+		if err := conn.WriteJSON(reply); err != nil {
+			t.Errorf("WriteJSON() error = %v", err)
+			return
+		}
+		_ = conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			time.Now().Add(time.Second),
+		)
+	}))
+	defer srv.Close()
+
+	remoteURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/pico/ws?foo=bar"
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := remoteAgentCmd(ctx, remoteURL, token, "hello", sessionID, strings.NewReader(""), &out); err != nil {
+		t.Fatalf("remoteAgentCmd() error = %v", err)
+	}
+
+	select {
+	case got := <-gotSession:
+		if got != sessionID {
+			t.Fatalf("connected session_id = %q, want %q", got, sessionID)
+		}
+	default:
+		t.Fatal("server did not record connected session_id")
+	}
+
+	select {
+	case msg := <-gotMessage:
+		if msg.Type != pico.TypeMessageSend {
+			t.Fatalf("sent type = %q, want %q", msg.Type, pico.TypeMessageSend)
+		}
+		if msg.SessionID != sessionID {
+			t.Fatalf("sent session_id = %q, want %q", msg.SessionID, sessionID)
+		}
+		if got := msg.Payload[pico.PayloadKeyContent]; got != "hello" {
+			t.Fatalf("sent content = %#v, want hello", got)
+		}
+	default:
+		t.Fatal("server did not record sent message")
+	}
+
+	if !strings.Contains(out.String(), "remote response") {
+		t.Fatalf("output = %q, want remote response", out.String())
+	}
+}
+
+func TestRemoteOneShotUsesPicoTokenEnvFallback(t *testing.T) {
+	const sessionID = "env-session"
+	const token = "env-token"
+	t.Setenv("PICO_TOKEN", token)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Errorf("Authorization = %q, want Bearer %s", got, token)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("Upgrade() error = %v", err)
+			return
+		}
+		defer conn.Close()
+
+		var msg pico.PicoMessage
+		if err := conn.ReadJSON(&msg); err != nil {
+			t.Errorf("ReadJSON() error = %v", err)
+			return
+		}
+		_ = conn.WriteJSON(pico.PicoMessage{
+			Type:      pico.TypeMessageCreate,
+			SessionID: msg.SessionID,
+			Payload:   map[string]any{pico.PayloadKeyContent: "env ok"},
+		})
+	}))
+	defer srv.Close()
+
+	remoteURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/pico/ws"
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := remoteAgentCmd(ctx, remoteURL, "", "hello", sessionID, strings.NewReader(""), &out); err != nil {
+		t.Fatalf("remoteAgentCmd() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "env ok") {
+		t.Fatalf("output = %q, want env ok", out.String())
+	}
+}
+
+func TestRemoteOneShotReportsHandshakeStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	remoteURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/pico/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := remoteAgentCmd(ctx, remoteURL, "", "hello", "auth-session", strings.NewReader(""), &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("remoteAgentCmd() error = nil, want handshake error")
+	}
+	if got := err.Error(); !strings.Contains(got, "HTTP 401 Unauthorized") || !strings.Contains(got, "unauthorized") {
+		t.Fatalf("error = %q, want HTTP status and body", got)
+	}
+}
+
+func TestRemoteCommandExecutesRemoteMode(t *testing.T) {
+	const sessionID = "cmd-session"
+	gotMessage := make(chan pico.PicoMessage, 1)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("session_id"); got != sessionID {
+			t.Errorf("session_id = %q, want %q", got, sessionID)
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("Upgrade() error = %v", err)
+			return
+		}
+		defer conn.Close()
+
+		var msg pico.PicoMessage
+		if err := conn.ReadJSON(&msg); err != nil {
+			t.Errorf("ReadJSON() error = %v", err)
+			return
+		}
+		gotMessage <- msg
+		_ = conn.WriteJSON(pico.PicoMessage{
+			Type:      pico.TypeMessageCreate,
+			SessionID: msg.SessionID,
+			Payload:   map[string]any{pico.PayloadKeyContent: "ok"},
+		})
+	}))
+	defer srv.Close()
+
+	cmd := NewAgentCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetArgs([]string{
+		"--remote", "ws" + strings.TrimPrefix(srv.URL, "http") + "/pico/ws",
+		"--session", sessionID,
+		"--message", "hello",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+
+	select {
+	case msg := <-gotMessage:
+		if msg.Type != pico.TypeMessageSend {
+			t.Fatalf("type = %q, want %q", msg.Type, pico.TypeMessageSend)
+		}
+		if msg.SessionID != sessionID {
+			t.Fatalf("session_id = %q, want %q", msg.SessionID, sessionID)
+		}
+	default:
+		t.Fatal("server did not receive command message")
+	}
+	if !strings.Contains(out.String(), "ok") {
+		t.Fatalf("output = %q, want ok", out.String())
+	}
+}

--- a/cmd/picoclaw/internal/agent/remote_test.go
+++ b/cmd/picoclaw/internal/agent/remote_test.go
@@ -334,7 +334,7 @@ func TestRemoteOneShotWebSocket(t *testing.T) {
 	}
 }
 
-func TestRemoteOneShotWaitsThroughShortIdleGap(t *testing.T) {
+func TestRemoteOneShotWaitsThroughVisibleSilence(t *testing.T) {
 	const sessionID = "slow-session"
 
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
@@ -360,7 +360,7 @@ func TestRemoteOneShotWaitsThroughShortIdleGap(t *testing.T) {
 			return
 		}
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(6 * time.Second)
 		if err := conn.WriteJSON(pico.PicoMessage{
 			Type:      pico.TypeMessageCreate,
 			SessionID: msg.SessionID,
@@ -379,7 +379,7 @@ func TestRemoteOneShotWaitsThroughShortIdleGap(t *testing.T) {
 
 	remoteURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/pico/ws"
 	var out bytes.Buffer
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	if err := remoteAgentCmd(ctx, remoteURL, "", "hello", sessionID, strings.NewReader(""), &out); err != nil {
@@ -390,6 +390,53 @@ func TestRemoteOneShotWaitsThroughShortIdleGap(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "second chunk") {
 		t.Fatalf("output = %q, want second chunk", out.String())
+	}
+}
+
+func TestRemoteOneShotReturnsErrorForRemoteErrorEvent(t *testing.T) {
+	const sessionID = "error-session"
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("Upgrade() error = %v", err)
+			return
+		}
+		defer conn.Close()
+
+		var msg pico.PicoMessage
+		if err := conn.ReadJSON(&msg); err != nil {
+			t.Errorf("ReadJSON() error = %v", err)
+			return
+		}
+		if err := conn.WriteJSON(pico.PicoMessage{
+			Type:      pico.TypeError,
+			SessionID: msg.SessionID,
+			Payload: map[string]any{
+				"code":    "bad_request",
+				"message": "server rejected message",
+			},
+		}); err != nil {
+			t.Errorf("WriteJSON(error) error = %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	remoteURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/pico/ws"
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := remoteAgentCmd(ctx, remoteURL, "", "hello", sessionID, strings.NewReader(""), &out)
+	if err == nil {
+		t.Fatal("remoteAgentCmd() error = nil, want remote error")
+	}
+	if got := err.Error(); !strings.Contains(got, "remote error[bad_request]: server rejected message") {
+		t.Fatalf("error = %q, want remote error details", got)
+	}
+	if !strings.Contains(out.String(), "error[bad_request]: server rejected message") {
+		t.Fatalf("output = %q, want rendered remote error", out.String())
 	}
 }
 

--- a/cmd/picoclaw/internal/agent/remote_test.go
+++ b/cmd/picoclaw/internal/agent/remote_test.go
@@ -334,6 +334,65 @@ func TestRemoteOneShotWebSocket(t *testing.T) {
 	}
 }
 
+func TestRemoteOneShotWaitsThroughShortIdleGap(t *testing.T) {
+	const sessionID = "slow-session"
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("Upgrade() error = %v", err)
+			return
+		}
+		defer conn.Close()
+
+		var msg pico.PicoMessage
+		if err := conn.ReadJSON(&msg); err != nil {
+			t.Errorf("ReadJSON() error = %v", err)
+			return
+		}
+		if err := conn.WriteJSON(pico.PicoMessage{
+			Type:      pico.TypeMessageCreate,
+			SessionID: msg.SessionID,
+			Payload:   map[string]any{pico.PayloadKeyContent: "first chunk"},
+		}); err != nil {
+			t.Errorf("WriteJSON(first) error = %v", err)
+			return
+		}
+
+		time.Sleep(2 * time.Second)
+		if err := conn.WriteJSON(pico.PicoMessage{
+			Type:      pico.TypeMessageCreate,
+			SessionID: msg.SessionID,
+			Payload:   map[string]any{pico.PayloadKeyContent: "second chunk"},
+		}); err != nil {
+			t.Errorf("WriteJSON(second) error = %v", err)
+			return
+		}
+		_ = conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			time.Now().Add(time.Second),
+		)
+	}))
+	defer srv.Close()
+
+	remoteURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/pico/ws"
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	if err := remoteAgentCmd(ctx, remoteURL, "", "hello", sessionID, strings.NewReader(""), &out); err != nil {
+		t.Fatalf("remoteAgentCmd() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "first chunk") {
+		t.Fatalf("output = %q, want first chunk", out.String())
+	}
+	if !strings.Contains(out.String(), "second chunk") {
+		t.Fatalf("output = %q, want second chunk", out.String())
+	}
+}
+
 func TestRemoteOneShotUsesPicoTokenEnvFallback(t *testing.T) {
 	const sessionID = "env-session"
 	const token = "env-token"

--- a/cmd/picoclaw/internal/agent/remote_test.go
+++ b/cmd/picoclaw/internal/agent/remote_test.go
@@ -396,6 +396,61 @@ func TestRemoteOneShotReportsHandshakeStatus(t *testing.T) {
 	}
 }
 
+func TestRemoteClientCloseUnblocksReadLoop(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("Upgrade() error = %v", err)
+			return
+		}
+		defer conn.Close()
+
+		for {
+			if _, _, err := conn.NextReader(); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	remoteURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/pico/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := newRemoteClient(ctx, remoteURL, "", "close-session", &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("newRemoteClient() error = %v", err)
+	}
+
+	events := make(chan remoteEventResult, 1)
+	done := make(chan struct{})
+	go func() {
+		client.readLoop(ctx, events)
+		close(done)
+	}()
+
+	client.Close(websocket.CloseNormalClosure)
+	client.Close(websocket.CloseGoingAway)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("readLoop did not exit after Close")
+	}
+	select {
+	case evt, ok := <-events:
+		if ok {
+			t.Fatalf("readLoop event after Close = %#v", evt)
+		}
+	default:
+		t.Fatal("readLoop returned without closing events")
+	}
+	if err := client.Send("close-session", "hello"); err == nil {
+		t.Fatal("Send() after Close error = nil, want closed connection error")
+	}
+}
+
 func TestRemoteCommandExecutesRemoteMode(t *testing.T) {
 	const sessionID = "cmd-session"
 	gotMessage := make(chan pico.PicoMessage, 1)

--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -801,6 +801,7 @@ func formatCurrentSenderLine(senderID, senderDisplayName string) string {
 
 func (cb *ContextBuilder) buildDynamicContext(
 	channel, chatID, senderID, senderDisplayName string,
+	clientTransport, clientKind, clientName string,
 ) string {
 	now := time.Now().Format("2006-01-02 15:04 (Monday)")
 	rt := fmt.Sprintf("%s %s, Go %s", runtime.GOOS, runtime.GOARCH, runtime.Version())
@@ -810,6 +811,21 @@ func (cb *ContextBuilder) buildDynamicContext(
 
 	if channel != "" && chatID != "" {
 		fmt.Fprintf(&sb, "\n\n## Current Session\nChannel: %s\nChat ID: %s", channel, chatID)
+		clientName = strings.TrimSpace(clientName)
+		clientKind = strings.TrimSpace(clientKind)
+		clientTransport = strings.TrimSpace(clientTransport)
+		if clientName != "" || clientKind != "" {
+			if clientName != "" && clientKind != "" {
+				fmt.Fprintf(&sb, "\nClient: %s (%s)", clientName, clientKind)
+			} else if clientName != "" {
+				fmt.Fprintf(&sb, "\nClient: %s", clientName)
+			} else {
+				fmt.Fprintf(&sb, "\nClient: %s", clientKind)
+			}
+		}
+		if clientTransport != "" {
+			fmt.Fprintf(&sb, "\nTransport: %s", clientTransport)
+		}
 	}
 	if senderLine := formatCurrentSenderLine(senderID, senderDisplayName); senderLine != "" {
 		fmt.Fprintf(&sb, "\n\n## Current Sender\n%s", senderLine)
@@ -915,6 +931,9 @@ func (cb *ContextBuilder) BuildMessagesFromPrompt(req PromptBuildRequest) []prov
 			req.ChatID,
 			req.SenderID,
 			req.SenderDisplayName,
+			req.ClientTransport,
+			req.ClientKind,
+			req.ClientName,
 		)
 		dynamicChars = len(dynamicCtx)
 		runtimePart := PromptPart{

--- a/pkg/agent/context_cache_test.go
+++ b/pkg/agent/context_cache_test.go
@@ -188,6 +188,34 @@ func TestBuildMessages_CurrentSenderDynamicContext(t *testing.T) {
 	}
 }
 
+func TestBuildMessages_CurrentClientDynamicContext(t *testing.T) {
+	tmpDir := setupWorkspace(t, map[string]string{
+		"IDENTITY.md": "# Identity\nTest agent.",
+	})
+	defer os.RemoveAll(tmpDir)
+
+	cb := NewContextBuilder(tmpDir)
+	msgs := cb.BuildMessagesFromPrompt(PromptBuildRequest{
+		CurrentMessage:  "hello",
+		Channel:         "pico",
+		ChatID:          "pico:cli-default",
+		ClientTransport: "websocket",
+		ClientKind:      "remote_cli",
+		ClientName:      "picoclaw agent --remote",
+	})
+	sys := msgs[0].Content
+
+	if !strings.Contains(sys, "## Current Session\nChannel: pico\nChat ID: pico:cli-default") {
+		t.Fatalf("system prompt missing current session context:\n%s", sys)
+	}
+	if !strings.Contains(sys, "Client: picoclaw agent --remote (remote_cli)") {
+		t.Fatalf("system prompt missing client context:\n%s", sys)
+	}
+	if !strings.Contains(sys, "Transport: websocket") {
+		t.Fatalf("system prompt missing transport context:\n%s", sys)
+	}
+}
+
 // TestMtimeAutoInvalidation verifies that the cache detects source file changes
 // via mtime without requiring explicit InvalidateCache().
 // Fix: original implementation had no auto-invalidation — edits to bootstrap files,

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -114,6 +114,9 @@ type PromptBuildRequest struct {
 	ChatID            string
 	SenderID          string
 	SenderDisplayName string
+	ClientTransport   string
+	ClientKind        string
+	ClientName        string
 
 	ActiveSkills []string
 	Overlays     []PromptPart

--- a/pkg/agent/prompt_turn.go
+++ b/pkg/agent/prompt_turn.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
 	"github.com/sipeed/picoclaw/pkg/providers"
 )
@@ -28,6 +29,9 @@ func promptBuildRequestForTurn(
 		ActiveSkills:      activeSkillNames(ts.agent, ts.opts),
 		Overlays:          promptOverlaysForOptions(ts.opts),
 	}
+	req.ClientTransport, req.ClientKind, req.ClientName = clientPromptContextFromInbound(
+		ts.opts.Dispatch.InboundContext,
+	)
 	hasCallableTools := true
 	if ts.profile.Enabled {
 		hasCallableTools = turnProfileHasCallableTools(ts.profile, ts.agent.Tools.ToProviderDefs()) ||
@@ -91,6 +95,9 @@ func promptBuildRequestForProcessOptions(
 		ActiveSkills:      activeSkillNames(agent, opts),
 		Overlays:          promptOverlaysForOptions(opts),
 	}
+	req.ClientTransport, req.ClientKind, req.ClientName = clientPromptContextFromInbound(
+		opts.Dispatch.InboundContext,
+	)
 	profile := opts.TurnProfile
 	hasCallableTools := true
 	if profile.Enabled && agent != nil {
@@ -114,6 +121,15 @@ func promptBuildRequestForProcessOptions(
 		req.AllowedTools = append([]string(nil), profile.AllowedTools...)
 	}
 	return req
+}
+
+func clientPromptContextFromInbound(inbound *bus.InboundContext) (transport, kind, name string) {
+	if inbound == nil || len(inbound.Raw) == 0 {
+		return "", "", ""
+	}
+	return strings.TrimSpace(inbound.Raw["transport"]),
+		strings.TrimSpace(inbound.Raw["client_kind"]),
+		strings.TrimSpace(inbound.Raw["client_name"])
 }
 
 func promptOverlaysForOptions(opts processOptions) []PromptPart {

--- a/pkg/channels/pico/pico.go
+++ b/pkg/channels/pico/pico.go
@@ -1221,10 +1221,12 @@ func (c *PicoChannel) handleMessageSend(pc *picoConn, msg PicoMessage) {
 	senderID := "pico-user"
 
 	metadata := map[string]string{
-		"platform":   "pico",
-		"session_id": sessionID,
-		"conn_id":    pc.id,
+		"platform":          "pico",
+		"session_id":        sessionID,
+		"conn_id":           pc.id,
+		PayloadKeyTransport: TransportWebSocket,
 	}
+	copyPicoClientMetadata(metadata, msg.Payload)
 
 	logger.DebugCF("pico", "Received message", map[string]any{
 		"session_id": sessionID,
@@ -1252,6 +1254,19 @@ func (c *PicoChannel) handleMessageSend(pc *picoConn, msg PicoMessage) {
 	}
 
 	c.HandleInboundContext(c.ctx, chatID, content, media, inboundCtx, sender)
+}
+
+func copyPicoClientMetadata(metadata map[string]string, payload map[string]any) {
+	for _, key := range []string{
+		PayloadKeyClientKind,
+		PayloadKeyClientName,
+	} {
+		value, _ := payload[key].(string)
+		value = strings.TrimSpace(value)
+		if value != "" {
+			metadata[key] = value
+		}
+	}
 }
 
 // truncate truncates a string to maxLen runes.

--- a/pkg/channels/pico/pico_test.go
+++ b/pkg/channels/pico/pico_test.go
@@ -52,7 +52,10 @@ func TestHandleMessageSend_ForwardsMessageMetadata(t *testing.T) {
 		ID:        "msg-1",
 		SessionID: "sess-1",
 		Payload: map[string]any{
-			PayloadKeyContent: "hello",
+			PayloadKeyContent:    "hello",
+			PayloadKeyClientKind: "remote_cli",
+			PayloadKeyClientName: "picoclaw agent --remote",
+			PayloadKeyTransport:  "not-authoritative",
 		},
 	})
 
@@ -63,6 +66,15 @@ func TestHandleMessageSend_ForwardsMessageMetadata(t *testing.T) {
 		}
 		if got := inbound.Context.Raw["session_id"]; got != "sess-1" {
 			t.Fatalf("session_id raw = %q, want sess-1", got)
+		}
+		if got := inbound.Context.Raw["transport"]; got != "websocket" {
+			t.Fatalf("transport raw = %q, want websocket", got)
+		}
+		if got := inbound.Context.Raw["client_kind"]; got != "remote_cli" {
+			t.Fatalf("client_kind raw = %q, want remote_cli", got)
+		}
+		if got := inbound.Context.Raw["client_name"]; got != "picoclaw agent --remote" {
+			t.Fatalf("client_name raw = %q, want picoclaw agent --remote", got)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("expected inbound pico message")

--- a/pkg/channels/pico/protocol.go
+++ b/pkg/channels/pico/protocol.go
@@ -29,9 +29,15 @@ const (
 	PayloadKeyToolCalls   = "tool_calls"
 	PayloadKeyModelName   = "model_name"
 	PayloadKeyUsage       = "usage"
+	PayloadKeyClientKind  = "client_kind"
+	PayloadKeyClientName  = "client_name"
+	PayloadKeyTransport   = "transport"
 
 	MessageKindThought   = "thought"
 	MessageKindToolCalls = "tool_calls"
+
+	ClientKindRemoteCLI = "remote_cli"
+	TransportWebSocket  = "websocket"
 )
 
 // PicoMessage is the wire format for all Pico Protocol messages.


### PR DESCRIPTION
## 📝 Description

This PR adds an optional remote mode to the existing `picoclaw agent`
command.

Local behavior is unchanged:

```bash
picoclaw agent
picoclaw agent -m "hello"
```

New remote behavior:

```
picoclaw agent --remote ws://localhost:18790/pico/ws
picoclaw agent --remote ws://localhost:18790/pico/ws --token "$PICO_TOKEN"
picoclaw agent --remote ws://localhost:18790/pico/ws -s test-session -m "hello"
```

When `--remote` is set, the CLI connects to a remote Pico WebSocket
endpoint instead of starting the local agent loop.

The remote client:

- Adds or replaces `session_id` in the WebSocket URL.
- Sends `message.send` with the same session ID.
- Supports `--token` and falls back to `PICO_TOKEN`.
- Supports one-shot mode with `-m`.
- Supports interactive mode with the lobster prompt.
- Handles Ctrl-C and EOF cleanly.
- Renders Pico events such as:
    - `message.create`
    - `message.update`
    - `message.delete`
    - `typing.start`
    - `typing.stop`
    - `media.create`
    - `error`
    - `pong`
    - unknown event types
- Generates a fresh `cli:<uuid>` session when `--session` is not passed.

The PR also adds simple client metadata so the agent can know that a
turn came from the remote CLI over WebSocket. The remote client sends
metadata like:

client_kind=remote_cli
client_name=picoclaw agent --remote
transport=websocket

The Pico server records this on inbound messages. The server sets
`transport=websocket` itself, so the client cannot spoof the transport.

## 🗣️ Type of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation

- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

N/A

## 📚 Technical Context (Skip for Docs)

- Reference URL: N/A
- Reasoning:

The Pico WebSocket server expects clients to connect to:

/pico/ws?session_id=<session>

The same session ID must also be used in outgoing `message.send`
events. If the URL session and message session differ, the remote
response can be broadcast to a session that has no connected client.

When --session is omitted in remote mode, the CLI generates a fresh
cli:<uuid> session. This avoids accidentally sharing one remote
conversation across separate CLI runs.

Local mode is unchanged and still uses the existing cli:default
session.

Example:

```bash
picoclaw agent --remote ws://localhost:18790/pico/ws
```

connects with a generated session ID, for example:

ws://localhost:18790/pico/ws?session_id=cli%3A550e8400-e29b-41d4-a716-446655440000

while this uses the explicit session:

```
picoclaw agent --remote ws://localhost:18790/pico/ws -s test-session -m "hello"
```

ws://localhost:18790/pico/ws?session_id=test-session

And sends a Pico message with:

type=message.send
session_id=test-session

## 🧪 Test Environment

- Hardware: Development PC, plus remote PicoClaw gateway host
- OS: Linux
- Model/Provider: Existing configured PicoClaw provider
- Channels: Pico WebSocket, local CLI agent

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Focused test run:

go test ./cmd/picoclaw/internal/agent ./pkg/channels/pico ./pkg/agent

Result:

ok   github.com/sipeed/picoclaw/cmd/picoclaw/internal/agent
ok   github.com/sipeed/picoclaw/pkg/channels/pico
ok   github.com/sipeed/picoclaw/pkg/agent

Example remote one-shot command:

```
picoclaw agent \
  --remote ws://localhost:18790/pico/ws \
  --token "$PICO_TOKEN" \
  --session test-session \
  --message "hello"
```

Example remote interactive command:

```
picoclaw agent \
  --remote ws://localhost:18790/pico/ws \
  --token "$PICO_TOKEN"
```
</details>

## ☑️ Checklist

- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.