### PR TITLE
fix(channels): explicitly ignore resp.Body.Close() errors in websocket dial cleanup

### DIFF
--- a/pkg/channels/pico/client.go
+++ b/pkg/channels/pico/client.go
@@ -88,7 +88,7 @@ func (c *PicoClientChannel) dial() error {
 
 	ws, resp, err := websocket.DefaultDialer.DialContext(c.ctx, c.config.URL, header)
 	if resp != nil && resp.Body != nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 	if err != nil {
 		return err

--- a/pkg/channels/whatsapp/whatsapp.go
+++ b/pkg/channels/whatsapp/whatsapp.go
@@ -62,7 +62,7 @@ func (c *WhatsAppChannel) Start(ctx context.Context) error {
 
 	conn, resp, err := dialer.Dial(c.url, nil)
 	if resp != nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 	if err != nil {
 		c.cancel()


### PR DESCRIPTION
## Description

In the Pico and WhatsApp channel websocket dial error paths, `resp.Body.Close()` is called without error handling. The close error from the websocket upgrade response body is secondary to the dial operation itself and should be explicitly ignored.

- `pkg/channels/pico/client.go`: `resp.Body.Close()` after dial connection cleanup
- `pkg/channels/whatsapp/whatsapp.go`: `resp.Body.Close()` on bridge connection failure

## Type of Change

- [x] Bug fix (lint / error handling hygiene)

## AI Code Generation

- [x] 🛠️ Mostly AI-generated — AI produced the draft; contributor reviewed and validated

## Test Environment

- OS: Windows 11
- Go: 1.25
- Verification: `go build ./pkg/channels/pico/ ./pkg/channels/whatsapp/` passed, `go vet` clean

## Checklist

- [x] Focused, same-pattern fix across two channels
- [x] Matches pattern of already-merged fixes (e.g. #3170, #3172)