### PR TITLE
fix(openai_compat): use structured logger for native_search warning

### DIFF
--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -160,9 +160,12 @@ func (p *Provider) buildRequestBody(
 		// treat it as false — web_search_preview must not be injected
 		// when the caller cannot express a well-typed intent.
 		if _, present := options["native_search"]; present {
-			log.Printf(
-				"[openai_compat] native_search option has unexpected type %T, ignoring",
-				options["native_search"],
+			logger.WarnCF(
+				"provider.openai_compat",
+				"native_search option has unexpected type, ignoring",
+				map[string]any{
+					"type": fmt.Sprintf("%T", options["native_search"]),
+				},
 			)
 		}
 	}


### PR DESCRIPTION
## Summary
- replace the stray `log.Printf` call in `openai_compat` with the package's existing structured logger
- fixes the current `undefined: log` build failure in `pkg/providers/openai_compat`

## Verification
- `go test ./pkg/providers/openai_compat`
- `git diff --check`
- 81 remote: `GOPROXY=https://proxy.golang.org,direct go test ./pkg/providers/openai_compat`