### PR TITLE
fix(web): explicitly ignore resp.Body.Close() errors after io.ReadAll

### DIFF
--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -315,7 +315,7 @@ func (p *BraveSearchProvider) Search(
 		}
 
 		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		if err != nil {
 			lastErr = fmt.Errorf("failed to read response: %w", err)
@@ -448,7 +448,7 @@ func (p *TavilySearchProvider) Search(
 		}
 
 		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		if err != nil {
 			lastErr = fmt.Errorf("failed to read response: %w", err)
@@ -906,7 +906,7 @@ func (p *SogouSearchProvider) Search(
 		}
 
 		body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return "", fmt.Errorf("failed to read response: %w", err)
 		}
@@ -1147,7 +1147,7 @@ func (p *PerplexitySearchProvider) Search(
 		}
 
 		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		if err != nil {
 			lastErr = fmt.Errorf("failed to read response: %w", err)


### PR DESCRIPTION
Explicitly ignore esp.Body.Close() errors after io.ReadAll in four search provider functions within pkg/tools/integration/web.go (Bing, Tavily, Sogou, Perplexity). The response body has already been fully consumed by io.ReadAll, so the Close() error is non-meaningful.