### PR TITLE
fix: explicitly ignore Close() errors on directory file descriptors

### DIFF
--- a/pkg/fileutil/file.go
+++ b/pkg/fileutil/file.go
@@ -110,7 +110,7 @@ func WriteFileAtomic(path string, data []byte, perm os.FileMode) error {
 	// This prevents the renamed file from disappearing after a crash
 	if dirFile, err := os.Open(dir); err == nil {
 		_ = dirFile.Sync()
-		dirFile.Close()
+		_ = dirFile.Close()
 	}
 
 	// Success: skip cleanup (file was renamed, no temp to remove)


### PR DESCRIPTION
Explicitly ignore Close() errors on directory file descriptors in pkg/fileutil/file.go and pkg/tools/fs/filesystem.go. Both locations already use _ = dirFile.Sync() for consistency; this adds the same explicit ignore for the adjacent Close() call.