### PR TITLE
fix(membench): explicitly ignore resp.Body.Close() error after io.ReadAll

### DIFF
--- a/cmd/membench/llm_client.go
+++ b/cmd/membench/llm_client.go
@@ -155,7 +155,7 @@ func (c *LLMClient) Complete(ctx context.Context, systemPrompt, userPrompt strin
 		}
 
 		respBody, lastErr = io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if lastErr != nil {
 			continue
 		}


### PR DESCRIPTION
## Description

In membench LLM client retry loop, `resp.Body.Close()` is called after `io.ReadAll` without error handling. Since the body was already fully consumed, the close error is secondary and should be explicitly ignored.

## Type of Change
- [x] Bug fix (lint / error handling hygiene)

## AI Code Generation
- [x] 🛠️ Mostly AI-generated

## Checklist
- [x] Single-file, single-location, mechanical change
- [x] Matches pattern of already-merged fixes (#3170, #3172)