### PR TITLE
feat(bedrock): leverage Converse prompt caching via cache points

### DIFF
--- a/pkg/providers/bedrock/provider_bedrock.go
+++ b/pkg/providers/bedrock/provider_bedrock.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 
+	"github.com/sipeed/picoclaw/pkg/logger"
 	"github.com/sipeed/picoclaw/pkg/providers/common"
 	"github.com/sipeed/picoclaw/pkg/providers/protocoltypes"
 )
@@ -158,8 +159,56 @@ func modelDeprecatesTemperature(model string) bool {
 	return strings.Contains(m, "claude-opus-4-8")
 }
 
+// modelSupportsCaching reports whether the given Bedrock model accepts prompt
+// cache points (CachePointBlock) in the Converse request. Inserting a cache
+// point for a model that does not support it returns a ValidationException, so
+// caching is opt-in by model.
+//
+// The match is loose for the same reason as modelDeprecatesTemperature: Bedrock
+// model IDs and inference-profile ARNs embed the model name, so a substring
+// check covers bare IDs and region-prefixed inference profiles alike. The set
+// covers the cache-enabled Claude families on Bedrock (3.5 v2, 3.7, and 4.x).
+func modelSupportsCaching(model string) bool {
+	m := strings.ToLower(model)
+	if !strings.Contains(m, "claude") {
+		return false
+	}
+	switch {
+	case strings.Contains(m, "claude-3-5-sonnet"),
+		strings.Contains(m, "claude-3-5-haiku"),
+		strings.Contains(m, "claude-3-7-sonnet"),
+		strings.Contains(m, "claude-sonnet-4"),
+		strings.Contains(m, "claude-opus-4"),
+		strings.Contains(m, "claude-haiku-4"):
+		return true
+	default:
+		return false
+	}
+}
+
+// cachePointBlock returns the SDK cache-point marker inserted after a cacheable
+// prefix in system, tool, or message content.
+func newCachePointContentBlock() types.ContentBlock {
+	return &types.ContentBlockMemberCachePoint{
+		Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+	}
+}
+
+func newCachePointSystemBlock() types.SystemContentBlock {
+	return &types.SystemContentBlockMemberCachePoint{
+		Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+	}
+}
+
+func newCachePointTool() types.Tool {
+	return &types.ToolMemberCachePoint{
+		Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+	}
+}
+
 func buildConverseParams(messages []Message, tools []ToolDefinition, model string, options map[string]any) converseParams {
-	bedrockMessages, systemPrompts := convertMessages(messages)
+	cacheEnabled := modelSupportsCaching(model)
+	bedrockMessages, systemPrompts := convertMessagesWithCache(messages, cacheEnabled)
 
 	var inferenceConfig *types.InferenceConfiguration
 
@@ -186,7 +235,7 @@ func buildConverseParams(messages []Message, tools []ToolDefinition, model strin
 
 	var toolConfig *types.ToolConfiguration
 	if len(tools) > 0 {
-		tc := convertTools(tools)
+		tc := convertToolsWithCache(tools, cacheEnabled)
 		if len(tc.Tools) > 0 {
 			toolConfig = tc
 		}
@@ -418,7 +467,10 @@ func parseStreamResponse(
 						) + int(
 							aws.ToInt32(e.Value.Usage.OutputTokens),
 						),
+						CacheReadTokens:  int(aws.ToInt32(e.Value.Usage.CacheReadInputTokens)),
+						CacheWriteTokens: int(aws.ToInt32(e.Value.Usage.CacheWriteInputTokens)),
 					}
+					logCacheUsage("conversestream", usage)
 				}
 			}
 		}
