### PR TITLE
fix(openai_compat): recover Doubao Seed tool calls leaked as <seed:to…

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"maps"
@@ -485,7 +486,25 @@ func (p *Provider) Chat(
 		return nil, common.HandleErrorResponse(resp, p.apiBase)
 	}
 
-	return common.ReadAndParseResponse(resp, p.apiBase)
+	out, err := common.ReadAndParseResponse(resp, p.apiBase)
+	if err != nil {
+		return nil, err
+	}
+
+	// Some providers (e.g. Volcengine Doubao Seed) occasionally embed
+	// <seed:tool_call> XML inside message.content instead of using the
+	// standard tool_calls field. Detect and recover when that happens.
+	if len(out.ToolCalls) == 0 && strings.Contains(out.Content, "<seed:tool_call") {
+		tc, cleaned := extractSeedToolCallsFromText(out.Content)
+		if len(tc) > 0 {
+			out.ToolCalls = tc
+			out.Content = cleaned
+			if out.FinishReason == "stop" {
+				out.FinishReason = "tool_calls"
+			}
+		}
+	}
+	return out, nil
 }
 
 // ChatStream implements streaming via OpenAI-compatible SSE (stream: true).
@@ -787,8 +806,24 @@ func parseStreamResponse(
 		finishReason = "stop"
 	}
 
+	content := textContent.String()
+
+	// Some providers (e.g. Volcengine Doubao Seed) occasionally embed
+	// <seed:tool_call> XML inside message.content instead of using the
+	// standard tool_calls field. Detect and recover when that happens.
+	if len(toolCalls) == 0 && strings.Contains(content, "<seed:tool_call") {
+		tc, cleaned := extractSeedToolCallsFromText(content)
+		if len(tc) > 0 {
+			toolCalls = tc
+			content = cleaned
+			if finishReason == "stop" {
+				finishReason = "tool_calls"
+			}
+		}
+	}
+
 	return &LLMResponse{
-		Content:          textContent.String(),
+		Content:          content,
 		ReasoningContent: reasoningContent.String(),
 		Reasoning:        reasoning.String(),
 		ReasoningDetails: reasoningDetails,
@@ -856,3 +891,125 @@ func isNativeSearchHost(apiBase string) bool {
 func supportsPromptCacheKey(apiBase string) bool {
 	return isNativeOpenAIOrAzureEndpoint(apiBase)
 }
+
+// extractSeedToolCallsFromText detects and parses <seed:tool_call> XML blocks
+// that some providers (e.g. Volcengine Doubao Seed) embed in message.content
+// instead of returning standard tool_calls.  It returns the extracted ToolCall
+// slice and the cleaned text with the XML blocks removed.
+func extractSeedToolCallsFromText(text string) ([]ToolCall, string) {
+	if !strings.Contains(text, "<seed:tool_call") {
+		return nil, text
+	}
+
+	toolCalls, cleaned := []ToolCall{}, text
+	for {
+		start := strings.Index(cleaned, "<seed:tool_call")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(cleaned[start:], "</seed:tool_call>")
+		if end == -1 {
+			break
+		}
+		end += start + len("</seed:tool_call>")
+
+		block := cleaned[start:end]
+		tc := parseSeedToolCallBlock(block)
+		if tc != nil {
+			toolCalls = append(toolCalls, *tc)
+		}
+		// Remove the XML block and collapse adjacent newlines to avoid double blanks
+		before := cleaned[:start]
+		after := cleaned[end:]
+		if len(before) > 0 && (before[len(before)-1] == '\n' || before[len(before)-1] == '\r') {
+			for len(after) > 0 && (after[0] == '\n' || after[0] == '\r') {
+				after = after[1:]
+			}
+		}
+		cleaned = strings.TrimSpace(before + after)
+	}
+	return toolCalls, cleaned
+}
+
+// parseSeedToolCallBlock parses a single <seed:tool_call> XML block into a
+// ToolCall using encoding/xml so that the namespace prefix is handled
+// robustly.
+func parseSeedToolCallBlock(block string) *ToolCall {
+	decoder := xml.NewDecoder(strings.NewReader(block))
+	var currentFn *struct {
+		name       string
+		args       map[string]any
+		argsJSON   string
+		inParam    bool
+		paramName  string
+		paramValue strings.Builder
+	}
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			break
+		}
+		switch se := tok.(type) {
+		case xml.StartElement:
+			if se.Name.Local == "function" {
+				fnName := ""
+				for _, attr := range se.Attr {
+					if attr.Name.Local == "name" {
+						fnName = attr.Value
+						break
+					}
+				}
+				currentFn = &struct {
+					name       string
+					args       map[string]any
+					argsJSON   string
+					inParam    bool
+					paramName  string
+					paramValue strings.Builder
+				}{
+					name: fnName,
+					args: make(map[string]any),
+				}
+			}
+			if se.Name.Local == "parameter" && currentFn != nil {
+				pName := ""
+				for _, attr := range se.Attr {
+					if attr.Name.Local == "name" {
+						pName = attr.Value
+						break
+					}
+				}
+				currentFn.inParam = true
+				currentFn.paramName = pName
+				currentFn.paramValue.Reset()
+			}
+		case xml.EndElement:
+			if se.Name.Local == "parameter" && currentFn != nil && currentFn.inParam {
+				currentFn.args[currentFn.paramName] = strings.TrimSpace(currentFn.paramValue.String())
+				currentFn.inParam = false
+			}
+			if se.Name.Local == "function" && currentFn != nil && currentFn.name != "" {
+				argsJSON, _ := json.Marshal(currentFn.args)
+				currentFn.argsJSON = string(argsJSON)
+			}
+		case xml.CharData:
+			if currentFn != nil && currentFn.inParam {
+				currentFn.paramValue.WriteString(string(se))
+			}
+		}
+	}
+	if currentFn == nil || currentFn.name == "" {
+		return nil
+	}
+	id := fmt.Sprintf("call_%s_%d", currentFn.name, time.Now().UnixNano())
+	return &ToolCall{
+		ID:        id,
+		Name:      currentFn.name,
+		Arguments: currentFn.args,
+		Function: &FunctionCall{
+			Name:      currentFn.name,
+			Arguments: currentFn.argsJSON,
+		},
+	}
+}
+

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -2196,3 +2196,222 @@ func TestSerializeMessages_StripsSystemParts(t *testing.T) {
 		t.Fatal("system_parts should not appear in serialized output")
 	}
 }
