### PR TITLE
chore(docker): bump goreleaser base images from alpine:3.21 to 3.23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ cmd/**/workspace
 .picoclaw/
 config.json
 sessions/
-build/
 
 # Coverage
 

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.23
 
 ARG TARGETPLATFORM
 

--- a/docker/Dockerfile.goreleaser.launcher
+++ b/docker/Dockerfile.goreleaser.launcher
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.23
 
 ARG TARGETPLATFORM
 

--- a/web/frontend/src/i18n/locales/bn-in.json
+++ b/web/frontend/src/i18n/locales/bn-in.json
@@ -99,6 +99,7 @@
     "contextCompressAt": "Compress at",
     "contextSummarizeAt": "Summarize at",
     "attachImage": "ছবি যোগ করুন",
+    "dropImagesActive": "Release to add images",
     "removeImage": "ছবি সরান",
     "uploadedImage": "আপলোড করা ছবি",
     "invalidImage": "\"{{name}}\" একটি সমর্থিত ছবি ফাইল নয়।",

--- a/web/frontend/src/i18n/locales/cs.json
+++ b/web/frontend/src/i18n/locales/cs.json
@@ -76,6 +76,8 @@
     "copyMessage": "Kopírovat zprávu",
     "copyCode": "Kopírovat kód",
     "copiedLabel": "Zkopírováno",
+    "enableCodeWrap": "Wrap lines",
+    "disableCodeWrap": "Disable wrap",
     "expandCode": "Rozbalit kód",
     "collapseCode": "Sbalit kód",
     "history": "Historie",


### PR DESCRIPTION
## Description

Bump goreleaser Dockerfiles from `alpine:3.21` to `alpine:3.23` for consistency with the main Dockerfiles.

- `docker/Dockerfile.goreleaser`
- `docker/Dockerfile.goreleaser.launcher`

## Type of Change
- [x] Chore (dependency update)