### PR TITLE
fix(model): handle error response read failures

### DIFF
--- a/cmd/picoclaw/internal/model/add_test.go
+++ b/cmd/picoclaw/internal/model/add_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -66,6 +67,21 @@ func TestFetchOpenAIModels_HTTPError(t *testing.T) {
 	_, err := fetchOpenAIModels(srv.URL, "bad")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTP 401")
+}
+
+func TestFetchOpenAIModels_HTTPErrorReadFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		body := "short"
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)+1))
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	_, err := fetchOpenAIModels(srv.URL, "bad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read error response")
+	assert.Contains(t, err.Error(), "unexpected EOF")
 }
 
 func TestFetchOpenAIModels_EmptyDataEnvelope(t *testing.T) {

--- a/cmd/picoclaw/internal/model/online.go
+++ b/cmd/picoclaw/internal/model/online.go
@@ -45,9 +45,9 @@ func fetchOpenAIModels(baseURL, apiKey string) ([]modelEntry, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(io.LimitReader(resp.Body, 512))
-		if err != nil {
-			return nil, fmt.Errorf("read error response: %w", err)
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))
+		if readErr != nil {
+			return nil, fmt.Errorf("read error response: %w", readErr)
 		}
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}

--- a/cmd/picoclaw/internal/model/online.go
+++ b/cmd/picoclaw/internal/model/online.go
@@ -45,7 +45,10 @@ func fetchOpenAIModels(baseURL, apiKey string) ([]modelEntry, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 512))
+		if err != nil {
+			return nil, fmt.Errorf("read error response: %w", err)
+		}
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -160,9 +160,12 @@ func (p *Provider) buildRequestBody(
 		// treat it as false — web_search_preview must not be injected
 		// when the caller cannot express a well-typed intent.
 		if _, present := options["native_search"]; present {
-			log.Printf(
-				"[openai_compat] native_search option has unexpected type %T, ignoring",
-				options["native_search"],
+			logger.WarnCF(
+				"provider.openai_compat",
+				"native_search option has unexpected type, ignoring",
+				map[string]any{
+					"type": fmt.Sprintf("%T", options["native_search"]),
+				},
 			)
 		}
 	}


### PR DESCRIPTION
## Summary
- Return the body read error when fetching OpenAI-compatible model lists receives a non-200 response but the error body cannot be read.
- Avoid reporting an empty or misleading HTTP error when the response stream fails.
- Add a regression test using a truncated HTTP error response.

## Stacking note
This PR is temporarily stacked on #3166 because the current `origin/main` fails the PR workflow test command with `pkg/providers/openai_compat/provider.go:163:4: undefined: log`. Once #3166 lands, I will rebase this branch and drop the base commit from this PR.

## Test plan
- `go test ./cmd/picoclaw/internal/model -run 'FetchOpenAIModels_HTTPError|FetchOpenAIModels_HTTPErrorReadFailure'`

## Notes
- `go test ./cmd/picoclaw/internal/model` was also attempted on both this branch and the #3166 base. In this root-run local environment it fails before this change on `TestSetDefaultModel_SaveConfigError` because `/nonexistent/directory/config.json` is writable, so that full-package failure is baseline/environment-specific.