### PR TITLE
fix(line): explicitly ignore resp.Body.Close() errors in Send and classifySDKError

### DIFF
--- a/pkg/channels/line/line.go
+++ b/pkg/channels/line/line.go
@@ -69,7 +69,8 @@ func NewLINEChannel(
 		return nil, fmt.Errorf("failed to create LINE messaging client: %w", err)
 	}
 
-	base := channels.NewBaseChannel("line", cfg, messageBus, bc.AllowFrom,
+	base := channels.NewBaseChannel(
+		"line", cfg, messageBus, bc.AllowFrom,
 		channels.WithMaxMessageLength(5000),
 		channels.WithGroupTrigger(bc.GroupTrigger),
 		channels.WithReasoningChannelID(bc.ReasoningChannelID),
@@ -481,11 +482,11 @@ func (c *LINEChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]stri
 				ReplyToken: tokenEntry.token,
 				Messages:   []messaging_api.MessageInterface{&textMsg},
 			})
-		if resp != nil && resp.Body != nil {
-			_ = resp.Body.Close()
-		}
-		if err == nil {
-			logger.DebugCF("line", "Message sent via Reply API", map[string]any{
+			if resp != nil && resp.Body != nil {
+				_ = resp.Body.Close()
+			}
+			if err == nil {
+				logger.DebugCF("line", "Message sent via Reply API", map[string]any{
 					"chat_id": msg.ChatID,
 					"quoted":  quoteToken != "",
 				})

--- a/pkg/channels/line/line.go
+++ b/pkg/channels/line/line.go
@@ -481,11 +481,11 @@ func (c *LINEChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]stri
 				ReplyToken: tokenEntry.token,
 				Messages:   []messaging_api.MessageInterface{&textMsg},
 			})
-			if resp != nil && resp.Body != nil {
-				resp.Body.Close()
-			}
-			if err == nil {
-				logger.DebugCF("line", "Message sent via Reply API", map[string]any{
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if err == nil {
+			logger.DebugCF("line", "Message sent via Reply API", map[string]any{
 					"chat_id": msg.ChatID,
 					"quoted":  quoteToken != "",
 				})
@@ -588,7 +588,7 @@ func (c *LINEChannel) StartTyping(ctx context.Context, chatID string) (func(), e
 // classifySDKError maps an SDK HTTP response to the project's sentinel errors.
 func classifySDKError(resp *http.Response, err error) error {
 	if resp != nil && resp.Body != nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 	if err == nil {
 		return nil


### PR DESCRIPTION
## Description

Explicitly ignore `resp.Body.Close()` errors in the LINE channel's `Send` method (Reply API path) and `classifySDKError` helper. Both already have nil checks; the close error is secondary.

- `Send` Reply API cleanup (line 485)
- `classifySDKError` response cleanup (line 591)

## Type of Change
- [x] Bug fix (lint / error handling hygiene)

## AI Code Generation
- [x] 🛠️ Mostly AI-generated

## Checklist
- [x] Single-file, 2 locations, mechanical change