### PR TITLE
fix(health): explicitly ignore json.Encode errors in HTTP handler responses

### DIFF
--- a/pkg/health/server.go
+++ b/pkg/health/server.go
@@ -162,7 +162,7 @@ func (s *Server) reloadHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "reload triggered"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "reload triggered"})
 }
 
 func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
@@ -176,7 +176,7 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 		PID:    os.Getpid(),
 	}
 
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
@@ -190,7 +190,7 @@ func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
 
 	if !ready {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		json.NewEncoder(w).Encode(StatusResponse{
+		_ = json.NewEncoder(w).Encode(StatusResponse{
 			Status: "not ready",
 			Checks: checks,
 		})
@@ -200,7 +200,7 @@ func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
 	for _, check := range checks {
 		if check.Status == "fail" {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			json.NewEncoder(w).Encode(StatusResponse{
+			_ = json.NewEncoder(w).Encode(StatusResponse{
 				Status: "not ready",
 				Checks: checks,
 			})
@@ -210,7 +210,7 @@ func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	uptime := time.Since(s.startTime)
-	json.NewEncoder(w).Encode(StatusResponse{
+	_ = json.NewEncoder(w).Encode(StatusResponse{
 		Status: "ready",
 		Uptime: uptime.String(),
 		Checks: checks,


### PR DESCRIPTION
## Description

Explicitly ignore `json.NewEncoder(w).Encode()` errors in health server HTTP handler responses. These encode failures are secondary to the response writer operation (typically caused by client disconnection) and should not go unhandled.

5 call sites in `pkg/health/server.go`.

## Type of Change
- [x] Bug fix (lint / error handling hygiene)

## AI Code Generation
- [x] 🛠️ Mostly AI-generated

## Checklist
- [x] Single-file, focused fix