@@ -453,6 +505,17 @@ func (p *Provider) Region() string {
 // user message with multiple ToolResultBlock content blocks. This function merges
 // consecutive tool result messages accordingly.
 func convertMessages(messages []Message) ([]types.Message, []types.SystemContentBlock) {
+	return convertMessagesWithCache(messages, false)
+}
+
+// convertMessagesWithCache is convertMessages with optional Bedrock prompt
+// caching. When cacheEnabled is true and a system message carries structured
+// SystemParts, each part is emitted as its own block and a cache point is
+// inserted after the last part marked CacheControl "ephemeral". This caches the
+// stable system prefix while leaving volatile trailing parts (time, session,
+// summary) outside the cached region. The cache point is omitted when no part
+// is ephemeral, so the per-request dynamic context never anchors the cache.
+func convertMessagesWithCache(messages []Message, cacheEnabled bool) ([]types.Message, []types.SystemContentBlock) {
 	var bedrockMessages []types.Message
 	var systemPrompts []types.SystemContentBlock
 
@@ -481,10 +544,30 @@ func convertMessages(messages []Message) ([]types.Message, []types.SystemContent
 
 		switch {
 		case msg.Role == "system":
-			// System messages go to the System field
-			systemPrompts = append(systemPrompts, &types.SystemContentBlockMemberText{
-				Value: msg.Content,
-			})
+			// System messages go to the System field. With caching enabled and
+			// structured SystemParts available, emit each part separately and
+			// place a cache point after the last ephemeral (stable) part so the
+			// static prefix is cached and volatile trailing parts are not.
+			if cacheEnabled && len(msg.SystemParts) > 0 {
+				lastEphemeral := -1
+				for idx, part := range msg.SystemParts {
+					if part.CacheControl != nil && part.CacheControl.Type == "ephemeral" {
+						lastEphemeral = idx
+					}
+				}
+				for idx, part := range msg.SystemParts {
+					systemPrompts = append(systemPrompts, &types.SystemContentBlockMemberText{
+						Value: part.Text,
+					})
+					if idx == lastEphemeral {
+						systemPrompts = append(systemPrompts, newCachePointSystemBlock())
+					}
+				}
+			} else {
+				systemPrompts = append(systemPrompts, &types.SystemContentBlockMemberText{
+					Value: msg.Content,
+				})
+			}
 			i++
 
 		case isToolResult(msg):
@@ -684,6 +767,15 @@ func buildAssistantContent(msg Message) []types.ContentBlock {
 
 // convertTools converts tool definitions to Bedrock format.
 func convertTools(tools []ToolDefinition) *types.ToolConfiguration {
+	return convertToolsWithCache(tools, false)
+}
+
+// convertToolsWithCache is convertTools with optional Bedrock prompt caching.
+// When cacheEnabled is true and at least one tool is produced, a cache point is
+// appended after the tool list. The tool schema is large and identical across
+// turns, so caching it yields the most reliable savings. The point is omitted
+// when no tools are emitted to avoid a ValidationException on an empty config.
+func convertToolsWithCache(tools []ToolDefinition, cacheEnabled bool) *types.ToolConfiguration {
 	bedrockTools := make([]types.Tool, 0, len(tools))
 
 	for _, tool := range tools {
@@ -713,6 +805,10 @@ func convertTools(tools []ToolDefinition) *types.ToolConfiguration {
 				},
 			},
 		})
+	}
+
+	if cacheEnabled && len(bedrockTools) > 0 {
+		bedrockTools = append(bedrockTools, newCachePointTool())
 	}
 
 	return &types.ToolConfiguration{
@@ -794,7 +890,10 @@ func parseResponse(output *bedrockruntime.ConverseOutput) (*LLMResponse, error) 
 			PromptTokens:     int(aws.ToInt32(output.Usage.InputTokens)),
 			CompletionTokens: int(aws.ToInt32(output.Usage.OutputTokens)),
 			TotalTokens:      int(aws.ToInt32(output.Usage.InputTokens)) + int(aws.ToInt32(output.Usage.OutputTokens)),
+			CacheReadTokens:  int(aws.ToInt32(output.Usage.CacheReadInputTokens)),
+			CacheWriteTokens: int(aws.ToInt32(output.Usage.CacheWriteInputTokens)),
 		}
+		logCacheUsage("converse", usage)
 	}
 
 	return &LLMResponse{
@@ -803,6 +902,26 @@ func parseResponse(output *bedrockruntime.ConverseOutput) (*LLMResponse, error) 
 		FinishReason: finishReason,
 		Usage:        usage,
 	}, nil
+}
+
+// logCacheUsage emits a single line summarizing prompt-cache activity for the
+// turn so cache hits/writes are observable in logs. read>0 means the static
+// prefix (system + tools) was served from cache at ~0.1x input price; write>0
+// means it was (re)written this turn at ~1.25x.
+func logCacheUsage(api string, usage *UsageInfo) {
+	if usage == nil {
+		return
+	}
+	// Use the structured logger (not the std log package, whose output is not
+	// captured in deployed builds) so cache activity is visible in pod logs.
+	logger.InfoCF("provider.bedrock", "prompt cache usage", map[string]any{
+		"api":           api,
+		"input_tokens":  usage.PromptTokens,
+		"output_tokens": usage.CompletionTokens,
+		"cache_read":    usage.CacheReadTokens,
+		"cache_write":   usage.CacheWriteTokens,
+		"cache_hit":     usage.CacheReadTokens > 0,
+	})
 }
 
 // isSSOTokenError checks if the error is related to expired or invalid AWS SSO tokens.

--- a/pkg/providers/bedrock/provider_bedrock_test.go
+++ b/pkg/providers/bedrock/provider_bedrock_test.go
@@ -921,3 +921,256 @@ func TestBuildConverseParams_KeepsTemperatureForSupportedModel(t *testing.T) {
 	require.NotNil(t, params.inferenceConfig.Temperature)
 	assert.InDelta(t, 0.7, float64(*params.inferenceConfig.Temperature), 0.0001)
 }
+
+func TestModelSupportsCaching(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{"opus 4.8 inference profile", "us.anthropic.claude-opus-4-8-20260514-v1:0", true},
+		{"opus 4.7", "us.anthropic.claude-opus-4-7-20250101-v1:0", true},
+		{"sonnet 4.6", "us.anthropic.claude-sonnet-4-6", true},
+		{"haiku 4.5", "anthropic.claude-haiku-4-5", true},
+		{"claude 3.7 sonnet", "us.anthropic.claude-3-7-sonnet-20250219-v1:0", true},
+		{"claude 3.5 sonnet v2", "anthropic.claude-3-5-sonnet-20241022-v2:0", true},
+		{"claude 3 sonnet (no cache)", "anthropic.claude-3-sonnet-20240229-v1:0", false},
+		{"non-claude model", "meta.llama3-70b-instruct-v1:0", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, modelSupportsCaching(tt.model))
+		})
+	}
+}
+
+func TestConvertMessagesWithCache_SystemCachePoint(t *testing.T) {
+	messages := []Message{
+		{
+			Role:    "system",
+			Content: "static\n\ndynamic",
+			SystemParts: []protocoltypes.ContentBlock{
+				{Type: "text", Text: "static prefix", CacheControl: &protocoltypes.CacheControl{Type: "ephemeral"}},
+				{Type: "text", Text: "dynamic runtime context"}, // volatile, no cache control
+			},
+		},
+		{Role: "user", Content: "hi"},
+	}
+
+	_, systemPrompts := convertMessagesWithCache(messages, true)
+
+	// Expect: static text, cache point, dynamic text (cache point AFTER the
+	// last ephemeral block, so the dynamic part stays outside the cached prefix).
+	require.Len(t, systemPrompts, 3)
+
+	first, ok := systemPrompts[0].(*types.SystemContentBlockMemberText)
+	require.True(t, ok)
+	assert.Equal(t, "static prefix", first.Value)
+
+	_, ok = systemPrompts[1].(*types.SystemContentBlockMemberCachePoint)
+	require.True(t, ok, "cache point must follow the last ephemeral block")
+
+	third, ok := systemPrompts[2].(*types.SystemContentBlockMemberText)
+	require.True(t, ok)
+	assert.Equal(t, "dynamic runtime context", third.Value)
+}
+
+func TestConvertMessagesWithCache_NoCachePointWhenDisabled(t *testing.T) {
+	messages := []Message{
+		{
+			Role:    "system",
+			Content: "static\n\ndynamic",
+			SystemParts: []protocoltypes.ContentBlock{
+				{Type: "text", Text: "static prefix", CacheControl: &protocoltypes.CacheControl{Type: "ephemeral"}},
+			},
+		},
+	}
+
+	_, systemPrompts := convertMessagesWithCache(messages, false)
+
+	// Caching disabled: single text block from Content, no cache point.
+	require.Len(t, systemPrompts, 1)
+	text, ok := systemPrompts[0].(*types.SystemContentBlockMemberText)
+	require.True(t, ok)
+	assert.Equal(t, "static\n\ndynamic", text.Value)
+}
+
+func TestConvertMessagesWithCache_NoCachePointWithoutEphemeralPart(t *testing.T) {
+	messages := []Message{
+		{
+			Role:    "system",
+			Content: "only dynamic",
+			SystemParts: []protocoltypes.ContentBlock{
+				{Type: "text", Text: "only dynamic"}, // no cache control
+			},
+		},
+	}
+
+	_, systemPrompts := convertMessagesWithCache(messages, true)
+
+	// No ephemeral part -> no cache point (dynamic context must not anchor cache).
+	require.Len(t, systemPrompts, 1)
+	_, ok := systemPrompts[0].(*types.SystemContentBlockMemberText)
+	require.True(t, ok)
+}
+
+func TestConvertToolsWithCache_AppendsCachePoint(t *testing.T) {
+	tools := []ToolDefinition{
+		{
+			Function: protocoltypes.ToolFunctionDefinition{
+				Name:        "get_weather",
+				Description: "Get the current weather",
+			},
+		},
+	}
+
+	toolConfig := convertToolsWithCache(tools, true)
+
+	require.NotNil(t, toolConfig)
+	require.Len(t, toolConfig.Tools, 2) // tool spec + cache point
+
+	_, ok := toolConfig.Tools[0].(*types.ToolMemberToolSpec)
+	require.True(t, ok)
+	_, ok = toolConfig.Tools[1].(*types.ToolMemberCachePoint)
+	require.True(t, ok, "cache point must be appended after the tool list")
+}
+
+func TestConvertToolsWithCache_NoCachePointWhenDisabled(t *testing.T) {
+	tools := []ToolDefinition{
+		{Function: protocoltypes.ToolFunctionDefinition{Name: "get_weather"}},
+	}
+
+	toolConfig := convertToolsWithCache(tools, false)
+
+	require.Len(t, toolConfig.Tools, 1)
+	_, ok := toolConfig.Tools[0].(*types.ToolMemberToolSpec)
+	require.True(t, ok)
+}
+
+func TestConvertToolsWithCache_NoCachePointWhenEmpty(t *testing.T) {
+	// All tools skipped (empty names) -> no tools, so no cache point either.
+	tools := []ToolDefinition{
+		{Function: protocoltypes.ToolFunctionDefinition{Name: ""}},
+	}
+
+	toolConfig := convertToolsWithCache(tools, true)
+
+	assert.Empty(t, toolConfig.Tools)
+}
+
+func TestBuildConverseParams_AddsCachePointsForSupportedModel(t *testing.T) {
+	messages := []Message{
+		{
+			Role:    "system",
+			Content: "static",
+			SystemParts: []protocoltypes.ContentBlock{
+				{Type: "text", Text: "static prefix", CacheControl: &protocoltypes.CacheControl{Type: "ephemeral"}},
+			},
+		},
+		{Role: "user", Content: "hi"},
+	}
+	tools := []ToolDefinition{
+		{Function: protocoltypes.ToolFunctionDefinition{Name: "tool_a"}},
+	}
+
+	params := buildConverseParams(messages, tools, "us.anthropic.claude-sonnet-4-6", nil)
+
+	// System cache point present.
+	var sysCachePoints int
+	for _, b := range params.system {
+		if _, ok := b.(*types.SystemContentBlockMemberCachePoint); ok {
+			sysCachePoints++
+		}
+	}
+	assert.Equal(t, 1, sysCachePoints)
+
+	// Tool cache point present.
+	require.NotNil(t, params.toolConfig)
+	var toolCachePoints int
+	for _, tl := range params.toolConfig.Tools {
+		if _, ok := tl.(*types.ToolMemberCachePoint); ok {
+			toolCachePoints++
+		}
+	}
+	assert.Equal(t, 1, toolCachePoints)
+}
+
+func TestBuildConverseParams_NoCachePointsForUnsupportedModel(t *testing.T) {
+	messages := []Message{
+		{
+			Role:    "system",
+			Content: "static",
+			SystemParts: []protocoltypes.ContentBlock{
+				{Type: "text", Text: "static prefix", CacheControl: &protocoltypes.CacheControl{Type: "ephemeral"}},
+			},
+		},
+	}
+	tools := []ToolDefinition{
+		{Function: protocoltypes.ToolFunctionDefinition{Name: "tool_a"}},
+	}
+
+	params := buildConverseParams(messages, tools, "meta.llama3-70b-instruct-v1:0", nil)
+
+	for _, b := range params.system {
+		_, ok := b.(*types.SystemContentBlockMemberCachePoint)
+		assert.False(t, ok, "no system cache point for unsupported model")
+	}
+	require.NotNil(t, params.toolConfig)
+	for _, tl := range params.toolConfig.Tools {
+		_, ok := tl.(*types.ToolMemberCachePoint)
+		assert.False(t, ok, "no tool cache point for unsupported model")
+	}
+}
+
+func TestParseResponse_CacheUsage(t *testing.T) {
+	output := &bedrockruntime.ConverseOutput{
+		Output: &types.ConverseOutputMemberMessage{
+			Value: types.Message{
+				Content: []types.ContentBlock{
+					&types.ContentBlockMemberText{Value: "hi"},
+				},
+			},
+		},
+		StopReason: types.StopReasonEndTurn,
+		Usage: &types.TokenUsage{
+			InputTokens:           aws.Int32(100),
+			OutputTokens:          aws.Int32(20),
+			CacheReadInputTokens:  aws.Int32(80),
+			CacheWriteInputTokens: aws.Int32(15),
+		},
+	}
+
+	resp, err := parseResponse(output)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Usage)
+	assert.Equal(t, 80, resp.Usage.CacheReadTokens)
+	assert.Equal(t, 15, resp.Usage.CacheWriteTokens)
+}
+
+func TestParseStreamResponse_CacheUsage(t *testing.T) {
+	events := []types.ConverseStreamOutput{
+		&types.ConverseStreamOutputMemberMessageStop{
+			Value: types.MessageStopEvent{StopReason: types.StopReasonEndTurn},
+		},
+		&types.ConverseStreamOutputMemberMetadata{
+			Value: types.ConverseStreamMetadataEvent{
+				Usage: &types.TokenUsage{
+					InputTokens:           aws.Int32(100),
+					OutputTokens:          aws.Int32(20),
+					CacheReadInputTokens:  aws.Int32(80),
+					CacheWriteInputTokens: aws.Int32(15),
+				},
+			},
+		},
+	}
+
+	stream := newMockStream(events)
+	resp, err := parseStreamResponse(context.Background(), stream, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Usage)
+	assert.Equal(t, 80, resp.Usage.CacheReadTokens)
+	assert.Equal(t, 15, resp.Usage.CacheWriteTokens)
+}

