### PR TITLE
feat(config): add RegisterChannelSettings hook for out-of-tree channels

### DIFF
--- a/pkg/config/config_channel.go
+++ b/pkg/config/config_channel.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/caarlos0/env/v11"
 	"gopkg.in/yaml.v3"
@@ -655,6 +656,8 @@ func filterSecureFields(r RawNode, secureFields map[string]struct{}) RawNode {
 // channelSettingsFactory maps channel type to a zero-value prototype of the
 // corresponding Settings struct. InitChannelList uses reflect.New to create
 // fresh instances, avoiding repeated closure boilerplate.
+var channelSettingsMu sync.RWMutex
+
 var channelSettingsFactory = map[string]any{
 	ChannelPico:           (PicoSettings{}),
 	ChannelPicoClient:     (PicoClientSettings{}),
@@ -679,10 +682,24 @@ var channelSettingsFactory = map[string]any{
 	ChannelSlackWebHook:   (SlackWebhookSettings{}),
 }
 
+// RegisterChannelSettings registers a settings struct prototype for a custom
+// channel type. External packages (out-of-tree channels registered via
+// channels.RegisterFactory) call this from an init() so their channel type
+// passes config validation (isValidChannelType) and its settings block decodes
+// into the right struct (newChannelSettings). The prototype must be a struct
+// value, e.g. RegisterChannelSettings("my_channel", MyChannelSettings{}).
+func RegisterChannelSettings(channelType string, prototype any) {
+	channelSettingsMu.Lock()
+	defer channelSettingsMu.Unlock()
+	channelSettingsFactory[channelType] = prototype
+}
+
 // newChannelSettings creates a fresh zero-value pointer for the given channel type.
 // Returns nil if the type is not registered.
 func newChannelSettings(channelType string) any {
+	channelSettingsMu.RLock()
 	proto, ok := channelSettingsFactory[channelType]
+	channelSettingsMu.RUnlock()
 	if !ok {
 		return nil
 	}
@@ -691,7 +708,9 @@ func newChannelSettings(channelType string) any {
 
 // isValidChannelType returns true if the channel type is a known, registered type.
 func isValidChannelType(channelType string) bool {
+	channelSettingsMu.RLock()
 	_, ok := channelSettingsFactory[channelType]
+	channelSettingsMu.RUnlock()
 	return ok
 }
 

--- a/pkg/config/register_channel_settings_test.go
+++ b/pkg/config/register_channel_settings_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// customChannelSettings stands in for an out-of-tree channel's settings struct.
+type customChannelSettings struct {
+	Token string `json:"token"`
+}
+
+// TestRegisterChannelSettings verifies the public registration hook makes a
+// previously-unknown channel type valid and decodable — the behavior out-of-tree
+// channels rely on (they call RegisterChannelSettings from init()).
+func TestRegisterChannelSettings(t *testing.T) {
+	const typ = "custom_test_channel"
+
+	assert.False(t, isValidChannelType(typ), "type should be unknown before registration")
+
+	RegisterChannelSettings(typ, customChannelSettings{})
+
+	assert.True(t, isValidChannelType(typ), "type should be valid after registration")
+
+	got := newChannelSettings(typ)
+	_, ok := got.(*customChannelSettings)
+	assert.Truef(t, ok, "newChannelSettings(%q) = %T, want *customChannelSettings", typ, got)
+}
+
+// TestRegisterChannelSettings_InitChannelList verifies that a config carrying a
+// registered out-of-tree channel type passes InitChannelList and decodes its
+// settings — the full path that previously errored with "unknown type".
+func TestRegisterChannelSettings_InitChannelList(t *testing.T) {
+	const typ = "custom_initlist_channel"
+	RegisterChannelSettings(typ, customChannelSettings{})
+
+	channels := ChannelsConfig{
+		"mychan": {
+			Type:     typ,
+			Enabled:  true,
+			Settings: RawNode(`{"token":"secret-123"}`),
+		},
+	}
+
+	require.NoError(t, InitChannelList(channels))
+
+	decoded, err := channels["mychan"].GetDecoded()
+	require.NoError(t, err)
+	cfg, ok := decoded.(*customChannelSettings)
+	require.True(t, ok)
+	assert.Equal(t, "secret-123", cfg.Token)
+}


### PR DESCRIPTION
Makes PicoClaw extensible for **out-of-tree channels** — channels that live in a third-party module and register via the already-public `channels.RegisterFactory`, without forking PicoClaw.

## Why

The factory side is public (`channels.RegisterFactory`), but the **config side is not**: `InitChannelList` (called from `LoadConfig`) rejects any channel whose `type` is not in the **private** `channelSettingsFactory` map:

```go
if !isValidChannelType(bc.Type) {
    return fmt.Errorf("channel %q has unknown type %q", name, bc.Type)
}
```

So today a custom channel is impossible without editing PicoClaw. This PR closes that asymmetry: register the factory **and** its settings prototype, both from your own `init()`.

## What

One small, additive export (map access now guarded by a `sync.RWMutex`):

```go
func RegisterChannelSettings(channelType string, prototype any)
```

Usage from an out-of-tree channel package:

```go
func init() {
    config.RegisterChannelSettings("my_channel", MyChannelSettings{})
    channels.RegisterFactory("my_channel", newMyChannel)
}
```

## Why it is safe / low-effort to accept

- **Purely additive** — no existing channel or code path changes; built-in channels keep using the same map.
- **Tested** — unit tests cover the hook and the full `InitChannelList -> GetDecoded` path that previously failed with "unknown type".
- **Tiny surface** — one exported function + a mutex.
- `go test ./pkg/config/` passes; `go vet ./pkg/config/` clean.

Happy to adjust the API shape or naming if you prefer a different convention. Thanks for PicoClaw — we are building on it as a library and this is the one seam we are missing.
