### PR TITLE
fix(evolution): capture Close() error on write file in appendJSONLRecords

### DIFF
--- a/pkg/evolution/store.go
+++ b/pkg/evolution/store.go
@@ -88,7 +88,11 @@ func (s *Store) appendJSONLRecords(ctx context.Context, path string, records []L
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
 
 	enc := json.NewEncoder(f)
 	for _, record := range records {


### PR DESCRIPTION
`defer f.Close()` on a file opened with `O_WRONLY|O_APPEND` silently discards the `Close()` error. On write-only files, `Close()` can surface delayed write failures (e.g. disk full, NFS errors).

Changed to a named defer that captures the close error when the function would otherwise return nil.

**Verification:** `go build ./pkg/evolution/...` and `go test ./pkg/evolution/...` pass.