### PR TITLE
fix(auth): reject cross-site launcher setup requests

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"maps"
 	"net/http"
 	"net/url"

--- a/web/backend/api/auth.go
+++ b/web/backend/api/auth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/sipeed/picoclaw/web/backend/middleware"
@@ -87,6 +88,60 @@ func (h *launcherAuthHandlers) isStoreInitialized(ctx context.Context) (bool, er
 		return false, fmt.Errorf("password store not configured")
 	}
 	return h.store.IsInitialized(ctx)
+}
+
+func launcherSetupCrossSite(r *http.Request) bool {
+	fetchSite := strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")))
+	if fetchSite == "cross-site" {
+		return true
+	}
+
+	if origin := strings.TrimSpace(r.Header.Get("Origin")); origin != "" {
+		return !sameLauncherRequestOrigin(r, origin)
+	}
+
+	if referer := strings.TrimSpace(r.Header.Get("Referer")); referer != "" {
+		return !sameLauncherRequestOrigin(r, referer)
+	}
+
+	return false
+}
+
+func sameLauncherRequestOrigin(r *http.Request, raw string) bool {
+	if strings.ContainsAny(raw, " \t\r\n") {
+		return false
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return false
+	}
+
+	wantScheme := launcherRequestScheme(r)
+	wantHost := r.Host
+	if wantHost == "" {
+		wantHost = r.URL.Host
+	}
+	return strings.EqualFold(u.Scheme, wantScheme) && strings.EqualFold(u.Host, wantHost)
+}
+
+func launcherRequestScheme(r *http.Request) string {
+	if proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); proto != "" {
+		if i := strings.IndexByte(proto, ','); i >= 0 {
+			proto = proto[:i]
+		}
+		proto = strings.ToLower(strings.TrimSpace(proto))
+		if proto == "http" || proto == "https" {
+			return proto
+		}
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	if r.URL != nil && r.URL.Scheme != "" {
+		return r.URL.Scheme
+	}
+	return "http"
 }
 
 func (h *launcherAuthHandlers) handleLogin(w http.ResponseWriter, r *http.Request) {
@@ -197,6 +252,12 @@ func (h *launcherAuthHandlers) handleStatus(w http.ResponseWriter, r *http.Reque
 //   - If a password is already set, the caller must hold a valid session cookie.
 func (h *launcherAuthHandlers) handleSetup(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+
+	if launcherSetupCrossSite(r) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"cross-site setup request rejected"}`))
+		return
+	}
 
 	if h.store == nil {
 		w.WriteHeader(http.StatusServiceUnavailable)

--- a/web/backend/api/auth_csrf_test.go
+++ b/web/backend/api/auth_csrf_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLauncherAuthSetupRejectsCrossSiteFirstRun(t *testing.T) {
+	store := &fakePasswordStore{}
+	mux := http.NewServeMux()
+	RegisterLauncherAuthRoutes(mux, LauncherAuthRouteOpts{
+		SessionCookie: "session-cookie-value",
+		PasswordStore: store,
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"http://127.0.0.1:18800/api/auth/setup",
+		strings.NewReader(`{"password":"CrossSitePwn123!","confirm":"CrossSitePwn123!"}`),
+	)
+	req.Header.Set("Origin", "https://evil.example")
+	req.Header.Set("Referer", "https://evil.example/attack")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("cross-site setup code = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if store.initialized || store.password != "" {
+		t.Fatalf("cross-site setup mutated store: initialized=%v password=%q", store.initialized, store.password)
+	}
+}
+
+func TestLauncherAuthSetupAllowsSameOriginFirstRun(t *testing.T) {
+	store := &fakePasswordStore{}
+	mux := http.NewServeMux()
+	RegisterLauncherAuthRoutes(mux, LauncherAuthRouteOpts{
+		SessionCookie: "session-cookie-value",
+		PasswordStore: store,
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"http://127.0.0.1:18800/api/auth/setup",
+		strings.NewReader(`{"password":"LocalSetup123!","confirm":"LocalSetup123!"}`),
+	)
+	req.Header.Set("Origin", "http://127.0.0.1:18800")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("same-origin setup code = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !store.initialized || store.password != "LocalSetup123!" {
+		t.Fatalf("same-origin setup store: initialized=%v password=%q", store.initialized, store.password)
+	}
+}


### PR DESCRIPTION
📝 Description

Rejects cross-site launcher password setup requests before they can mutate the first-run dashboard password store.

This adds browser provenance checks for "POST /api/auth/setup" using "Sec-Fetch-Site", "Origin", and "Referer", while preserving same-origin first-run setup.

🗣️ Type of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

🤖 AI Code Generation

- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

🔗 Related Issue

Fixes #3072

📚 Technical Context (Skip for Docs)

- Reference URL: #3072
- Reasoning: The first-run launcher setup endpoint is intentionally public while the password store is uninitialized. Without browser provenance checks, a malicious cross-site page can submit an attacker-controlled password to a reachable local launcher before the legitimate setup completes. This change rejects cross-site setup attempts using standard browser request headers and keeps same-origin setup working.

🧪 Test Environment

- Hardware: Redmi Android phone via Termux
- OS: Android / Termux
- Model/Provider: Not applicable
- Channels: Not applicable

📸 Evidence (Optional)

<details>
<summary>Click to view Logs/Screenshots</summary>go test -tags goolm,stdjson ./web/backend/api

Result:

ok      github.com/sipeed/picoclaw/web/backend/api   26.255s

</details>☑️ Checklist

- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.