### PR TITLE
fix(openai_compat): recover Seed XML tool calls

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -631,6 +631,7 @@ func parseStreamResponse(
 	var reasoningDetails []ReasoningDetail
 	var finishReason string
 	var usage *UsageInfo
+	seedToolCallStreamingContent := false
 
 	// Tool call assembly: OpenAI streams tool calls as incremental deltas
 	type toolAccum struct {
@@ -703,7 +704,14 @@ func parseStreamResponse(
 		if choice.Delta.Content != "" {
 			textContent.WriteString(choice.Delta.Content)
 			if onChunk != nil {
-				onChunk(StreamChunk{Content: textContent.String()})
+				if visible, seedStarted := stripSeedToolCallStart(textContent.String()); !seedStarted {
+					onChunk(StreamChunk{Content: visible})
+				} else if !seedToolCallStreamingContent && strings.TrimSpace(visible) != "" {
+					onChunk(StreamChunk{Content: visible})
+					seedToolCallStreamingContent = true
+				} else {
+					seedToolCallStreamingContent = true
+				}
 			}
 		}
 
@@ -892,6 +900,14 @@ func parseSeedToolCallsFromContent(content string) ([]ToolCall, string) {
 	}
 
 	return toolCalls, strings.TrimSpace(sb.String())
+}
+
+func stripSeedToolCallStart(content string) (string, bool) {
+	start := strings.Index(content, "<seed")
+	if start < 0 {
+		return content, false
+	}
+	return strings.TrimSpace(content[:start]), true
 }
 
 // xmlSeedFunction mirrors the inner XML structure of a <seed:tool_call> block.

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"maps"
@@ -160,9 +161,11 @@ func (p *Provider) buildRequestBody(
 		// treat it as false — web_search_preview must not be injected
 		// when the caller cannot express a well-typed intent.
 		if _, present := options["native_search"]; present {
-			log.Printf(
-				"[openai_compat] native_search option has unexpected type %T, ignoring",
-				options["native_search"],
+			logger.WarnCF("provider.openai_compat",
+				"native_search option has unexpected type, ignoring",
+				map[string]any{
+					"type": fmt.Sprintf("%T", options["native_search"]),
+				},
 			)
 		}
 	}
@@ -496,7 +499,11 @@ func (p *Provider) Chat(
 		return nil, common.HandleErrorResponse(resp, p.apiBase)
 	}
 
-	return common.ReadAndParseResponse(resp, p.apiBase)
+	result, err := common.ReadAndParseResponse(resp, p.apiBase)
+	if err != nil {
+		return nil, err
+	}
+	return extractSeedToolCalls(result), nil
 }
 
 // ChatStream implements streaming via OpenAI-compatible SSE (stream: true).
@@ -572,7 +579,11 @@ func (p *Provider) ChatStreamEvents(
 		return nil, common.HandleErrorResponse(resp, p.apiBase)
 	}
 
-	return parseStreamResponse(ctx, withStreamingReadIdleTimeout(resp.Body, defaultStreamingReadIdleTimeout), onChunk)
+	result, err := parseStreamResponse(ctx, withStreamingReadIdleTimeout(resp.Body, defaultStreamingReadIdleTimeout), onChunk)
+	if err != nil {
+		return nil, err
+	}
+	return extractSeedToolCalls(result), nil
 }
 
 func withStreamingReadIdleTimeout(body io.ReadCloser, timeout time.Duration) io.ReadCloser {
@@ -807,6 +818,114 @@ func parseStreamResponse(
 		FinishReason:     finishReason,
 		Usage:            usage,
 	}, nil
+}
+
+// extractSeedToolCalls checks resp.Content for Volcengine Doubao Seed-style
+// <seed:tool_call>...</seed:tool_call> blocks that the model leaks into the
+// message content instead of using the standard OpenAI tool_calls field.
+// When standard tool_calls are absent and at least one seed block is found,
+// it strips the XML from Content, populates ToolCalls, and sets FinishReason
+// to "tool_calls". Malformed XML is left as normal content (no error returned).
+func extractSeedToolCalls(resp *LLMResponse) *LLMResponse {
+	if resp == nil || len(resp.ToolCalls) > 0 {
+		return resp
+	}
+	if !strings.Contains(resp.Content, "<seed:tool_call>") {
+		return resp
+	}
+	toolCalls, cleanContent := parseSeedToolCallsFromContent(resp.Content)
+	if len(toolCalls) == 0 {
+		return resp
+	}
+	clone := *resp
+	clone.Content = cleanContent
+	clone.ToolCalls = toolCalls
+	if clone.FinishReason == "" || clone.FinishReason == "stop" {
+		clone.FinishReason = "tool_calls"
+	}
+	return &clone
+}
+
+const (
+	seedOpenTag  = "<seed:tool_call>"
+	seedCloseTag = "</seed:tool_call>"
+)
+
+// parseSeedToolCallsFromContent extracts all <seed:tool_call> blocks from
+// content, parses them into ToolCalls, and returns the calls alongside a
+// version of the content with those blocks removed (surrounding whitespace
+// trimmed).  Unparseable blocks are kept as-is in the returned content.
+func parseSeedToolCallsFromContent(content string) ([]ToolCall, string) {
+	var toolCalls []ToolCall
+	var sb strings.Builder
+	remaining := content
+
+	for {
+		start := strings.Index(remaining, seedOpenTag)
+		if start < 0 {
+			sb.WriteString(remaining)
+			break
+		}
+		end := strings.Index(remaining[start:], seedCloseTag)
+		if end < 0 {
+			// No closing tag: treat everything from here as plain content.
+			sb.WriteString(remaining)
+			break
+		}
+		end += start // absolute index of "</seed:tool_call>" in remaining
+
+		// Append content before the block (trim trailing whitespace).
+		sb.WriteString(strings.TrimRight(remaining[:start], " \t\r\n"))
+
+		inner := remaining[start+len(seedOpenTag) : end]
+		remaining = remaining[end+len(seedCloseTag):]
+
+		tc, ok := parseSeedFunctionXML(inner, len(toolCalls))
+		if !ok {
+			// Malformed inner XML: keep original block intact.
+			sb.WriteString(seedOpenTag)
+			sb.WriteString(inner)
+			sb.WriteString(seedCloseTag)
+			continue
+		}
+		toolCalls = append(toolCalls, tc)
+	}
+
+	return toolCalls, strings.TrimSpace(sb.String())
+}
+
+// xmlSeedFunction mirrors the inner XML structure of a <seed:tool_call> block.
+type xmlSeedFunction struct {
+	XMLName    xml.Name       `xml:"function"`
+	Name       string         `xml:"name,attr"`
+	Parameters []xmlSeedParam `xml:"parameter"`
+}
+
+type xmlSeedParam struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:",chardata"`
+}
+
+// parseSeedFunctionXML parses the <function> element inside a <seed:tool_call>
+// block and returns a ToolCall.  idx is used to build a unique synthetic call ID.
+// Returns (zero, false) if the XML is malformed or missing a function name.
+func parseSeedFunctionXML(inner string, idx int) (ToolCall, bool) {
+	var fn xmlSeedFunction
+	if err := xml.Unmarshal([]byte(strings.TrimSpace(inner)), &fn); err != nil {
+		return ToolCall{}, false
+	}
+	if fn.Name == "" {
+		return ToolCall{}, false
+	}
+	args := make(map[string]any, len(fn.Parameters))
+	for _, p := range fn.Parameters {
+		args[p.Name] = strings.TrimSpace(p.Value)
+	}
+	return ToolCall{
+		ID:        fmt.Sprintf("seed_tc_%d", idx),
+		Name:      fn.Name,
+		Arguments: args,
+	}, true
 }
 
 func normalizeModel(model, apiBase string) string {

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -579,7 +579,11 @@ func (p *Provider) ChatStreamEvents(
 		return nil, common.HandleErrorResponse(resp, p.apiBase)
 	}
 
-	result, err := parseStreamResponse(ctx, withStreamingReadIdleTimeout(resp.Body, defaultStreamingReadIdleTimeout), onChunk)
+	result, err := parseStreamResponse(
+		ctx,
+		withStreamingReadIdleTimeout(resp.Body, defaultStreamingReadIdleTimeout),
+		onChunk,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -2436,13 +2436,24 @@ func TestProviderChatStream_SeedToolCallsExtractedFromContent(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{\"content\":%s}}]}\n\n", jsonStr(part1))
-		fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{\"content\":%s},\"finish_reason\":\"stop\"}]}\n\n", jsonStr(part2))
+		fmt.Fprintf(
+			w,
+			"data: {\"choices\":[{\"delta\":{\"content\":%s},\"finish_reason\":\"stop\"}]}\n\n",
+			jsonStr(part2),
+		)
 		fmt.Fprint(w, "data: [DONE]\n\n")
 	}))
 	defer server.Close()
 
 	p := NewProvider("key", server.URL, "")
-	out, err := p.ChatStream(t.Context(), []Message{{Role: "user", Content: "weather?"}}, nil, "doubao-seed-1-6-250528", nil, nil)
+	out, err := p.ChatStream(
+		t.Context(),
+		[]Message{{Role: "user", Content: "weather?"}},
+		nil,
+		"doubao-seed-1-6-250528",
+		nil,
+		nil,
+	)
 	if err != nil {
 		t.Fatalf("ChatStream() error = %v", err)
 	}

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -2196,3 +2196,269 @@ func TestSerializeMessages_StripsSystemParts(t *testing.T) {
 		t.Fatal("system_parts should not appear in serialized output")
 	}
 }
+
+// --- Volcengine Doubao Seed <seed:tool_call> XML extraction tests ---
+
+const seedToolCallSample = `<seed:tool_call>
+<function name="get_weather">
+<parameter name="city" string="true">Beijing</parameter>
+</function>
+</seed:tool_call>`
+
+func TestParseSeedToolCallsFromContent_BasicExtraction(t *testing.T) {
+	content := "I'll check the weather for you.\n" + seedToolCallSample
+	toolCalls, cleaned := parseSeedToolCallsFromContent(content)
+
+	if len(toolCalls) != 1 {
+		t.Fatalf("len(toolCalls) = %d, want 1", len(toolCalls))
+	}
+	tc := toolCalls[0]
+	if tc.Name != "get_weather" {
+		t.Fatalf("Name = %q, want %q", tc.Name, "get_weather")
+	}
+	if tc.Arguments["city"] != "Beijing" {
+		t.Fatalf("Arguments[city] = %v, want %q", tc.Arguments["city"], "Beijing")
+	}
+	if tc.ID != "seed_tc_0" {
+		t.Fatalf("ID = %q, want %q", tc.ID, "seed_tc_0")
+	}
+	if strings.Contains(cleaned, "<seed:tool_call>") {
+		t.Fatalf("cleaned content still contains seed:tool_call block: %q", cleaned)
+	}
+}
+
+func TestParseSeedToolCallsFromContent_ContentBeforeAndAfter(t *testing.T) {
+	content := "Calling weather API now.\n" + seedToolCallSample + "\nDone."
+	_, cleaned := parseSeedToolCallsFromContent(content)
+
+	if strings.Contains(cleaned, "<seed:tool_call>") {
+		t.Fatalf("cleaned content still contains seed:tool_call block: %q", cleaned)
+	}
+	if !strings.Contains(cleaned, "Calling weather API now.") {
+		t.Fatalf("cleaned content should contain prefix text, got: %q", cleaned)
+	}
+	if !strings.Contains(cleaned, "Done.") {
+		t.Fatalf("cleaned content should contain suffix text, got: %q", cleaned)
+	}
+}
+
+func TestParseSeedToolCallsFromContent_MultipleParameters(t *testing.T) {
+	content := `<seed:tool_call>
+<function name="search">
+<parameter name="query" string="true">golang XML</parameter>
+<parameter name="limit" string="true">10</parameter>
+</function>
+</seed:tool_call>`
+	toolCalls, cleaned := parseSeedToolCallsFromContent(content)
+
+	if len(toolCalls) != 1 {
+		t.Fatalf("len(toolCalls) = %d, want 1", len(toolCalls))
+	}
+	if toolCalls[0].Arguments["query"] != "golang XML" {
+		t.Fatalf("query = %v, want %q", toolCalls[0].Arguments["query"], "golang XML")
+	}
+	if toolCalls[0].Arguments["limit"] != "10" {
+		t.Fatalf("limit = %v, want %q", toolCalls[0].Arguments["limit"], "10")
+	}
+	if cleaned != "" {
+		t.Fatalf("cleaned = %q, want empty string", cleaned)
+	}
+}
+
+func TestParseSeedToolCallsFromContent_MultipleToolCalls(t *testing.T) {
+	content := `<seed:tool_call>
+<function name="get_weather">
+<parameter name="city" string="true">Shanghai</parameter>
+</function>
+</seed:tool_call>
+<seed:tool_call>
+<function name="get_time">
+<parameter name="timezone" string="true">Asia/Shanghai</parameter>
+</function>
+</seed:tool_call>`
+	toolCalls, _ := parseSeedToolCallsFromContent(content)
+
+	if len(toolCalls) != 2 {
+		t.Fatalf("len(toolCalls) = %d, want 2", len(toolCalls))
+	}
+	if toolCalls[0].Name != "get_weather" {
+		t.Fatalf("toolCalls[0].Name = %q, want %q", toolCalls[0].Name, "get_weather")
+	}
+	if toolCalls[1].Name != "get_time" {
+		t.Fatalf("toolCalls[1].Name = %q, want %q", toolCalls[1].Name, "get_time")
+	}
+	if toolCalls[0].ID != "seed_tc_0" {
+		t.Fatalf("toolCalls[0].ID = %q, want %q", toolCalls[0].ID, "seed_tc_0")
+	}
+	if toolCalls[1].ID != "seed_tc_1" {
+		t.Fatalf("toolCalls[1].ID = %q, want %q", toolCalls[1].ID, "seed_tc_1")
+	}
+}
+
+func TestParseSeedToolCallsFromContent_MalformedXMLKeptAsContent(t *testing.T) {
+	malformed := "<seed:tool_call><not-valid-xml</seed:tool_call>"
+	toolCalls, cleaned := parseSeedToolCallsFromContent(malformed)
+
+	if len(toolCalls) != 0 {
+		t.Fatalf("len(toolCalls) = %d, want 0 for malformed XML", len(toolCalls))
+	}
+	if !strings.Contains(cleaned, "<seed:tool_call>") {
+		t.Fatalf("malformed block should be kept in content, got: %q", cleaned)
+	}
+}
+
+func TestParseSeedToolCallsFromContent_MissingCloseTagKeptAsContent(t *testing.T) {
+	content := "text <seed:tool_call><function name=\"f\"></function>"
+	toolCalls, cleaned := parseSeedToolCallsFromContent(content)
+
+	if len(toolCalls) != 0 {
+		t.Fatalf("len(toolCalls) = %d, want 0 for missing close tag", len(toolCalls))
+	}
+	if !strings.Contains(cleaned, "<seed:tool_call>") {
+		t.Fatalf("content with missing close tag should be kept intact, got: %q", cleaned)
+	}
+}
+
+func TestParseSeedToolCallsFromContent_NoSeedTag(t *testing.T) {
+	content := "plain text response with no tool calls"
+	toolCalls, cleaned := parseSeedToolCallsFromContent(content)
+
+	if len(toolCalls) != 0 {
+		t.Fatalf("len(toolCalls) = %d, want 0", len(toolCalls))
+	}
+	if cleaned != content {
+		t.Fatalf("cleaned = %q, want unchanged %q", cleaned, content)
+	}
+}
+
+func TestExtractSeedToolCalls_NilSafe(t *testing.T) {
+	if got := extractSeedToolCalls(nil); got != nil {
+		t.Fatalf("extractSeedToolCalls(nil) = %v, want nil", got)
+	}
+}
+
+func TestExtractSeedToolCalls_SkipsWhenStandardToolCallsPresent(t *testing.T) {
+	resp := &LLMResponse{
+		Content: seedToolCallSample,
+		ToolCalls: []ToolCall{
+			{ID: "call_1", Name: "existing_tool", Arguments: map[string]any{"x": "y"}},
+		},
+		FinishReason: "tool_calls",
+	}
+	got := extractSeedToolCalls(resp)
+	if len(got.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1 (standard calls must not be replaced)", len(got.ToolCalls))
+	}
+	if got.ToolCalls[0].Name != "existing_tool" {
+		t.Fatalf("ToolCalls[0].Name = %q, want existing_tool", got.ToolCalls[0].Name)
+	}
+}
+
+func TestExtractSeedToolCalls_SetsFinishReason(t *testing.T) {
+	resp := &LLMResponse{
+		Content:      seedToolCallSample,
+		FinishReason: "stop",
+	}
+	got := extractSeedToolCalls(resp)
+	if got.FinishReason != "tool_calls" {
+		t.Fatalf("FinishReason = %q, want %q", got.FinishReason, "tool_calls")
+	}
+}
+
+func TestExtractSeedToolCalls_PreservesNonStopFinishReason(t *testing.T) {
+	resp := &LLMResponse{
+		Content:      seedToolCallSample,
+		FinishReason: "truncated",
+	}
+	got := extractSeedToolCalls(resp)
+	// FinishReason other than "stop"/"" must not be overwritten.
+	if got.FinishReason != "truncated" {
+		t.Fatalf("FinishReason = %q, want %q (non-stop reason must be preserved)", got.FinishReason, "truncated")
+	}
+}
+
+func TestProviderChat_SeedToolCallsExtractedFromContent(t *testing.T) {
+	// Simulate a Volcengine Doubao Seed response where tool calls leak into
+	// the content field instead of using the standard tool_calls field.
+	sampleContent := "Checking the weather for you.\n" + seedToolCallSample
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{
+					"message": map[string]any{
+						"content": sampleContent,
+						// tool_calls deliberately absent — Seed leaks XML into content
+					},
+					"finish_reason": "stop",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	out, err := p.Chat(t.Context(), []Message{{Role: "user", Content: "What's the weather in Beijing?"}}, nil, "doubao-seed-1-6-250528", nil)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(out.ToolCalls))
+	}
+	if out.ToolCalls[0].Name != "get_weather" {
+		t.Fatalf("ToolCalls[0].Name = %q, want %q", out.ToolCalls[0].Name, "get_weather")
+	}
+	if out.ToolCalls[0].Arguments["city"] != "Beijing" {
+		t.Fatalf("ToolCalls[0].Arguments[city] = %v, want %q", out.ToolCalls[0].Arguments["city"], "Beijing")
+	}
+	if strings.Contains(out.Content, "<seed:tool_call>") {
+		t.Fatalf("Content must not contain raw <seed:tool_call> XML, got: %q", out.Content)
+	}
+	if out.FinishReason != "tool_calls" {
+		t.Fatalf("FinishReason = %q, want %q", out.FinishReason, "tool_calls")
+	}
+}
+
+func TestProviderChatStream_SeedToolCallsExtractedFromContent(t *testing.T) {
+	// Same issue in the streaming path: Seed leaks XML across SSE chunks.
+	part1 := "Checking the weather.\n<seed:tool_call>\n<function name=\"get_weather\">\n<parameter name=\"city\" string=\"true\">"
+	part2 := "Shanghai</parameter>\n</function>\n</seed:tool_call>"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{\"content\":%s}}]}\n\n", jsonStr(part1))
+		fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{\"content\":%s},\"finish_reason\":\"stop\"}]}\n\n", jsonStr(part2))
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	out, err := p.ChatStream(t.Context(), []Message{{Role: "user", Content: "weather?"}}, nil, "doubao-seed-1-6-250528", nil, nil)
+	if err != nil {
+		t.Fatalf("ChatStream() error = %v", err)
+	}
+
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(out.ToolCalls))
+	}
+	if out.ToolCalls[0].Name != "get_weather" {
+		t.Fatalf("ToolCalls[0].Name = %q, want %q", out.ToolCalls[0].Name, "get_weather")
+	}
+	if out.ToolCalls[0].Arguments["city"] != "Shanghai" {
+		t.Fatalf("ToolCalls[0].Arguments[city] = %v, want %q", out.ToolCalls[0].Arguments["city"], "Shanghai")
+	}
+	if strings.Contains(out.Content, "<seed:tool_call>") {
+		t.Fatalf("Content must not contain raw <seed:tool_call> XML, got: %q", out.Content)
+	}
+	if out.FinishReason != "tool_calls" {
+		t.Fatalf("FinishReason = %q, want %q", out.FinishReason, "tool_calls")
+	}
+}
+
+// jsonStr returns s as a JSON-quoted string literal (for inline SSE event construction).
+func jsonStr(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -2482,7 +2482,11 @@ func TestProviderChatStreamEvents_SeedToolCallsNotEmittedInChunks(t *testing.T) 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{\"content\":%s}}]}\n\n", jsonStr(part1))
-		fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{\"content\":%s},\"finish_reason\":\"stop\"}]}\n\n", jsonStr(part2))
+		fmt.Fprintf(
+			w,
+			"data: {\"choices\":[{\"delta\":{\"content\":%s},\"finish_reason\":\"stop\"}]}\n\n",
+			jsonStr(part2),
+		)
 		fmt.Fprint(w, "data: [DONE]\n\n")
 	}))
 	defer server.Close()

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -2400,7 +2400,13 @@ func TestProviderChat_SeedToolCallsExtractedFromContent(t *testing.T) {
 	defer server.Close()
 
 	p := NewProvider("key", server.URL, "")
-	out, err := p.Chat(t.Context(), []Message{{Role: "user", Content: "What's the weather in Beijing?"}}, nil, "doubao-seed-1-6-250528", nil)
+	out, err := p.Chat(
+		t.Context(),
+		[]Message{{Role: "user", Content: "What's the weather in Beijing?"}},
+		nil,
+		"doubao-seed-1-6-250528",
+		nil,
+	)
 	if err != nil {
 		t.Fatalf("Chat() error = %v", err)
 	}

--- a/pkg/providers/openai_compat/provider_test.go
+++ b/pkg/providers/openai_compat/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -2454,6 +2455,48 @@ func TestProviderChatStream_SeedToolCallsExtractedFromContent(t *testing.T) {
 	}
 	if out.FinishReason != "tool_calls" {
 		t.Fatalf("FinishReason = %q, want %q", out.FinishReason, "tool_calls")
+	}
+}
+
+func TestProviderChatStreamEvents_SeedToolCallsNotEmittedInChunks(t *testing.T) {
+	part1 := "Checking the weather.\n<seed:tool_call>\n<function name=\"get_weather\">\n<parameter name=\"city\" string=\"true\">"
+	part2 := "Shanghai</parameter>\n</function>\n</seed:tool_call>"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{\"content\":%s}}]}\n\n", jsonStr(part1))
+		fmt.Fprintf(w, "data: {\"choices\":[{\"delta\":{\"content\":%s},\"finish_reason\":\"stop\"}]}\n\n", jsonStr(part2))
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	p := NewProvider("key", server.URL, "")
+	var chunks []string
+	out, err := p.ChatStreamEvents(
+		t.Context(),
+		[]Message{{Role: "user", Content: "weather?"}},
+		nil,
+		"doubao-seed-1-6-250528",
+		nil,
+		func(chunk StreamChunk) {
+			if chunk.Content != "" {
+				chunks = append(chunks, chunk.Content)
+			}
+		},
+	)
+	if err != nil {
+		t.Fatalf("ChatStreamEvents() error = %v", err)
+	}
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(out.ToolCalls))
+	}
+	for _, chunk := range chunks {
+		if strings.Contains(chunk, "<seed:tool_call>") || strings.Contains(chunk, "</seed:tool_call>") {
+			t.Fatalf("stream chunk leaked seed tool call XML: %q", chunk)
+		}
+	}
+	if got, want := chunks, []string{"Checking the weather."}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("chunks = %#v, want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- recover Volcengine Doubao Seed `<seed:tool_call>` XML blocks from OpenAI-compatible response content as structured tool calls
- strip recovered Seed tool-call XML from user-visible content
- suppress leaked Seed XML from streaming chunks while preserving final tool-call extraction

## Verification
- `go test ./pkg/providers/openai_compat -run 'Seed|ToolCalls'`
- `go test ./pkg/providers/openai_compat`
- `git diff --check`

Fixes #3153