+
+// TestProviderChat_ExtractsSeedToolCallsFromContent verifies that when a provider
+// embeds <seed:tool_call> XML in message.content (instead of the standard
+// tool_calls field), we extract it, convert it to ToolCall structs, strip the
+// XML from the returned text, and change the finish_reason to "tool_calls".
+func TestProviderChat_ExtractsSeedToolCallsFromContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{
+					"message": map[string]any{
+						"content": "Let me check that for you.\n<seed:tool_call>\n  <function name=\"exec\">\n    <parameter name=\"action\" string=\"true\">run</parameter>\n    <parameter name=\"command\" string=\"true\">ls -la /tmp</parameter>\n  </function>\n</seed:tool_call>",
+						"tool_calls": []any{}, // empty array, not nil
+					},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]any{
+				"prompt_tokens":     10,
+				"completion_tokens": 20,
+				"total_tokens":      30,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	out, err := p.Chat(t.Context(), []Message{{Role: "user", Content: "list files"}}, nil, "volcengine/Doubao-Seed-2.0-pro", nil)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(out.ToolCalls))
+	}
+	if out.ToolCalls[0].Name != "exec" {
+		t.Fatalf("ToolCalls[0].Name = %q, want %q", out.ToolCalls[0].Name, "exec")
+	}
+	if out.ToolCalls[0].Arguments["action"] != "run" {
+		t.Fatalf("ToolCalls[0].Arguments[action] = %v, want run", out.ToolCalls[0].Arguments["action"])
+	}
+	if out.ToolCalls[0].Arguments["command"] != "ls -la /tmp" {
+		t.Fatalf("ToolCalls[0].Arguments[command] = %v, want ls -la /tmp", out.ToolCalls[0].Arguments["command"])
+	}
+	if out.Content != "Let me check that for you." {
+		t.Fatalf("Content = %q, want %q", out.Content, "Let me check that for you.")
+	}
+	if out.FinishReason != "tool_calls" {
+		t.Fatalf("FinishReason = %q, want tool_calls", out.FinishReason)
+	}
+}
+
+// TestProviderChatStream_ExtractsSeedToolCallsFromContent verifies that streaming
+// responses also recover <seed:tool_call> XML embedded in content text.
+func TestProviderChatStream_ExtractsSeedToolCallsFromContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("expected http.Flusher")
+		}
+
+		events := []string{
+			func() string {
+				d, _ := json.Marshal(map[string]any{
+					"choices": []map[string]any{
+						{"delta": map[string]any{"content": "Checking"}},
+					},
+				})
+				return "data: " + string(d) + "\n\n"
+			}(),
+			func() string {
+				d, _ := json.Marshal(map[string]any{
+					"choices": []map[string]any{
+						{"delta": map[string]any{"content": "...\n<seed:tool_call>\n  <function name=\"exec\">\n    <parameter name=\"action\" string=\"true\">run</parameter>\n    <parameter name=\"command\" string=\"true\">pwd</parameter>\n  </function>\n</seed:tool_call>"}},
+					},
+				})
+				return "data: " + string(d) + "\n\n"
+			}(),
+			func() string {
+				d, _ := json.Marshal(map[string]any{
+					"choices": []map[string]any{
+						{"delta": map[string]any{}, "finish_reason": "stop"},
+					},
+				})
+				return "data: " + string(d) + "\n\n"
+			}(),
+			"data: [DONE]\n\n",
+		}
+		for _, e := range events {
+			w.Write([]byte(e))
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	out, err := p.ChatStream(t.Context(), []Message{{Role: "user", Content: "where am I"}}, nil, "volcengine/Doubao-Seed-2.0-pro", nil, nil)
+	if err != nil {
+		t.Fatalf("ChatStream() error = %v", err)
+	}
+
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(out.ToolCalls))
+	}
+	if out.ToolCalls[0].Name != "exec" {
+		t.Fatalf("ToolCalls[0].Name = %q, want %q", out.ToolCalls[0].Name, "exec")
+	}
+	if out.ToolCalls[0].Arguments["action"] != "run" {
+		t.Fatalf("ToolCalls[0].Arguments[action] = %v, want run", out.ToolCalls[0].Arguments["action"])
+	}
+	if out.ToolCalls[0].Arguments["command"] != "pwd" {
+		t.Fatalf("ToolCalls[0].Arguments[command] = %v, want pwd", out.ToolCalls[0].Arguments["command"])
+	}
+	if out.Content != "Checking..." {
+		t.Fatalf("Content = %q, want %q", out.Content, "Checking...")
+	}
+	if out.FinishReason != "tool_calls" {
+		t.Fatalf("FinishReason = %q, want tool_calls", out.FinishReason)
+	}
+}
+
+// TestProviderChat_IgnoresStandardToolCallsWhenNotSeed verifies that normal
+// OpenAI-style tool_calls are left untouched and we do not touch content when
+// standard tool_calls are already present.
+func TestProviderChat_IgnoresStandardToolCallsWhenNotSeed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{
+					"message": map[string]any{
+						"content": "ok",
+						"tool_calls": []map[string]any{
+							{
+								"id":   "call_1",
+								"type": "function",
+								"function": map[string]any{
+									"name":      "get_weather",
+									"arguments": "{\"city\":\"SF\"}",
+								},
+							},
+						},
+					},
+					"finish_reason": "tool_calls",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	out, err := p.Chat(t.Context(), []Message{{Role: "user", Content: "weather"}}, nil, "gpt-4o", nil)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(out.ToolCalls))
+	}
+	if out.ToolCalls[0].Name != "get_weather" {
+		t.Fatalf("ToolCalls[0].Name = %q, want get_weather", out.ToolCalls[0].Name)
+	}
+	if out.Content != "ok" {
+		t.Fatalf("Content = %q, want ok", out.Content)
+	}
+	if out.FinishReason != "tool_calls" {
+		t.Fatalf("FinishReason = %q, want tool_calls", out.FinishReason)
+	}
+}
+
+// TestExtractSeedToolCallsFromText_MultipleCalls verifies extraction of multiple
+// <seed:tool_call> blocks in a single content string.
+func TestExtractSeedToolCallsFromText_MultipleCalls(t *testing.T) {
+	input := "Planning...\n<seed:tool_call>\n  <function name=\"read_file\">\n    <parameter name=\"path\" string=\"true\">/tmp/a.txt</parameter>\n  </function>\n</seed:tool_call>\n<seed:tool_call>\n  <function name=\"write_file\">\n    <parameter name=\"path\" string=\"true\">/tmp/b.txt</parameter>\n    <parameter name=\"content\" string=\"true\">hello</parameter>\n  </function>\n</seed:tool_call>\nDone."
+	tc, cleaned := extractSeedToolCallsFromText(input)
+	if len(tc) != 2 {
+		t.Fatalf("len(tc) = %d, want 2", len(tc))
+	}
+	if tc[0].Name != "read_file" {
+		t.Fatalf("tc[0].Name = %q, want read_file", tc[0].Name)
+	}
+	if tc[1].Name != "write_file" {
+		t.Fatalf("tc[1].Name = %q, want write_file", tc[1].Name)
+	}
+	if cleaned != "Planning...\nDone." {
+		t.Fatalf("cleaned = %q, want %q", cleaned, "Planning...\nDone.")
+	}
+}
+
+// TestExtractSeedToolCallsFromText_NoMatch verifies that plain text without XML
+// is returned untouched.
+func TestExtractSeedToolCallsFromText_NoMatch(t *testing.T) {
+	input := "This is just plain text."
+	tc, cleaned := extractSeedToolCallsFromText(input)
+	if len(tc) != 0 {
+		t.Fatalf("len(tc) = %d, want 0", len(tc))
+	}
+	if cleaned != input {
+		t.Fatalf("cleaned = %q, want %q", cleaned, input)
+	}
+}
+
+// TestExtractSeedToolCallsFromText_MalformedXML verifies that malformed blocks
+// are skipped without panicking.
+func TestExtractSeedToolCallsFromText_MalformedXML(t *testing.T) {
+	input := "<seed:tool_call>\n  <function>\n    <parameter name=\"x\">1</parameter>\n  </function>\n</seed:tool_call>\n"
+	tc, cleaned := extractSeedToolCallsFromText(input)
+	// function without name attribute is skipped
+	if len(tc) != 0 {
+		t.Fatalf("len(tc) = %d, want 0", len(tc))
+	}
+	if strings.Contains(cleaned, "seed:tool_call") {
+		t.Fatalf("cleaned should not contain seed:tool_call, got %q", cleaned)
+	}
+}
+


