### PR TITLE
fix(spawn): clear ForUser in sub-turn ToolResult to prevent duplicate messages

### DIFF
--- a/pkg/agent/subturn.go
+++ b/pkg/agent/subturn.go
@@ -507,7 +507,9 @@ func spawnSubTurn(
 	} else {
 		result = &tools.ToolResult{
 			ForLLM:  turnRes.finalContent,
-			ForUser: turnRes.finalContent,
+			ForUser: "", // Clear ForUser to prevent direct push;
+			// the main agent controls delivery via the orchestration path,
+			// avoiding duplicate messages on async sub-agent completion.
 		}
 	}
 


### PR DESCRIPTION
## 📝 Description

Clear the `ForUser` field in the spawn sub-turn `ToolResult` to prevent duplicate message delivery on async sub-agent completion.

**Root cause:** When a spawn sub-agent finishes, `subturn.go` set both `ForLLM` and `ForUser` to the same content. This triggered two independent push paths:
1. The async callback in `pipeline_execute.go` directly pushed to the outbound bus when `ForUser` was non-empty
2. The main agent's orchestration path also delivered the result via `pendingResults`

**Fix:** Clear `ForUser` (set to `""`) so the main agent exclusively controls message delivery, eliminating the duplicate.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## 🔗 Related Issue

Closes #3094

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/3094
- **Reasoning:** The issue identified three fix options. Option A (clearing ForUser at the source in subturn.go) was chosen as the most minimal, zero-invasive approach that concentrates the fix at the right abstraction layer.

## 🧪 Test Environment
- **Hardware:** PC (x86_64)
- **OS:** Linux
- **Model/Provider:** N/A (code logic change)
- **Channels:** All channels (bug affects all async spawn delivery paths)

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
