### PR TITLE
fix(agent): close base64 encoder on io.Copy error path

### DIFF
--- a/pkg/agent/agent_media.go
+++ b/pkg/agent/agent_media.go
@@ -172,14 +172,22 @@ func encodeImageToDataURL(localPath, mime string, info os.FileInfo, maxSize int)
 	buf.WriteString(prefix)
 
 	encoder := base64.NewEncoder(base64.StdEncoding, &buf)
-	if _, err := io.Copy(encoder, f); err != nil {
+	_, copyErr := io.Copy(encoder, f)
+	closeErr := encoder.Close()
+	if copyErr != nil {
 		logger.WarnCF("agent", "Failed to encode media file", map[string]any{
 			"path":  localPath,
-			"error": err.Error(),
+			"error": copyErr.Error(),
 		})
 		return ""
 	}
-	encoder.Close()
+	if closeErr != nil {
+		logger.WarnCF("agent", "Failed to close base64 encoder", map[string]any{
+			"path":  localPath,
+			"error": closeErr.Error(),
+		})
+		return ""
+	}
 
 	return buf.String()
 }


### PR DESCRIPTION
## Description

Previously when `io.Copy` to the base64 encoder failed, `encoder.Close()` was skipped entirely. This left the encoder's internal buffer unflushed and could cause resource leaks.

This fix:
- Always calls `encoder.Close()` immediately after `io.Copy`, regardless of success or failure
- Handles both `copyErr` and `closeErr` explicitly with separate log messages
- Returns early on either error to prevent using incomplete data

## Type of Change

- [x] Bug fix

## AI Code Generation

- [x] 🛠️ Mostly AI-generated — AI produced the draft; contributor reviewed and validated

## Test Environment

- OS: Windows 11
- Go: 1.25
- Verification: `go build ./pkg/agent/` passed, `go vet ./pkg/agent/` clean

## Checklist

- [x] I have read and understand every line of the generated code
- [x] I have tested the change locally
- [x] The change passes `go build` and `go vet`
- [x] This is a focused, single-issue fix