### PR TITLE
test(utils): explicitly ignore resp.Body.Close() errors in tests

### DIFF
--- a/pkg/utils/http_guard_test.go
+++ b/pkg/utils/http_guard_test.go
@@ -62,7 +62,7 @@ func TestCreateSafeHTTPClient_BlocksPrivateRedirect(t *testing.T) {
 	allowPrivateHosts = false
 	resp, err := client.Get(server.URL)
 	if resp != nil && resp.Body != nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 	if err == nil {
 		t.Fatal("expected redirect to private host to fail")

--- a/pkg/utils/http_retry_test.go
+++ b/pkg/utils/http_retry_test.go
@@ -68,11 +68,11 @@ func TestDoRequestWithRetry(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, resp)
 				assert.Equal(t, http.StatusOK, resp.StatusCode)
-				resp.Body.Close()
+				_ = resp.Body.Close()
 			} else {
 				require.NotNil(t, resp)
 				assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-				resp.Body.Close()
+				_ = resp.Body.Close()
 			}
 
 			assert.Equal(t, tc.wantAttempts, attempts)
@@ -111,7 +111,7 @@ func TestDoRequestWithRetry_RetryAfter429Honored(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, 2, attempts)
 
 	assert.GreaterOrEqual(t, secondAttemptAt.Sub(firstAttemptAt), 900*time.Millisecond)
@@ -148,7 +148,7 @@ func TestDoRequestWithRetry_RetryAfter429InvalidFallsBack(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, 2, attempts)
 
 	assert.GreaterOrEqual(t, secondAttemptAt.Sub(firstAttemptAt), 45*time.Millisecond)
@@ -200,7 +200,7 @@ func TestDoRequestWithRetry_ContextCancel(t *testing.T) {
 
 	resp, err := DoRequestWithRetry(client, req)
 	if resp != nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 	require.Error(t, err, "expected error from context cancellation")
 	assert.Nil(t, resp, "expected nil response when context is canceled")
@@ -275,7 +275,7 @@ func TestDoRequestWithRetry_Delay(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	assert.GreaterOrEqual(t, delays[2], time.Millisecond)
 }


### PR DESCRIPTION
## Description

Explicitly ignore `resp.Body.Close()` errors in test files within `pkg/utils/`. These test helpers create mock HTTP servers and the close errors on response bodies are secondary to the test assertions.

- `pkg/utils/http_guard_test.go`: 1 occurrence
- `pkg/utils/http_retry_test.go`: 6 occurrences

## Type of Change
- [x] Test cleanup (lint / error handling hygiene)

## AI Code Generation
- [x] 🛠️ Mostly AI-generated

## Checklist
- [x] Mechanical change, same pattern as source code fixes (#3170, #3172)