### PR TITLE
fix(web_search): add diagnostic logging for Brave empty results

### DIFF
--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -350,6 +350,19 @@ func (p *BraveSearchProvider) Search(
 
 		results := searchResp.Web.Results
 		if len(results) == 0 {
+			// Log a warning when the API returned 200 but no results.
+			// This helps diagnose API format changes or silent errors
+			// where the response body does not match the expected structure.
+			bodyPreview := string(body)
+			if len(bodyPreview) > 300 {
+				bodyPreview = bodyPreview[:300]
+			}
+			logger.WarnCF("web_search", "Brave API returned empty results",
+				map[string]any{
+					"query":        query,
+					"status":       resp.StatusCode,
+					"body_preview": bodyPreview,
+				})
 			return fmt.Sprintf("No results for: %s", query), nil
 		}
 


### PR DESCRIPTION
## 📝 Description

Add diagnostic logging when the Brave Search API returns HTTP 200 with zero results. This helps diagnose silent failures where the response format has changed or a non-standard error response is misinterpreted as a successful empty result.

Previously, empty results were silently returned to the LLM as "No results for: <query>", making it impossible to distinguish between genuinely empty results and API format mismatches or silent errors.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## 🔗 Related Issue

Closes #3125

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/3125
- **Reasoning:** The Brave Search API can return HTTP 200 with an empty results array when the response structure doesn't match expectations. Without logging the response body, this failure mode is invisible to operators.

## 🧪 Test Environment
- **Hardware:** PC (x86_64)
- **OS:** Linux
- **Model/Provider:** N/A (logging change)
- **Channels:** N/A (backend change)

## 📸 Evidence (Optional)
<details>
<summary>Click to view code change</summary>

The change adds a warning log with the response body preview when the API returns zero results:

```go
logger.WarnCF("web_search", "Brave API returned empty results",
    map[string]any{
        "query":        query,
        "status":       resp.StatusCode,
        "body_preview": bodyPreview,
    })
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
