### PR TITLE
fix(tts): handle io.ReadAll error in error response path

### DIFF
--- a/pkg/audio/tts/openai_tts.go
+++ b/pkg/audio/tts/openai_tts.go
@@ -196,7 +196,10 @@ func (t *OpenAITTSProvider) doSpeechRequest(
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte(fmt.Sprintf("(failed to read error body: %v)", readErr))
+		}
 		return nil, &openAITTSAPIError{
 			statusCode: resp.StatusCode,
 			body:       string(body),


### PR DESCRIPTION
When the TTS API returns a non-200 status, `io.ReadAll(resp.Body)` was called but its error was discarded with `_`. If `ReadAll` fails (e.g. network truncation), the diagnostic information in the error response would be silently degraded.

Now checks the error and provides a descriptive fallback message.

**Verification:** `go build ./pkg/audio/tts/...` passes.