--- a/pkg/providers/protocoltypes/types.go
+++ b/pkg/providers/protocoltypes/types.go
@@ -53,6 +53,13 @@ type UsageInfo struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+
+	// Prompt-cache accounting (provider prefix caching). Zero when the provider
+	// does not cache or the request had no cache activity.
+	//   CacheReadTokens  — input tokens served from cache (~0.1x input price)
+	//   CacheWriteTokens — input tokens written to cache this request (~1.25x)
+	CacheReadTokens  int `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
 }
 
 // CacheControl marks a content block for LLM-side prefix caching.


### PR DESCRIPTION
## Summary

AWS Bedrock's Converse API supports [prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) via explicit **cache points** in `system`, `tools`, and `messages` — everything up to a cache point is cached as a prefix (reads bill at ~0.1× input, writes at ~1.25×).

The agent runtime already produces the breakpoint metadata (`Message.SystemParts` carrying `CacheControl{Type:"ephemeral"}`), and the Anthropic provider already consumes it — but the Bedrock adapter discarded it entirely. This PR has the Bedrock adapter honor that existing convention, behind a model-capability guard.

## Changes

- **System prompt caching** — `convertMessages` now reads structured `SystemParts`: each part becomes its own `SystemContentBlockMemberText`, and a cache point is inserted **after the last `ephemeral` part**. The stable prefix (identity, tool docs, skills, memory) is cached; volatile trailing parts (time, session, summary) stay outside the cached region. If no part is `ephemeral`, no cache point is emitted — so per-request dynamic context never anchors the cache.
- **Tool-schema caching** — a cache point is appended after the tool list (large, identical every turn). Omitted when no tools survive name validation.
- **Cache-usage reporting** — new additive `CacheReadTokens` / `CacheWriteTokens` fields on `UsageInfo`, populated from Bedrock's `CacheReadInputTokens` / `CacheWriteInputTokens` in both `Converse` and `ConverseStream`. Other providers leave them zero.

## Capability guard

`modelSupportsCaching` gates everything to cache-enabled Claude families on Bedrock (3.5 v2, 3.7, 4.x). Unsupported and non-Claude models keep the original behavior with zero cache points, avoiding `ValidationException`. Max 2 cache points per request (system + tools), well under Bedrock's limit of 4. Caching is fully opt-in by model and changes nothing for existing configurations.

## Testing

`go test -tags bedrock ./pkg/providers/bedrock/` — existing suite plus 11 new tests covering the capability guard, system/tool cache-point placement, the no-ephemeral / disabled / empty cases, and cache-usage parsing for both streaming and non-streaming paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)