### PR TITLE
fix(onebot): explicitly ignore resp.Body.Close() error after websocket dial

### DIFF
--- a/pkg/channels/onebot/onebot.go
+++ b/pkg/channels/onebot/onebot.go
@@ -195,7 +195,7 @@ func (c *OneBotChannel) connect() error {
 
 	conn, resp, err := dialer.Dial(c.config.WSUrl, header)
 	if resp != nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

In the OneBot channel websocket dial error path, `resp.Body.Close()` is called without error handling. While the response body is typically nil after a successful websocket upgrade, when it is present the close error is secondary to the dial operation and should be explicitly ignored.

## Type of Change

- [x] Bug fix (lint / error handling hygiene)

## AI Code Generation

- [x] 🛠️ Mostly AI-generated — AI produced the draft; contributor reviewed and validated

## Test Environment

- OS: Windows 11
- Go: 1.25
- Verification: `go build ./pkg/channels/onebot/` passed, `go vet` clean

## Checklist

- [x] Single-file, single-location, mechanical change
- [x] Matches pattern of already-merged fixes (e.g. #3170, #3172)