### PR DESCRIPTION
fix #3153 
### Implementation Plan Details

**Root Cause**: The Volcengine Doubao Seed model occasionally embeds tool calls as raw `<seed:tool_call>` XML inside `message.content` (instead of returning them via the standard OpenAI-compatible `tool_calls` field), especially during long or tool-heavy conversations. The `openai_compat` provider previously only parsed the standard `tool_calls` field, so the XML markup leaked into the user chat and the intended tools were never executed.

**Fix Strategy**: Add a fallback detection layer in both the streaming and non-streaming response parsing paths of the `openai_compat` provider. When `tool_calls` is empty and `content` contains `<seed:tool_call>`, automatically parse the XML, convert it into standard `ToolCall` structs, strip the XML from the text, and rewrite `finish_reason` to `"tool_calls"`.

### Implementation Content Details

1. **New XML Parsing Functions** (`provider.go`):
   - `extractSeedToolCallsFromText(text string) ([]ToolCall, string)`: Scans text for `<seed:tool_call>...</seed:tool_call>` blocks, parses each one, removes it, and returns the extracted ToolCall slice plus the cleaned text.
   - `parseSeedToolCallBlock(block string) *ToolCall`: Uses `encoding/xml` to token-by-token parse a single block (ignoring the `seed:` namespace prefix), extracts the `function` `name` attribute and all `parameter` `name/value` pairs, and builds a `ToolCall` struct (ID format: `call_<name>_<timestamp>`).

