### PR TITLE
refactor(openai_compat): replace log.Printf with structured logger

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"maps"
 	"net/http"
 	"net/url"
@@ -769,7 +768,10 @@ func parseStreamResponse(
 		raw := acc.argsJSON.String()
 		if raw != "" {
 			if err := json.Unmarshal([]byte(raw), &args); err != nil {
-				log.Printf("openai_compat stream: failed to decode tool call arguments for %q: %v", acc.name, err)
+				logger.WarnCF("openai_compat", "stream: failed to decode tool call arguments", map[string]any{
+					"tool":  acc.name,
+					"error": err.Error(),
+				})
 				args["raw"] = raw
 			}
 		}


### PR DESCRIPTION
The only remaining `log.Printf` call in this file is replaced with `logger.WarnCF`, matching the project's structured logging convention. The `log` import is removed as it is no longer used.

**Verification:** `go build ./pkg/providers/openai_compat/...` passes.