### PR TITLE
fix(seahorse): handle json.Marshal errors in grep and expand tools

### DIFF
--- a/pkg/seahorse/tool_expand.go
+++ b/pkg/seahorse/tool_expand.go
@@ -124,6 +124,9 @@ func (t *ExpandTool) Execute(ctx context.Context, args map[string]any) *tools.To
 		"tokenCount": result.TokenCount,
 		"messages":   messages,
 	}
-	data, _ := json.Marshal(output)
+	data, err := json.Marshal(output)
+	if err != nil {
+		return tools.ErrorResult(fmt.Sprintf("failed to marshal expand result: %v", err))
+	}
 	return tools.NewToolResult(string(data))
 }

--- a/pkg/seahorse/tool_grep.go
+++ b/pkg/seahorse/tool_grep.go
@@ -167,6 +167,9 @@ func (t *GrepTool) Execute(ctx context.Context, args map[string]any) *tools.Tool
 		output["hint"] = result.Hint
 	}
 
-	data, _ := json.Marshal(output)
+	data, err := json.Marshal(output)
+	if err != nil {
+		return tools.ErrorResult(fmt.Sprintf("failed to marshal grep result: %v", err))
+	}
 	return tools.NewToolResult(string(data))
 }


### PR DESCRIPTION
Handle json.Marshal errors in pkg/seahorse/tool_grep.go and pkg/seahorse/tool_expand.go. Previously both tools silently discarded marshal errors, potentially returning an empty string result. Now they return a descriptive ErrorResult on failure.