### PR TITLE
fix(filesystem): explicitly ignore Close() error on directory file descriptor

### DIFF
--- a/pkg/tools/fs/filesystem.go
+++ b/pkg/tools/fs/filesystem.go
@@ -1137,7 +1137,7 @@ func (r *sandboxFs) WriteFile(path string, data []byte) error {
 		// Sync directory to ensure rename is durable
 		if dirFile, err := root.Open("."); err == nil {
 			_ = dirFile.Sync()
-			dirFile.Close()
+			_ = dirFile.Close()
 		}
 
 		return nil


### PR DESCRIPTION
`dirFile.Close()` on a directory file descriptor completely discards the error. Added `_ =` to make the intentional discard explicit, matching the `_ = dirFile.Sync()` pattern on the preceding line.

**Verification:** `go build ./pkg/tools/fs/...` passes.