### PR TITLE
fix(web): update sogou search regex to match new HTML structure

### DIFF
--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -55,9 +55,9 @@ var (
 		`<a class="result__snippet[^"]*".*?>([\s\S]*?)</a>`,
 	)
 	reSogouTitle = regexp.MustCompile(
-		`<a\s+class=resultLink\s+href="([^"]+)"[^>]*id="sogou_vr_\d+_\d+"[^>]*>\s*(.*?)\s*</a>`,
+		`<a\s+class="?resultLink"?\s+href="([^"]+)"[^>]*id="sogou_vr_\d+_\d+"[^>]*>\s*(.*?)\s*</a>`,
 	)
-	reSogouSnippet = regexp.MustCompile(`<div class="clamp\d*">\s*(.*?)\s*</div>`)
+	reSogouSnippet = regexp.MustCompile(`<div class="clamp\d*[^"]*">\s*(.*?)\s*</div>`)
 	reSogouRealURL = regexp.MustCompile(`url=([^&]+)`)
 )
 


### PR DESCRIPTION
## 📝 Description

Fix `web_search` tool failing to parse Sogou search results due to HTML structure changes on the Sogou WAP search page.

**Changes detected:**
- Title link: `class=resultLink` → `class="resultLink"` (quotes added)
- Snippet area: `class="clamp3"` → `class="clamp2 fz-mid click-sugg-content"` (additional CSS classes)

**Fix:**
- `reSogouTitle`: `class=resultLink` → `class="?resultLink"?` — makes quotes optional, compatible with both formats
- `reSogouSnippet`: `clamp\d*` → `clamp\d*[^"]*` — allows additional CSS classes after `clamp`

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

N/A

## 📚 Technical Context
- **Reference URL:** https://wap.sogou.com/web/searchList.jsp
- **Reasoning:** Sogou WAP search page updated its HTML structure. The original regex patterns could no longer match the new format, causing `web_search` tool to return empty results. The updated regex is backward-compatible with the old format.

## 🧪 Test Environment
- **Hardware:** PC
- **OS:** Linux
- **Model/Provider:** N/A
- **Channels:** N/A

## 📸 Evidence
<details>
<summary>Click to view test results</summary>

```bash
$ go test -v -run "TestWebTool_Sogou" ./pkg/tools/integration/

=== RUN   TestWebTool_SogouSearch_Success
--- PASS: TestWebTool_SogouSearch_Success (0.00s)
=== RUN   TestWebTool_SogouPriorityAndExplicitProvider
--- PASS: TestWebTool_SogouPriorityAndExplicitProvider (0.00s)
PASS
ok      github.com/sipeed/picoclaw/pkg/tools/integration    0.003s
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.