### PR TITLE
fix(line): add ok checks for sync.Map type assertions in Send

### DIFF
--- a/pkg/channels/line/line.go
+++ b/pkg/channels/line/line.go
@@ -465,7 +465,9 @@ func (c *LINEChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]stri
 	// Load and consume quote token for this chat
 	var quoteToken string
 	if qt, ok := c.quoteTokens.LoadAndDelete(msg.ChatID); ok {
-		quoteToken = qt.(string)
+		if s, ok := qt.(string); ok {
+			quoteToken = s
+		}
 	}
 
 	textMsg := messaging_api.TextMessage{
@@ -475,8 +477,10 @@ func (c *LINEChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]stri
 
 	// Try reply token first (free, valid for ~25 seconds)
 	if entry, ok := c.replyTokens.LoadAndDelete(msg.ChatID); ok {
-		tokenEntry := entry.(replyTokenEntry)
-		if time.Since(tokenEntry.timestamp) < lineReplyTokenMaxAge {
+		tokenEntry, ok := entry.(replyTokenEntry)
+		if !ok {
+			// Unexpected type; skip reply path and fall through to Push API.
+		} else if time.Since(tokenEntry.timestamp) < lineReplyTokenMaxAge {
 			resp, _, err := c.client.WithContext(ctx).ReplyMessageWithHttpInfo(&messaging_api.ReplyMessageRequest{
 				ReplyToken: tokenEntry.token,
 				Messages:   []messaging_api.MessageInterface{&textMsg},


### PR DESCRIPTION
## Description

Add `ok` checks for `sync.Map` type assertions in the LINE channel's `Send` method to prevent potential panics from unexpected map value types.

- `quoteTokens.LoadAndDelete` type assertion: added `ok` check for `string` cast
- `replyTokens.LoadAndDelete` type assertion: added `ok` check for `replyTokenEntry` cast
- On `replyToken` assertion failure, gracefully skip the reply path and fall through to Push API (non-fatal)

Matches the same defensive type-assertion pattern already merged in previous fixes (e.g. #3053, #3091, #3058).

## Type of Change

- [x] Bug fix (defensive type safety)

## AI Code Generation

- [x] 🛠️ Mostly AI-generated — AI produced the draft; contributor reviewed and validated

## Test Environment

- OS: Windows 11
- Go: 1.25
- Verification: `go build ./pkg/channels/line/` passed, `go vet ./pkg/channels/line/` clean

## Checklist

- [x] I have read and understand every line of the generated code
- [x] The change passes `go build` and `go vet`
- [x] This is a focused, single-issue fix