### PR TITLE
fix(registry): add ok checks for tool schema type assertions

### DIFF
--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -415,9 +415,18 @@ func (r *ToolRegistry) ToProviderDefs() []providers.ToolDefinition {
 			continue
 		}
 
-		name, _ := fn["name"].(string)
-		desc, _ := fn["description"].(string)
-		params, _ := fn["parameters"].(map[string]any)
+		name, ok := fn["name"].(string)
+		if !ok {
+			name = ""
+		}
+		desc, ok := fn["description"].(string)
+		if !ok {
+			desc = ""
+		}
+		params, ok := fn["parameters"].(map[string]any)
+		if !ok {
+			params = nil
+		}
 		metadata := promptMetadataForTool(entry.Tool)
 
 		definitions = append(definitions, providers.ToolDefinition{


### PR DESCRIPTION
Add explicit ok checks for three type assertions in pkg/tools/registry.go when extracting 
ame, description, and parameters from tool schema maps. When the value is not the expected type, fall back to zero values (empty string / nil map). This is consistent with the pattern used in other type assertion fixes across the codebase.