### PR TITLE
fix(gemini): set both camelCase and snake_case thought_signature in tool call request body

### DIFF
--- a/pkg/providers/httpapi/gemini_provider.go
+++ b/pkg/providers/httpapi/gemini_provider.go
@@ -285,6 +285,7 @@ func (p *GeminiProvider) buildRequestBody(
 				}
 				if thoughtSignature != "" {
 					part.ThoughtSignature = thoughtSignature
+					part.ThoughtSignatureSnake = thoughtSignature
 				}
 				content.Parts = append(content.Parts, part)
 			}

--- a/pkg/providers/httpapi/gemini_provider_test.go
+++ b/pkg/providers/httpapi/gemini_provider_test.go
@@ -453,7 +453,7 @@ func TestGeminiProvider_ChatStreamReturnsErrorOnInvalidDataFrame(t *testing.T) {
 	}
 }
 
-func TestGeminiProvider_BuildRequestBody_UsesCamelCaseThoughtSignatureOnly(t *testing.T) {
+func TestGeminiProvider_BuildRequestBody_SetsBothThoughtSignatureFormats(t *testing.T) {
 	provider := NewGeminiProvider("test-key", "https://example.com/v1beta", "", "", 0, nil, nil)
 
 	body := provider.buildRequestBody(
@@ -484,8 +484,8 @@ func TestGeminiProvider_BuildRequestBody_UsesCamelCaseThoughtSignatureOnly(t *te
 	if !strings.Contains(jsonBody, `"thoughtSignature":"sig-1"`) {
 		t.Fatalf("request body = %s, expected camelCase thoughtSignature", jsonBody)
 	}
-	if strings.Contains(jsonBody, `"thought_signature"`) {
-		t.Fatalf("request body = %s, unexpected snake_case thought_signature", jsonBody)
+	if !strings.Contains(jsonBody, `"thought_signature":"sig-1"`) {
+		t.Fatalf("request body = %s, expected snake_case thought_signature for Gemini 3.5 Flash Agentic compatibility", jsonBody)
 	}
 }
 

--- a/pkg/providers/httpapi/gemini_provider_test.go
+++ b/pkg/providers/httpapi/gemini_provider_test.go
@@ -485,7 +485,11 @@ func TestGeminiProvider_BuildRequestBody_SetsBothThoughtSignatureFormats(t *test
 		t.Fatalf("request body = %s, expected camelCase thoughtSignature", jsonBody)
 	}
 	if !strings.Contains(jsonBody, `"thought_signature":"sig-1"`) {
-		t.Fatalf("request body = %s, expected snake_case thought_signature for Gemini 3.5 Flash Agentic compatibility", jsonBody)
+		t.Fatalf(
+			"request body = %s, expected snake_case thought_signature for "+
+				"Gemini 3.5 Flash Agentic compatibility",
+			jsonBody,
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The Gemini HTTP API provider only set `thoughtSignature` (camelCase) when building tool call request bodies
- Gemini 2.5 models accept camelCase, but Gemini 3.5 Flash Agentic reasoning requires `thought_signature` (snake_case) — matching the format it returns in API responses
- When only the camelCase variant was sent, Gemini 3.5 Flash rejected the request with a 400 Bad Request for missing `thought_signature`
- The fix sets both `ThoughtSignature` and `ThoughtSignatureSnake` in the geminiPart struct, matching the pattern already used in `antigravity_provider.go`

## Verification
- Ran `go test ./pkg/providers/httpapi/... -count=1` — all tests pass
- Updated test from `TestGeminiProvider_BuildRequestBody_UsesCamelCaseThoughtSignatureOnly` to `TestGeminiProvider_BuildRequestBody_SetsBothThoughtSignatureFormats` to validate both formats are present

## Real behavior proof

**Behavior addressed:** Gemini 3.5 Flash Agentic tool calls no longer fail with 400 Bad Request for missing thought_signature; both camelCase and snake_case variants are now included in the request body

**Environment tested:** Go 1.25.10 on Linux amd64, `go test ./pkg/providers/httpapi/...`

**Steps run after the patch:** Ran targeted unit tests for the httpapi provider

**Evidence after fix:**

```text
ok  github.com/sipeed/picoclaw/pkg/providers/httpapi  0.029s
```

**Observed result after the fix:** All httpapi provider tests pass. Request body now contains both `"thoughtSignature":"sig-1"` and `"thought_signature":"sig-1"`, ensuring compatibility with both Gemini 2.x and Gemini 3.x Agentic models.

**Not tested:** Live Gemini 3.5 Flash Agentic API request with real tool calls

## Root Cause
- Root cause: gemini_provider.go only set `part.ThoughtSignature` (camelCase json tag) in the request body, without also setting `part.ThoughtSignatureSnake` (snake_case json tag)
- Missing detection/guardrail: antigravity_provider.go already sets both formats (lines 267-268), but the Gemini direct HTTP API provider was missing the snake_case variant

Closes #3111