2. **Non-streaming Path Fix** (`Chat` method):
   - After `common.ReadAndParseResponse`, checks `len(out.ToolCalls) == 0 && strings.Contains(out.Content, "<seed:tool_call")`.
   - If hit, calls `extractSeedToolCallsFromText`, writes the extracted result into `out.ToolCalls`, cleans `out.Content`, and changes `FinishReason` from `"stop"` to `"tool_calls"`.

3. **Streaming Path Fix** (`parseStreamResponse`):
   - Before assembling the final `LLMResponse`, checks `len(toolCalls) == 0 && strings.Contains(textContent.String(), "<seed:tool_call")`.
   - If hit, applies the same extraction/cleanup/rewrite logic so streaming output is also recovered.

4. **Cleanup Optimization**:
   - When removing an XML block, adjacent newlines before and after the block are also collapsed to prevent extra blank lines.

### Test Points

- `TestProviderChat_ExtractsSeedToolCallsFromContent`: Verifies that embedded XML in a non-streaming response is correctly extracted into a ToolCall, the text is cleaned, and `FinishReason` is rewritten.
- `TestProviderChatStream_ExtractsSeedToolCallsFromContent`: Verifies the same recovery logic under an SSE streaming response.
- `TestProviderChat_IgnoresStandardToolCallsWhenNotSeed`: Verifies that standard `tool_calls` responses are left untouched and the fallback is not triggered.
- `TestExtractSeedToolCallsFromText_MultipleCalls`: Verifies that multiple `<seed:tool_call>` blocks in a single content string are all extracted.
- `TestExtractSeedToolCallsFromText_NoMatch`: Verifies that plain text without XML is returned unchanged.
- `TestExtractSeedToolCallsFromText_MalformedXML`: Verifies that malformed XML blocks (e.g., missing `name` attribute) are safely skipped without panic.

### Next Steps

1. **Community Validation**: Ask users who run the Volcengine Doubao Seed model to validate the fix in real-world scenarios and confirm the leak is fully eliminated.
2. **Logging Enhancement**: If occasional cases still occur, consider adding a `logger.InfoCF` log line when Seed XML recovery is triggered, to aid future diagnostics and metrics.
3. **Extended Coverage**: If other domestic models (e.g., Kimi, GLM) exhibit similar content-embedded tool-call formats, consider generalizing `extractSeedToolCallsFromText` into a more universal fallback extractor.
