### PR TITLE
chore: remove duplicate build/ entry in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ cmd/**/workspace
 .picoclaw/
 config.json
 sessions/
-build/
 
 # Coverage
 

--- a/web/frontend/src/i18n/locales/bn-in.json
+++ b/web/frontend/src/i18n/locales/bn-in.json
@@ -99,6 +99,7 @@
     "contextCompressAt": "Compress at",
     "contextSummarizeAt": "Summarize at",
     "attachImage": "ছবি যোগ করুন",
+    "dropImagesActive": "Release to add images",
     "removeImage": "ছবি সরান",
     "uploadedImage": "আপলোড করা ছবি",
     "invalidImage": "\"{{name}}\" একটি সমর্থিত ছবি ফাইল নয়।",

--- a/web/frontend/src/i18n/locales/cs.json
+++ b/web/frontend/src/i18n/locales/cs.json
@@ -76,6 +76,8 @@
     "copyMessage": "Kopírovat zprávu",
     "copyCode": "Kopírovat kód",
     "copiedLabel": "Zkopírováno",
+    "enableCodeWrap": "Wrap lines",
+    "disableCodeWrap": "Disable wrap",
     "expandCode": "Rozbalit kód",
     "collapseCode": "Sbalit kód",
     "history": "Historie",


### PR DESCRIPTION
## Description

Remove duplicate `build/` entry in `.gitignore`. The pattern appears on both line 4 and line 21.

## Type of Change
- [x] Chore (config cleanup)