### PR TITLE
fix(evolution): skip cold path for heartbeat turns

### DIFF
--- a/pkg/agent/evolution_bridge.go
+++ b/pkg/agent/evolution_bridge.go
@@ -202,6 +202,9 @@ func (b *evolutionBridge) handleTurnEndAsync(meta EventMeta, payload TurnEndPayl
 		FinalSuccessfulPath:   append([]string(nil), payload.FinalSuccessfulPath...),
 		SkillContextSnapshots: toEvolutionSkillContextSnapshots(payload.SkillContextSnapshots),
 	}
+	if isEvolutionHeartbeatInput(input) {
+		return false
+	}
 	b.rememberScheduledColdPathWorkspace(input.Workspace)
 
 	b.closeMu.Lock()
@@ -226,6 +229,10 @@ func (b *evolutionBridge) handleTurnEndAsync(meta EventMeta, payload TurnEndPayl
 		}
 	}()
 	return true
+}
+
+func isEvolutionHeartbeatInput(input evolution.TurnCaseInput) bool {
+	return strings.EqualFold(strings.TrimSpace(input.SessionKey), "heartbeat")
 }
 
 func (b *evolutionBridge) subscribeRuntimeEvents(ch runtimeevents.EventChannel) error {

--- a/pkg/agent/evolution_bridge_test.go
+++ b/pkg/agent/evolution_bridge_test.go
@@ -513,6 +513,31 @@ func TestEvolutionBridge_DraftModeAutomaticallyRunsColdPathAndCreatesDraftFile(t
 	waitForDrafts(t, filepath.Join(tmpDir, "state", "evolution", "skill-drafts.json"), 1)
 }
 
+func TestEvolutionBridge_DraftModeDoesNotRunColdPathForHeartbeat(t *testing.T) {
+	tmpDir := t.TempDir()
+	seedReadyRule(t, tmpDir)
+
+	al := newEvolutionTestLoop(t, tmpDir, config.EvolutionConfig{
+		Enabled: true,
+		Mode:    "draft",
+	}, &simpleMockProvider{
+		response: `{"target_skill_name":"weather","draft_type":"shortcut","change_kind":"append","human_summary":"unexpected heartbeat draft","body_or_patch":"## Unexpected"}`,
+	})
+	defer al.Close()
+
+	resp, err := al.ProcessHeartbeat(context.Background(), "check heartbeat tasks", "telegram", "chat-1")
+	if err != nil {
+		t.Fatalf("ProcessHeartbeat failed: %v", err)
+	}
+	if resp == "" {
+		t.Fatal("expected non-empty heartbeat response")
+	}
+
+	time.Sleep(150 * time.Millisecond)
+	assertNotExists(t, filepath.Join(tmpDir, "state", "evolution", "task-records.jsonl"))
+	assertNotExists(t, filepath.Join(tmpDir, "state", "evolution", "skill-drafts.json"))
+}
+
 func TestEvolutionBridge_ScheduledModeDoesNotRunColdPathAfterTurn(t *testing.T) {
 	tmpDir := t.TempDir()
 	seedReadyRule(t, tmpDir)

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -160,9 +160,12 @@ func (p *Provider) buildRequestBody(
 		// treat it as false — web_search_preview must not be injected
 		// when the caller cannot express a well-typed intent.
 		if _, present := options["native_search"]; present {
-			log.Printf(
-				"[openai_compat] native_search option has unexpected type %T, ignoring",
-				options["native_search"],
+			logger.WarnCF(
+				"provider.openai_compat",
+				"native_search option has unexpected type, ignoring",
+				map[string]any{
+					"type": fmt.Sprintf("%T", options["native_search"]),
+				},
 			)
 		}
 	}


### PR DESCRIPTION
## Summary
- Skip evolution cold-path scheduling for heartbeat turns.
- Prevent draft-mode evolution from spending tokens on periodic heartbeat checks.
- Add a regression test covering `ProcessHeartbeat` with evolution draft mode enabled.

## Stacking note
This PR is temporarily stacked on #3166 because the current `origin/main` fails the PR workflow test command with `pkg/providers/openai_compat/provider.go:163:4: undefined: log`. Once #3166 lands, I will rebase this branch and drop the base commit from this PR.

## Test plan
- `go test ./pkg/agent -run 'EvolutionBridge_DraftModeDoesNotRunColdPathForHeartbeat|ProcessHeartbeat'`

## Notes
- `go test ./pkg/agent` was attempted locally, but this environment produced unrelated existing integration-style failures/log-heavy LLM retry paths outside this focused change.
- Fixes #3012.