### PR TITLE
fix(telegram): use compositeChatID in InboundContext.ChatID for forum topics

### DIFF
--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -1185,7 +1185,7 @@ func (c *TelegramChannel) handleMessages(ctx context.Context, messages []*telego
 
 	inboundCtx := bus.InboundContext{
 		Channel:   c.Name(),
-		ChatID:    fmt.Sprintf("%d", chatID),
+		ChatID:    compositeChatID,
 		ChatType:  peerKind,
 		SenderID:  platformID,
 		MessageID: messageID,

--- a/pkg/channels/telegram/telegram_test.go
+++ b/pkg/channels/telegram/telegram_test.go
@@ -1212,8 +1212,9 @@ func TestHandleMessage_ForumTopic_SetsMetadata(t *testing.T) {
 	inbound, ok := <-messageBus.InboundChan()
 	require.True(t, ok, "expected inbound message")
 
-	// ChatID remains the parent chat; TopicID isolates the sub-conversation.
-	assert.Equal(t, "-1001234567890", inbound.ChatID)
+	// ChatID includes the thread ID for forum topics so outbound
+	// delivery resolves the correct topic without relying solely on TopicID fallback.
+	assert.Equal(t, "-1001234567890/42", inbound.ChatID)
 	assert.Equal(t, "group", inbound.Context.ChatType)
 	assert.Equal(t, "42", inbound.Context.TopicID)
 }


### PR DESCRIPTION
## Summary
- InboundContext.ChatID was set to the plain chat ID (without thread) for Telegram forum messages, while StartTyping received the compositeChatID (chatID/threadID format)
- This caused outbound text messages to be sent to the General topic instead of the specific forum topic — typing indicators were correct because they used compositeChatID directly
- The fix sets InboundContext.ChatID to compositeChatID for forum messages, ensuring outbound delivery resolves the correct topic thread from the ChatID itself, not just from TopicID fallback

## Verification
- Ran `go test ./pkg/channels/telegram/... -count=1` — all tests pass
- Updated `TestHandleMessage_ForumTopic_SetsMetadata` to reflect the new composite ChatID format
- `TestSend_UsesContextTopicIDWhenChatIDDoesNotIncludeThread` still passes (TopicID fallback still works for non-composite paths)

## Real behavior proof

**Behavior addressed:** Outbound Telegram messages now route to the correct forum topic instead of General, because InboundContext.ChatID carries the composite chatID/threadID format

**Environment tested:** Go 1.25.10 on Linux amd64, `go test ./pkg/channels/telegram/...`

**Steps run after the patch:** Ran targeted unit tests for the telegram channel adapter

**Evidence after fix:**

```text
ok  github.com/sipeed/picoclaw/pkg/channels/telegram  0.458s
```

**Observed result after the fix:** All telegram channel tests pass. Forum topic messages now carry composite ChatID ensuring correct outbound routing. TopicID is still preserved as a redundant fallback.

**Not tested:** Live Telegram Bot in a real Forum/Supergroup environment

## Root Cause
- Root cause: InboundContext.ChatID was set to plain chat ID (line 1188: `fmt.Sprintf("%d", chatID)`) instead of compositeChatID which already included the thread ID
- Missing detection/guardrail: the outbound delivery path relied on TopicID fallback from the context, but some code paths could lose or override the context before delivery, causing threadID to revert to 0 (General topic)

Closes #3110