### PR TITLE
fix(updater): explicitly ignore resp2.Body.Close() error after io.ReadAll

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -352,7 +352,7 @@ func findAssetInfo(releaseURL, platform, arch string) (string, string, error) {
 					continue
 				}
 				bs, err := io.ReadAll(resp2.Body)
-				resp2.Body.Close()
+				_ = resp2.Body.Close()
 				if err != nil {
 					continue
 				}


### PR DESCRIPTION
## Description

In the updater's checksum download path, `resp2.Body.Close()` is called after `io.ReadAll` without error handling. Since the body was already fully consumed by `io.ReadAll`, the close error is secondary to the read error and should be explicitly ignored.

## Type of Change

- [x] Bug fix (lint / error handling hygiene)

## AI Code Generation

- [x] 🛠️ Mostly AI-generated — AI produced the draft; contributor reviewed and validated

## Test Environment

- OS: Windows 11
- Go: 1.25
- Verification: `go build ./pkg/updater/` passed, `go vet` clean

## Checklist

- [x] Single-file, single-location, mechanical change
- [x] Matches pattern of already-merged fixes (e.g. #3170, #3172)