### PR TITLE
feat(spawn): add direct_reply parameter with SkipInboundTurn support

### DIFF
--- a/pkg/agent/pipeline_execute.go
+++ b/pkg/agent/pipeline_execute.go
@@ -519,6 +519,33 @@ toolLoop:
 				_ = al.bus.PublishOutbound(outCtx, outboundMessageForTurn(ts, result.ForUser))
 			}
 
+			// SkipInboundTurn: inject result into session history directly
+			// instead of publishing an inbound turn. This avoids triggering
+			// the main agent and creating duplicate messages (used by spawn's
+			// direct_reply mode).
+			if result.SkipInboundTurn {
+				content := result.ContentForLLM()
+				if content == "" {
+					return
+				}
+				content = al.cfg.FilterSensitiveData(content)
+				toolResultMsg := providers.Message{
+					Role:       "tool",
+					Content:    content,
+					ToolCallID: toolCallID,
+				}
+				ts.agent.Sessions.AddFullMessage(ts.sessionKey, toolResultMsg)
+				ts.ingestMessage(context.Background(), al, toolResultMsg)
+				if err := ts.agent.Sessions.Save(ts.sessionKey); err != nil {
+					logger.WarnCF("agent", "Failed to save session after SkipInboundTurn",
+						map[string]any{
+							"agent_id": ts.agent.ID,
+							"error":    err.Error(),
+						})
+				}
+				return
+			}
+
 			content := result.ContentForLLM()
 			if content == "" {
 				return

--- a/pkg/tools/shared/result.go
+++ b/pkg/tools/shared/result.go
@@ -59,6 +59,12 @@ type ToolResult struct {
 	// user's request at the channel/output level, so the agent loop can stop
 	// without a follow-up assistant response.
 	ResponseHandled bool `json:"response_handled,omitempty"`
+
+	// SkipInboundTurn suppresses the automatic inbound turn publication that
+	// normally triggers the main agent to respond. Used by async callbacks
+	// (e.g. spawn's direct_reply) when the sub-agent's result should be
+	// delivered to the user without invoking the main agent.
+	SkipInboundTurn bool `json:"skip_inbound_turn,omitempty"`
 }
 
 // ContentForLLM returns the normalized textual content to append to the

--- a/pkg/tools/spawn.go
+++ b/pkg/tools/spawn.go
@@ -57,6 +57,10 @@ func (t *SpawnTool) Parameters() map[string]any {
 				"type":        "string",
 				"description": "Optional target agent ID to delegate the task to",
 			},
+			"direct_reply": map[string]any{
+				"type":        "boolean",
+				"description": "When true (default), the sub-agent's final response is delivered directly to the user and the main agent is not triggered to reply. When false, the result flows through the normal inbound path so the main agent can process and respond.",
+			},
 		},
 		"required": []string{"task"},
 	}
@@ -99,6 +103,12 @@ func (t *SpawnTool) execute(
 		agentID = ""
 	}
 	targetAgentID := strings.TrimSpace(agentID)
+
+	// direct_reply defaults to true
+	directReply := true
+	if dr, ok := args["direct_reply"].(bool); ok {
+		directReply = dr
+	}
 
 	// Check allowlist if targeting a specific agent
 	if targetAgentID != "" && t.allowlistCheck != nil {
@@ -143,8 +153,19 @@ Task: %s`,
 				result = ErrorResult(fmt.Sprintf("Spawn failed: %v", err)).WithError(err)
 			}
 
-			// Call callback if provided
+			// Apply direct_reply semantics before invoking callback
 			if cb != nil {
+				if directReply {
+					// Deliver sub-agent result directly to user without
+					// triggering the main agent to reply again.
+					if !result.IsError && result.ForUser == "" {
+						result.ForUser = result.ForLLM
+					}
+					result.SkipInboundTurn = true
+				} else {
+					// Strip ForUser so main agent processes the result.
+					result.ForUser = ""
+				}
 				cb(ctx, result)
 			}
 		}()


### PR DESCRIPTION
## Problem

Issue #3094 - current spawn async callback does two things at once:
1. ForUser delivers to channel
2. PublishInbound triggers main agent

This causes duplicate messages.

## Solution

Two clear behavior paths via ToolResult.SkipInboundTurn:

| direct_reply | User sees | Main agent | Context continuity |
|---|---|---|---|
| true (default) | Sub-agent result directly | Not triggered | Saved to history |
| false | - | Processes and responds | Normal flow |

## Changes

pkg/tools/shared/result.go (+6)
- New SkipInboundTurn bool field

pkg/agent/pipeline_execute.go (+27)
- In asyncCallback: when SkipInboundTurn=true, inject to session directly instead of PublishInbound

pkg/tools/spawn.go (+22/-1)
- New direct_reply param (bool, default true)
- true: set ForUser + SkipInboundTurn=true
- false: strip ForUser, normal PublishInbound path

Closes #3094
