### PR TITLE
fix(cli): skip tool calls with invalid arguments

### DIFF
--- a/pkg/providers/cli/claude_cli_provider_test.go
+++ b/pkg/providers/cli/claude_cli_provider_test.go
@@ -789,6 +789,32 @@ func TestExtractToolCalls_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestExtractToolCalls_InvalidArgumentsJSON(t *testing.T) {
+	p := NewClaudeCliProvider("/workspace")
+	text := `{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"read_file","arguments":"not-json"}}]}`
+
+	got := p.extractToolCalls(text)
+	if len(got) != 0 {
+		t.Fatalf("extractToolCalls() = %d, want 0", len(got))
+	}
+}
+
+func TestExtractToolCalls_SkipsInvalidArgumentsAndKeepsValidCalls(t *testing.T) {
+	p := NewClaudeCliProvider("/workspace")
+	text := `{"tool_calls":[{"id":"bad","type":"function","function":{"name":"read_file","arguments":"not-json"}},{"id":"good","type":"function","function":{"name":"write_file","arguments":"{\"path\":\"out.txt\",\"content\":\"ok\"}"}}]}`
+
+	got := p.extractToolCalls(text)
+	if len(got) != 1 {
+		t.Fatalf("extractToolCalls() = %d, want 1", len(got))
+	}
+	if got[0].ID != "good" {
+		t.Fatalf("kept tool call ID = %q, want good", got[0].ID)
+	}
+	if got[0].Arguments["content"] != "ok" {
+		t.Fatalf("content = %v, want ok", got[0].Arguments["content"])
+	}
+}
+
 func TestExtractToolCalls_MultipleToolCalls(t *testing.T) {
 	p := NewClaudeCliProvider("/workspace")
 	text := `{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"/tmp/test\"}"}},{"id":"call_2","type":"function","function":{"name":"write_file","arguments":"{\"path\":\"/tmp/out\",\"content\":\"hello\"}"}}]}`

--- a/pkg/providers/cli/tool_call_extract.go
+++ b/pkg/providers/cli/tool_call_extract.go
@@ -39,7 +39,9 @@ func extractToolCallsFromText(text string) []ToolCall {
 	var result []ToolCall
 	for _, tc := range wrapper.ToolCalls {
 		var args map[string]any
-		json.Unmarshal([]byte(tc.Function.Arguments), &args)
+		if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil || args == nil {
+			continue
+		}
 
 		result = append(result, ToolCall{
 			ID:        tc.ID,


### PR DESCRIPTION
## Summary
- skip CLI-emitted tool calls when `function.arguments` is not valid JSON
- keep valid tool calls from the same response instead of dropping the whole batch
- add regression coverage for invalid and mixed valid/invalid CLI tool-call arguments

Without this check, malformed CLI tool-call arguments were parsed as an empty argument map, which could let an invalid tool call proceed with missing inputs.

## Test plan
- `go test ./pkg/providers/cli`