### PR TITLE
fix(tts): explicitly ignore file.Close() error in write error path

### DIFF
--- a/pkg/audio/tts/tts.go
+++ b/pkg/audio/tts/tts.go
@@ -146,7 +146,7 @@ func SynthesizeAndStore(
 
 	_, err = io.Copy(file, stream)
 	if err != nil {
-		file.Close()
+		_ = file.Close()
 		return "", fmt.Errorf("failed to write tts audio: %w", err)
 	}
 


### PR DESCRIPTION
In pkg/audio/tts/tts.go, when io.Copy(file, stream) fails, the subsequent ile.Close() error is implicitly discarded. This change makes the intentional discard explicit with _ = file.Close().