### PR TITLE
fix: explicitly ignore Close() errors in error paths and retry loops

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -696,11 +696,11 @@ func (t *ExecTool) runBackground(ctx context.Context, command, cwd string, ptyEn
 				}
 			}
 
-		// All pipes closed, get exit status
-		if stdinWriter != nil {
-			_ = stdinWriter.Close()
-		}
-		cmd.Wait()
+			// All pipes closed, get exit status
+			if stdinWriter != nil {
+				_ = stdinWriter.Close()
+			}
+			cmd.Wait()
 
 			session.mu.Lock()
 			if cmd.ProcessState != nil {

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -569,7 +569,7 @@ func (t *ExecTool) runBackground(ctx context.Context, command, cwd string, ptyEn
 	// with synchronous exec runs.
 	if err := isolation.Start(cmd); err != nil {
 		if session.ptyMaster != nil {
-			session.ptyMaster.Close()
+			_ = session.ptyMaster.Close()
 		}
 		return ErrorResult(fmt.Sprintf("failed to start command: %v", err))
 	}
@@ -696,11 +696,11 @@ func (t *ExecTool) runBackground(ctx context.Context, command, cwd string, ptyEn
 				}
 			}
 
-			// All pipes closed, get exit status
-			if stdinWriter != nil {
-				stdinWriter.Close()
-			}
-			cmd.Wait()
+		// All pipes closed, get exit status
+		if stdinWriter != nil {
+			_ = stdinWriter.Close()
+		}
+		cmd.Wait()
 
 			session.mu.Lock()
 			if cmd.ProcessState != nil {

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -574,19 +574,19 @@ func extractZip(archivePath, destDir string) error {
 		if err != nil {
 			return err
 		}
-	out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, f.FileInfo().Mode())
-	if err != nil {
-		_ = rc.Close()
-		return err
-	}
-	if _, err := io.Copy(out, rc); err != nil {
-		_ = rc.Close()
-		_ = out.Close()
-		return err
-	}
-	if err := rc.Close(); err != nil {
-		_ = out.Close()
-		return fmt.Errorf("close zip entry reader: %w", err)
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, f.FileInfo().Mode())
+		if err != nil {
+			_ = rc.Close()
+			return err
+		}
+		if _, err := io.Copy(out, rc); err != nil {
+			_ = rc.Close()
+			_ = out.Close()
+			return err
+		}
+		if err := rc.Close(); err != nil {
+			_ = out.Close()
+			return fmt.Errorf("close zip entry reader: %w", err)
 		}
 		if err := out.Close(); err != nil {
 			return fmt.Errorf("close extracted file %q: %w", target, err)

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -574,19 +574,19 @@ func extractZip(archivePath, destDir string) error {
 		if err != nil {
 			return err
 		}
-		out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, f.FileInfo().Mode())
-		if err != nil {
-			rc.Close()
-			return err
-		}
-		if _, err := io.Copy(out, rc); err != nil {
-			rc.Close()
-			out.Close()
-			return err
-		}
-		if err := rc.Close(); err != nil {
-			out.Close()
-			return fmt.Errorf("close zip entry reader: %w", err)
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, f.FileInfo().Mode())
+	if err != nil {
+		_ = rc.Close()
+		return err
+	}
+	if _, err := io.Copy(out, rc); err != nil {
+		_ = rc.Close()
+		_ = out.Close()
+		return err
+	}
+	if err := rc.Close(); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("close zip entry reader: %w", err)
 		}
 		if err := out.Close(); err != nil {
 			return fmt.Errorf("close extracted file %q: %w", target, err)

--- a/pkg/utils/http_retry.go
+++ b/pkg/utils/http_retry.go
@@ -26,7 +26,7 @@ func DoRequestWithRetry(client *http.Client, req *http.Request) (*http.Response,
 
 	for i := range maxRetries {
 		if i > 0 && resp != nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 		}
 
 		resp, err = client.Do(req)
@@ -42,7 +42,7 @@ func DoRequestWithRetry(client *http.Client, req *http.Request) (*http.Response,
 		if i < maxRetries-1 {
 			if err = sleepWithCtx(req.Context(), retryDelayForAttempt(resp, i)); err != nil {
 				if resp != nil {
-					resp.Body.Close()
+					_ = resp.Body.Close()
 				}
 				return nil, fmt.Errorf("failed to sleep: %w", err)
 			}

--- a/pkg/utils/media.go
+++ b/pkg/utils/media.go
@@ -176,7 +176,7 @@ func DownloadFile(urlStr, filename string, opts DownloadOptions) string {
 	}
 
 	if _, err := io.Copy(out, resp.Body); err != nil {
-		out.Close()
+		_ = out.Close()
 		os.Remove(localPath)
 		logger.ErrorCF(opts.LoggerPrefix, "Failed to write file", map[string]any{
 			"error": err.Error(),


### PR DESCRIPTION
## Description

Explicitly ignore `Close()` errors on error paths and retry loops where the primary error already provides sufficient context. In these cases, the `Close()` error is secondary and not meaningful to bubble up as a return value.

Affected locations (4 files, 8 call sites):
- `pkg/tools/shell.go`: `ptyMaster.Close()` on startup failure, `stdinWriter.Close()` on pipe cleanup
- `pkg/updater/updater.go`: `rc.Close()` / `out.Close()` in zip extraction error paths
- `pkg/utils/http_retry.go`: `resp.Body.Close()` in retry-loop cleanup and sleep-failure paths
- `pkg/utils/media.go`: `out.Close()` on `io.Copy` write failure

## Type of Change

- [x] Bug fix (lint / error handling hygiene)

## AI Code Generation

- [x] 🛠️ Mostly AI-generated — AI produced the draft; contributor reviewed and validated

## Test Environment

- OS: Windows 11
- Go: 1.25
- Verification: `go build ./pkg/tools/ ./pkg/updater/ ./pkg/utils/` passed, `go vet` clean

## Checklist

- [x] I have read and understand every line
- [x] All changes are mechanical: bare `Close()` → `_ = Close()` on error paths only
- [x] No functional behavior changed