### PR TITLE
refactor(deltachat): cleanup implementation, documentation -200LOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Talk to your PicoClaw through 19+ messaging platforms:
 | **QQ** | Easy (AppID + AppSecret) | WebSocket | [Guide](docs/channels/qq/README.md) |
 | **Slack** | Easy (bot + app token) | Socket Mode | [Guide](docs/channels/slack/README.md) |
 | **Matrix** | Medium (homeserver + token) | Sync API | [Guide](docs/channels/matrix/README.md) |
-| **Delta Chat** | Easy (account script or email/password) | JSON-RPC (email/E2EE) | [Guide](docs/channels/deltachat/README.md) |
+| **Delta Chat** | Easy (chatmail or existing account) | JSON-RPC (email/E2EE) | [Guide](docs/channels/deltachat/README.md) |
 | **DingTalk** | Medium (client credentials) | Stream | [Guide](docs/channels/dingtalk/README.md) |
 | **Feishu / Lark** | Medium (App ID + Secret) | WebSocket/SDK | [Guide](docs/channels/feishu/README.md) |
 | **LINE** | Medium (credentials + webhook) | Webhook | [Guide](docs/channels/line/README.md) |

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -226,6 +226,25 @@
         "crypto_passphrase": "YOUR_MATRIX_CRYPTO_PICKLE_KEY"
       }
     },
+    "deltachat": {
+      "enabled": false,
+      "type": "deltachat",
+      "allow_from": [],
+      "group_trigger": {
+        "mention_only": true
+      },
+      "reasoning_channel_id": "",
+      "settings": {
+        "email": "@nine.testrun.org",
+        "display_name": "PicoClaw Bot",
+        "avatar_image": "",
+        "data_dir": "",
+        "rpc_server_path": "",
+        "join_invite_link": "",
+        "show_invite_link": true,
+        "allow_crosspost": false
+      }
+    },
     "line": {
       "enabled": false,
       "type": "line",

--- a/docs/channels/deltachat/README.md
+++ b/docs/channels/deltachat/README.md
@@ -2,16 +2,16 @@
 
 # Delta Chat Channel
 
-PicoClaw can run as a Delta Chat bot by launching a local
-`deltachat-rpc-server` process and talking to it over JSON-RPC. The RPC server
-handles the email account, IMAP/SMTP connection, message store, and encryption
-keys.
+PicoClaw can run as a Delta Chat bot.
+
+DeltaChat is a distributed chatmail messaging system built on top of a jsonrpc
+server that manages all the encryption, storage, proxy and account management.
+
+You can read more about the project in [https://delta.chat](https://delta.chat)
 
 ## Install
 
-Install the Delta Chat RPC server. If `deltachat-rpc-server` is on `PATH`,
-PicoClaw can find it automatically; otherwise set `rpc_server_path` to the
-exact binary path.
+Download or install the Delta Chat RPC server from the GitHub releases or Pip:
 
 ```bash
 pip install deltachat-rpc-server
@@ -19,13 +19,17 @@ which deltachat-rpc-server
 ```
 
 Prebuilt binaries are also available from the
-[Delta Chat core releases](https://github.com/deltachat/deltachat-core-rust/releases).
+[Delta Chat core releases](https://github.com/chatmail/core/releases)
+
+The JSONRPC protocol is somehow stable and the picoclaw implementation will
+always try to keep up with latest releases of deltachat core. The deltachat
+channel for PicoClaw is known to work with chatmail core v2.53.
 
 ## Configure
 
 The easiest setup is to let PicoClaw create a chatmail account in Delta
-Chat's local account store. Put a relay marker in `email` using an empty local
-part, for example `@nine.testrun.org`:
+Chat's local account store. Put a relay marker in `email` using an empty
+user part, for example `@nine.testrun.org`:
 
 ```json
 {
@@ -40,7 +44,8 @@ part, for example `@nine.testrun.org`:
       "settings": {
         "email": "@nine.testrun.org",
         "display_name": "PicoClaw Bot",
-        "avatar_image": "/home/me/bot-avatar.png"
+        "avatar_image": "/home/me/bot-avatar.png",
+        "show_invite_link": true
       }
     }
   }
@@ -59,17 +64,8 @@ marker with that full email address and run PicoClaw again:
 }
 ```
 
-If `email` is missing, the startup error lists the built-in relay choices copied
-from Parla. You can use one of those relay markers, or a custom chatmail relay
-with the same `@server.name` form.
-
-`password` is not needed for PicoClaw-created chatmail accounts. Omit it when
-`email` points to an already configured account in `data_dir`; the JSON-RPC
-server owns the mailbox password. The legacy password-based path remains only
-for classic email accounts that PicoClaw must configure itself. In that mode,
-`password` is a secure field; on first config load it is moved to
-`~/.picoclaw/.security.yml`, and it can also be set with
-`PICOCLAW_CHANNELS_DELTACHAT_PASSWORD`.
+If `email` is missing, the startup error points at the default chatmail relay
+(`nine.testrun.org`) and the official relay directory at <https://chatmail.at/relays>.
 
 `display_name` and `avatar_image` are optional profile settings. When present,
 PicoClaw applies them on every startup, so changing the avatar path in config is
@@ -79,33 +75,29 @@ enough to update the bot profile.
 |-------|----------|-------------|
 | `email` | Yes | Full bot mailbox address, or first-run relay marker such as `@nine.testrun.org` |
 | `rpc_server_path` | No | Path to `deltachat-rpc-server`; only needed when it is not on `PATH` |
-| `password` | No | Legacy only; required when PicoClaw must configure/reconfigure a classic mailbox itself |
 | `display_name` | No | Startup-applied profile name shown to contacts and used for group mention detection |
 | `avatar_image` | No | Startup-applied profile avatar image path; `~` is expanded. Missing files are warned and ignored |
 | `data_dir` | No | Account database directory. Default: `~/.picoclaw/deltachat/<channel-name>` |
-| `invite_link` | No | Delta Chat invite link to join on startup |
+| `join_invite_link` | No | Delta Chat invite link for the bot account to join on startup |
+| `show_invite_link` | No | When `true`, prints the bot account's own invite link and QR code on startup so peers can add it. Omitted or `false` suppresses the startup printout |
 | `allow_crosspost` | No | Default `false`. When `true`, senders allowed by `allow_from` may use `message` tool targets outside the current chat, or resolve recipients by email/contact/chat name |
-| `imap_server`, `imap_port` | No | Manual IMAP override for password-based configuration |
-| `smtp_server`, `smtp_port` | No | Manual SMTP override for password-based configuration |
 
 Standard channel fields such as `allow_from`, `group_trigger`, and
 `reasoning_channel_id` also apply.
 
 ## First Run
 
-With `email` set to `@server`, PicoClaw creates the chatmail account, prints
-the generated full email in the startup error, and exits. Update `email` to that
-full address and run PicoClaw again. On later runs, PicoClaw selects the
-configured account by `email`, applies optional profile settings, marks it as a
-bot, and starts IO.
+Running `picoclaw setup reset` will generate a blank `~/.picoclaw/config.json`
+file with the default values.
 
-With a new `data_dir` plus legacy `password`, PicoClaw can still configure a
-classic email account and validate the mailbox credentials; after that, the
-account is reused from the local data directory.
+With `email` set to `@server` (without the username defined), PicoClaw creates
+the chatmail account, and stops with an startup error displaying the autogenerated
+full email that needs to be replaced manually in the configuration file.
 
-Delta Chat requires peers to learn the bot's encryption key before messaging
-it. On startup PicoClaw prints the bot invite link and QR code. Add the bot from
-Delta Chat with that invite, not by typing the bare email address.
+Starting up the gateway again will use `show_invite_link` to display the invite link
+and QR code to let your user to comunicate with it.
+
+Omit the field or set it to `false` to suppress the startup printout.
 
 ## Behavior
 
@@ -114,7 +106,11 @@ Delta Chat with that invite, not by typing the bare email address.
   handled.
 - Messages from the bot itself, device chats, and info/system messages are
   ignored.
-- Accepted inbound messages are marked seen after the allow-list check.
+- Accepted inbound messages are marked seen after successful dispatch to the
+  agent, with Delta Chat read receipts enabled so peer clients can show the
+  double-check seen state; dispatch failures leave the message unseen.
+- Accepted contact-request chats are accepted before the seen mark, because
+  Delta Chat does not send read receipts while a chat is still a contact request.
 - Incoming attachments (images, audio, video, documents) are registered with
   the media store and handed to the agent, so it can view images or operate on
   the files directly. If no media store is available, the path is appended
@@ -138,11 +134,68 @@ Delta Chat with that invite, not by typing the bare email address.
 | Symptom | Fix |
 |---------|-----|
 | `deltachat-rpc-server not found on PATH` or `rpc_server_path ... not found` | Install the RPC server on PATH, or set `rpc_server_path` to an absolute path |
-| `email is required` | Choose one listed chatmail server, set `email` to a first-run marker such as `@nine.testrun.org`, run `picoclaw g`, then replace it with the generated full email |
+| `email is required` | Set `email` to a first-run marker such as `@nine.testrun.org`, run `picoclaw g`, then replace it with the generated full email. Other chatmail relays are listed at <https://chatmail.at/relays> |
 | `created chatmail account ...` | Replace the `@server` marker in `email` with the generated full email and run PicoClaw again |
 | `account ... is not configured in data_dir` | Point `data_dir` at the existing JSON-RPC account store, or use `email="@server"` to create one |
-| `configure (check email/password/server)` | Check credentials, app password requirements, or IMAP/SMTP overrides |
 | Bot does not answer in a group | Check `group_trigger`; mention `display_name` or use a configured prefix |
 | Bot ignores a sender | Add the sender email to `allow_from`, or use `["*"]` for open access |
 | Sender cannot message the bot | Re-add the bot with the startup QR/invite so Delta Chat can establish encryption |
 | Agent cannot send to an email/name/other chat ID | Enable `settings.allow_crosspost` and allow the controlling sender in `allow_from`; this capability is disabled by default for privacy |
+
+## Transition From Legacy Options
+
+The Delta Chat channel does not keep backward-compatible aliases for the old
+configuration options. Update existing configs before starting the new binary:
+unknown legacy keys are ignored by the current settings decoder, so leaving them
+in place can make the channel start with missing behavior instead of migrating
+automatically.
+
+Use this mapping when updating `channel_list.<name>.settings`:
+
+| Old option | New option or action |
+|------------|----------------------|
+| `invite_link` | Rename to `join_invite_link` |
+| Always printing the bot invite | Add `show_invite_link: true` when you want the startup invite link and QR code |
+| `password` | Remove. PicoClaw no longer configures mailbox passwords; the selected account must already be configured in the Delta Chat JSON-RPC account store, or be created through the `@relay` chatmail bootstrap flow |
+| `imap_server`, `imap_port` | Remove. Manual IMAP setup is no longer handled by PicoClaw |
+| `smtp_server`, `smtp_port` | Remove. Manual SMTP setup is no longer handled by PicoClaw |
+| `PICOCLAW_CHANNELS_DELTACHAT_INVITE_LINK` | Rename to `PICOCLAW_CHANNELS_DELTACHAT_JOIN_INVITE_LINK` |
+| `PICOCLAW_CHANNELS_DELTACHAT_PASSWORD` | Remove |
+
+For an existing configured account, keep the account database and point the new
+config at it:
+
+```json
+{
+  "channel_list": {
+    "deltachat": {
+      "enabled": true,
+      "type": "deltachat",
+      "allow_from": ["friend@example.org"],
+      "group_trigger": {
+        "mention_only": true
+      },
+      "settings": {
+        "email": "bot@example.org",
+        "data_dir": "~/.picoclaw/deltachat/deltachat",
+        "join_invite_link": "DCJOIN:...",
+        "show_invite_link": true,
+        "allow_crosspost": false
+      }
+    }
+  }
+}
+```
+
+If the old setup depended on `password` plus IMAP/SMTP fields to configure a
+classic mailbox, use this plan:
+
+1. Configure that mailbox in a Delta Chat JSON-RPC account store outside
+   PicoClaw, or switch to a chatmail account by setting `email` to a relay marker
+   such as `@nine.testrun.org`.
+2. Remove the legacy password and server fields from `config.json`,
+   `~/.picoclaw/.security.yml`, and the environment, then set `email` and
+   `data_dir` to the configured account.
+3. Start PicoClaw. If it reports `account ... is not configured in data_dir`,
+   the `email` does not match an account in that `data_dir`; fix one of those
+   values or use the `@relay` bootstrap flow to create a new chatmail account.

--- a/pkg/channels/deltachat/deltachat.go
+++ b/pkg/channels/deltachat/deltachat.go
@@ -29,56 +29,15 @@ import (
 	"github.com/sipeed/picoclaw/pkg/media"
 )
 
-// chatTypeSingle is Delta Chat's Chattype::Single — a 1:1 direct chat.
-// The wire value is a string enum ("Single", "Group", "Mailinglist",
-// "OutBroadcast", "InBroadcast"); anything other than Single is a group.
-const chatTypeSingle = "Single"
-
 // configureTimeout bounds the (network-bound) account configuration step.
 const configureTimeout = 90 * time.Second
 
-type chatmailRelay struct {
-	Domain   string
-	Location string
-}
+// defaultChatmailRelay is the suggested example chatmail relay for DeltaChat
+const defaultChatmailRelay = "nine.testrun.org"
 
-// Keep this list in sync with Parla's CHATMAIL_RELAYS in ../parla/src/relay_picker.vala.
-var defaultChatmailRelays = []chatmailRelay{
-	{"nine.testrun.org", "Default"},
-	{"mehl.cloud", "German"},
-	{"mailchat.pl", "Poland"},
-	{"chatmail.woodpeckersnest.space", "Italy"},
-	{"chatmail.culturanerd.it", "Italy"},
-	{"chat.adminforge.de", "Falkenstein, Germany"},
-	{"chika.aangat.lahat.computer", "Santa Clara, USA"},
-	{"tarpit.fun", "Nuremberg, Germany"},
-	{"d.gaufr.es", "Roubaix, France"},
-	{"chtml.ca", "Quebec, Canada"},
-	{"chatmail.au", "Melbourne, Australia"},
-	{"e2ee.wang", "Johannesburg, South Africa"},
-	{"chat.privittytech.com", "Bangalore, India"},
-	{"e2ee.im", "Orastie, Romania"},
-	{"chatmail.email", "Warsaw, Poland"},
-	{"danneskjold.de", "Helsinki, Finland"},
-	{"chat.in-the.eu", "Falkenstein, Germany"},
-	{"chat.nuvon.app", "Prague, Czechia"},
-	{"nibblehole.com", "Zug, Switzerland"},
-	{"chat.zashm.org", "Lviv, Ukraine"},
-	{"chat.sus.fr", "Iceland/Japan/Kenya/South Africa"},
-	{"delta.thelab.uno", "Gravelines, France"},
-	{"chat.vim.wtf", "Frankfurt, Germany"},
-	{"uninterest.ing", "Elk Grove Village, USA"},
-	{"sweetfern.net", "Ashburn, USA"},
-	{"delta.disobey.net", "Roon, Netherlands"},
-}
-
-var managedAccountConfigKeys = []string{
-	"addr",
-	"mail_server",
-	"mail_port",
-	"send_server",
-	"send_port",
-}
+// chatmailRelaysURL is the official directory of public chatmail relays users
+// can pick from when choosing a server other than the default.
+const chatmailRelaysURL = "https://chatmail.at/relays"
 
 // dcAccount is one entry from get_all_accounts.
 type dcAccount struct {
@@ -114,11 +73,12 @@ type dcMessage struct {
 
 // dcChat is the subset of Delta Chat's FullChat we consume.
 type dcChat struct {
-	ID           int64  `json:"id"`
-	Name         string `json:"name"`
-	ChatType     string `json:"chatType"`
-	IsDeviceChat bool   `json:"isDeviceChat"`
-	CanSend      bool   `json:"canSend"`
+	ID               int64  `json:"id"`
+	Name             string `json:"name"`
+	ChatType         string `json:"chatType"`
+	IsContactRequest bool   `json:"isContactRequest"`
+	IsDeviceChat     bool   `json:"isDeviceChat"`
+	CanSend          bool   `json:"canSend"`
 }
 
 // dcMessageData mirrors the fields of Delta Chat's MessageData (camelCase on the
@@ -131,6 +91,11 @@ type dcMessageData struct {
 	File     string `json:"file,omitempty"`
 	Filename string `json:"filename,omitempty"`
 	Viewtype string `json:"viewtype,omitempty"`
+}
+
+type dcProfileConfig struct {
+	DisplayName string `json:"displayname,omitempty"`
+	SelfAvatar  string `json:"selfavatar,omitempty"`
 }
 
 // Ensure DeltaChatChannel satisfies the optional capability interfaces so the
@@ -161,9 +126,9 @@ func parseDeltaChatEmailSetting(value string) (string, bool, error) {
 	email := strings.TrimSpace(value)
 	if email == "" {
 		return "", false, fmt.Errorf(
-			"deltachat: email is required.\nNext step: choose one of the chatmail servers below and set channel_list.deltachat.settings.email to %q, or use the same @server form with another chatmail relay. Run `picoclaw g` again; PicoClaw will create the account, print the generated full email address, and stop so you can save that address in the config.\nAvailable chatmail servers:\n%s",
-			"@"+defaultChatmailRelays[0].Domain,
-			formatChatmailRelayList(),
+			"deltachat: email is required.\nNext step: set channel_list.deltachat.settings.email to %q (the default chatmail relay), or use the same @server form with another chatmail relay from %s. Run `picoclaw g` again; PicoClaw will create the account, print the generated full email address, and stop so you can save that address in the config",
+			"@"+defaultChatmailRelay,
+			chatmailRelaysURL,
 		)
 	}
 	if !strings.HasPrefix(email, "@") {
@@ -171,22 +136,18 @@ func parseDeltaChatEmailSetting(value string) (string, bool, error) {
 	}
 	domain := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(email, "@")))
 	if domain == "" {
-		return "", false, fmt.Errorf("deltachat: email %q is missing a chatmail server. Use %q or one of:\n%s",
-			email, "@"+defaultChatmailRelays[0].Domain, formatChatmailRelayList())
+		return "", false, fmt.Errorf(
+			"deltachat: email %q is missing a chatmail server. Use %q or another relay from %s",
+			email,
+			"@"+defaultChatmailRelay,
+			chatmailRelaysURL,
+		)
 	}
 	if strings.Contains(domain, "@") || strings.ContainsAny(domain, "/\\ \t\r\n") {
 		return "", false, fmt.Errorf("deltachat: invalid chatmail server marker %q; use settings.email like %q",
-			email, "@"+defaultChatmailRelays[0].Domain)
+			email, "@"+defaultChatmailRelay)
 	}
 	return domain, true, nil
-}
-
-func formatChatmailRelayList() string {
-	var b strings.Builder
-	for _, relay := range defaultChatmailRelays {
-		fmt.Fprintf(&b, "  @%-34s %s\n", relay.Domain, relay.Location)
-	}
-	return strings.TrimRight(b.String(), "\n")
 }
 
 func buildChatmailAccountQR(domain string) string {
@@ -267,7 +228,9 @@ func (c *DeltaChatChannel) Start(ctx context.Context) error {
 	// Print the bot's invite link + QR so users can add it. Delta Chat / chatmail
 	// require end-to-end encryption, so peers must obtain the bot's key via this
 	// invite (adding the bare email address will not work).
-	c.printInviteLink(c.ctx)
+	if c.config.ShowInviteLink {
+		c.printInviteLink(c.ctx)
+	}
 
 	return nil
 }
@@ -671,9 +634,6 @@ func (c *DeltaChatChannel) resolveAliasChatID(ctx context.Context, target string
 		if len(contacts) == 1 {
 			return c.chatIDForContact(ctx, contacts[0].ID)
 		}
-		if len(contacts) > 1 {
-			return 0, ambiguousRecipientError(target, contactRecipientLabels(contacts))
-		}
 
 		chats, err := c.findMatchingChats(ctx, query)
 		if err != nil {
@@ -682,8 +642,12 @@ func (c *DeltaChatChannel) resolveAliasChatID(ctx context.Context, target string
 		if len(chats) == 1 {
 			return chats[0].ID, nil
 		}
-		if len(chats) > 1 {
-			return 0, ambiguousRecipientError(target, chatRecipientLabels(chats))
+
+		if len(contacts) > 1 || len(chats) > 1 {
+			return 0, fmt.Errorf(
+				"ambiguous recipient %q: %w",
+				target, channels.ErrSendFailed,
+			)
 		}
 	}
 	return 0, nil
@@ -856,45 +820,6 @@ func (c *DeltaChatChannel) getFullChatByContext(ctx context.Context, chatID int6
 	return &chat, nil
 }
 
-func ambiguousRecipientError(target string, labels []string) error {
-	return fmt.Errorf(
-		"ambiguous recipient %q matches %s: %w",
-		target,
-		strings.Join(labels, ", "),
-		channels.ErrSendFailed,
-	)
-}
-
-func contactRecipientLabels(contacts []dcContact) []string {
-	labels := make([]string, 0, len(contacts))
-	for _, contact := range contacts {
-		name := strings.TrimSpace(contact.DisplayName)
-		if name == "" {
-			name = strings.TrimSpace(contact.Name)
-		}
-		if name != "" && contact.Address != "" {
-			labels = append(labels, fmt.Sprintf("%s <%s>", name, contact.Address))
-		} else if contact.Address != "" {
-			labels = append(labels, contact.Address)
-		} else {
-			labels = append(labels, strconv.FormatInt(contact.ID, 10))
-		}
-	}
-	return labels
-}
-
-func chatRecipientLabels(chats []dcChat) []string {
-	labels := make([]string, 0, len(chats))
-	for _, chat := range chats {
-		name := strings.TrimSpace(chat.Name)
-		if name == "" {
-			name = strconv.FormatInt(chat.ID, 10)
-		}
-		labels = append(labels, fmt.Sprintf("%s (chat %d)", name, chat.ID))
-	}
-	return labels
-}
-
 // deltaChatViewtype returns the explicit Delta Chat view type for an outbound
 // media part, or "" to let Delta Chat infer it from the file. Only voice replies
 // are forced (to Viewtype::Voice) so they render as playable voice bubbles;
@@ -977,17 +902,7 @@ func (c *DeltaChatChannel) ensureAccount(ctx context.Context) error {
 	}
 
 	if accountID == 0 {
-		if c.config.Password.String() == "" {
-			return c.passwordRequiredError("account not found")
-		}
-
-		raw, callErr := c.rpc.call(ctx, "add_account")
-		if callErr != nil {
-			return fmt.Errorf("deltachat add_account: %w", callErr)
-		}
-		if decErr := json.Unmarshal(raw, &accountID); decErr != nil {
-			return fmt.Errorf("deltachat add_account decode: %w", decErr)
-		}
+		return c.accountNotConfiguredError("account not found")
 	}
 
 	configured, err := c.isConfigured(ctx, accountID)
@@ -995,23 +910,7 @@ func (c *DeltaChatChannel) ensureAccount(ctx context.Context) error {
 		return err
 	}
 	if !configured {
-		if err := c.configureAccount(ctx, accountID); err != nil {
-			return err
-		}
-	} else if c.config.Password.String() != "" {
-		changed, err := c.accountConfigChanged(ctx, accountID)
-		if err != nil {
-			logger.WarnCF("deltachat", "Could not read account config; reconfiguring", map[string]any{
-				"email": c.config.Email,
-				"error": err.Error(),
-			})
-			changed = true
-		}
-		if changed {
-			if err := c.configureAccount(ctx, accountID); err != nil {
-				return err
-			}
-		}
+		return c.accountNotConfiguredError("account is not configured")
 	}
 
 	if _, err := c.rpc.call(ctx, "select_account", accountID); err != nil {
@@ -1021,7 +920,12 @@ func (c *DeltaChatChannel) ensureAccount(ctx context.Context) error {
 		return err
 	}
 	// Mark this account as a bot so the core delivers all messages to us.
-	if _, err := c.rpc.call(ctx, "batch_set_config", accountID, map[string]string{"bot": "1"}); err != nil {
+	// mdns_enabled lets markseen_msgs send read receipts for the visible
+	// double-check state in peer clients.
+	if _, err := c.rpc.call(ctx, "batch_set_config", accountID, map[string]string{
+		"bot":          "1",
+		"mdns_enabled": "1",
+	}); err != nil {
 		return fmt.Errorf("deltachat set bot config: %w", err)
 	}
 	if _, err := c.rpc.call(ctx, "start_io", accountID); err != nil {
@@ -1115,15 +1019,20 @@ func (c *DeltaChatChannel) getAccountConfigString(ctx context.Context, accountID
 	return *value, nil
 }
 
-func (c *DeltaChatChannel) passwordRequiredError(reason string) error {
-	return fmt.Errorf("deltachat: account %s is not configured in data_dir %s (%s)",
-		c.config.Email, c.dataDir, reason)
+func (c *DeltaChatChannel) accountNotConfiguredError(reason string) error {
+	return fmt.Errorf(
+		"deltachat: account %s is not configured in data_dir %s (%s). Use settings.email like %q to create a chatmail account, or point data_dir at an existing deltachat-rpc-server account store",
+		c.config.Email,
+		c.dataDir,
+		reason,
+		"@"+defaultChatmailRelay,
+	)
 }
 
 func (c *DeltaChatChannel) applyProfileConfig(ctx context.Context, accountID int64) error {
-	cfgMap := map[string]*string{}
+	var profile dcProfileConfig
 	if name := strings.TrimSpace(c.config.DisplayName); name != "" {
-		cfgMap["displayname"] = accountConfigString(name)
+		profile.DisplayName = name
 	}
 	if avatar := strings.TrimSpace(c.config.AvatarImage); avatar != "" {
 		avatar = expandHome(avatar)
@@ -1132,103 +1041,16 @@ func (c *DeltaChatChannel) applyProfileConfig(ctx context.Context, accountID int
 				"avatar_image": avatar,
 			})
 		} else {
-			cfgMap["selfavatar"] = accountConfigString(avatar)
+			profile.SelfAvatar = avatar
 		}
 	}
-	if len(cfgMap) == 0 {
+	if profile.DisplayName == "" && profile.SelfAvatar == "" {
 		return nil
 	}
-	if _, err := c.rpc.call(ctx, "batch_set_config", accountID, cfgMap); err != nil {
+	if _, err := c.rpc.call(ctx, "batch_set_config", accountID, profile); err != nil {
 		return fmt.Errorf("deltachat set profile config: %w", err)
 	}
 	return nil
-}
-
-// configureAccount writes the managed account settings and runs the (network-bound)
-// provider auto-configuration.
-func (c *DeltaChatChannel) configureAccount(ctx context.Context, accountID int64) error {
-	if c.config.Password.String() == "" {
-		return c.passwordRequiredError("account is not configured")
-	}
-
-	cfgMap := accountConfigMap(c.config)
-	if _, err := c.rpc.call(ctx, "batch_set_config", accountID, cfgMap); err != nil {
-		return fmt.Errorf("deltachat set account config: %w", err)
-	}
-
-	logger.InfoCF("deltachat", "Configuring account (validating credentials)", map[string]any{
-		"email": c.config.Email,
-	})
-	confCtx, cancel := context.WithTimeout(ctx, configureTimeout)
-	defer cancel()
-	if _, err := c.rpc.call(confCtx, "configure", accountID); err != nil {
-		return fmt.Errorf("deltachat configure (check email/password/server): %w", err)
-	}
-	return nil
-}
-
-func (c *DeltaChatChannel) accountConfigChanged(ctx context.Context, accountID int64) (bool, error) {
-	want := accountConfigMap(c.config)
-	for _, key := range managedAccountConfigKeys {
-		raw, err := c.rpc.call(ctx, "get_config", accountID, key)
-		if err != nil {
-			return false, fmt.Errorf("deltachat get config %s: %w", key, err)
-		}
-		var got *string
-		if err := json.Unmarshal(raw, &got); err != nil {
-			return false, fmt.Errorf("deltachat get config %s decode: %w", key, err)
-		}
-		if !accountConfigValueEqual(got, want[key]) {
-			logger.InfoCF("deltachat", "Account config changed; reconfiguring", map[string]any{
-				"email": c.config.Email,
-				"key":   key,
-			})
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func accountConfigValueEqual(got, want *string) bool {
-	if want == nil {
-		return got == nil || *got == ""
-	}
-	if got == nil {
-		return *want == ""
-	}
-	return *got == *want
-}
-
-func accountConfigMap(cfg *config.DeltaChatSettings) map[string]*string {
-	cfgMap := map[string]*string{
-		"addr":        accountConfigString(cfg.Email),
-		"mail_server": accountConfigOptionalString(cfg.IMAPServer),
-		"mail_port":   accountConfigOptionalInt(cfg.IMAPPort),
-		"send_server": accountConfigOptionalString(cfg.SMTPServer),
-		"send_port":   accountConfigOptionalInt(cfg.SMTPPort),
-	}
-	if password := cfg.Password.String(); password != "" {
-		cfgMap["mail_pw"] = accountConfigString(password)
-	}
-	return cfgMap
-}
-
-func accountConfigString(value string) *string {
-	return &value
-}
-
-func accountConfigOptionalString(value string) *string {
-	if value == "" {
-		return nil
-	}
-	return accountConfigString(value)
-}
-
-func accountConfigOptionalInt(value int) *string {
-	if value <= 0 {
-		return nil
-	}
-	return accountConfigString(strconv.Itoa(value))
 }
 
 func (c *DeltaChatChannel) listAccounts(ctx context.Context) ([]dcAccount, error) {
@@ -1257,7 +1079,7 @@ func (c *DeltaChatChannel) isConfigured(ctx context.Context, accountID int64) (b
 
 // joinInviteLink optionally joins a chat via a configured invite/QR link.
 func (c *DeltaChatChannel) joinInviteLink(ctx context.Context) error {
-	link := strings.TrimSpace(c.config.InviteLink)
+	link := c.config.JoinInviteLink
 	if link == "" {
 		return nil
 	}
@@ -1307,6 +1129,7 @@ func resolveDataDir(configured, channelName string) string {
 	return filepath.Join(home, ".picoclaw", "deltachat", name)
 }
 
+// home expansion and relative paths must be standarized instead of locally handled in every file
 func expandHome(path string) string {
 	if path == "" || path[0] != '~' {
 		return path

--- a/pkg/channels/deltachat/deltachat_test.go
+++ b/pkg/channels/deltachat/deltachat_test.go
@@ -27,7 +27,7 @@ func TestNewDeltaChatChannel(t *testing.T) {
 
 	t.Run("missing email", func(t *testing.T) {
 		bc := &config.Channel{Type: config.ChannelDeltaChat, Enabled: true}
-		cfg := &config.DeltaChatSettings{Password: *config.NewSecureString("pw"), RPCServerPath: fakeServer}
+		cfg := &config.DeltaChatSettings{RPCServerPath: fakeServer}
 		_, err := NewDeltaChatChannel(bc, cfg, msgBus)
 		if err == nil {
 			t.Fatal("expected error for missing email")
@@ -48,19 +48,10 @@ func TestNewDeltaChatChannel(t *testing.T) {
 		}
 	})
 
-	t.Run("password optional for existing account reference", func(t *testing.T) {
-		bc := &config.Channel{Type: config.ChannelDeltaChat, Enabled: true}
-		cfg := &config.DeltaChatSettings{Email: "bot@example.org", RPCServerPath: fakeServer}
-		if _, err := NewDeltaChatChannel(bc, cfg, msgBus); err != nil {
-			t.Fatalf("unexpected error without password: %v", err)
-		}
-	})
-
 	t.Run("missing rpc server", func(t *testing.T) {
 		bc := &config.Channel{Type: config.ChannelDeltaChat, Enabled: true}
 		cfg := &config.DeltaChatSettings{
 			Email:         "bot@example.org",
-			Password:      *config.NewSecureString("pw"),
 			RPCServerPath: filepath.Join(t.TempDir(), "does-not-exist"),
 		}
 		if _, err := NewDeltaChatChannel(bc, cfg, msgBus); err == nil {
@@ -72,7 +63,6 @@ func TestNewDeltaChatChannel(t *testing.T) {
 		bc := &config.Channel{Type: config.ChannelDeltaChat, Enabled: true}
 		cfg := &config.DeltaChatSettings{
 			Email:         "bot@example.org",
-			Password:      *config.NewSecureString("pw"),
 			RPCServerPath: fakeServer,
 			DataDir:       t.TempDir(),
 		}
@@ -137,53 +127,38 @@ func TestMentionsBot(t *testing.T) {
 	}
 }
 
-func TestExpandHome(t *testing.T) {
-	home, _ := os.UserHomeDir()
-	tests := []struct {
-		in   string
-		want string
-	}{
-		{"", ""},
-		{"/abs/path", "/abs/path"},
-		{"~", home},
-		{"~/sub", filepath.Join(home, "sub")},
-		{"relative", "relative"},
-	}
-	for _, tt := range tests {
-		if got := expandHome(tt.in); got != tt.want {
-			t.Errorf("expandHome(%q) = %q, want %q", tt.in, got, tt.want)
-		}
-	}
-}
-
-func TestResolveDataDir(t *testing.T) {
-	if got := resolveDataDir("/explicit/dir", "x"); got != "/explicit/dir" {
-		t.Errorf("explicit data dir = %q, want /explicit/dir", got)
-	}
-	home, _ := os.UserHomeDir()
-	want := filepath.Join(home, ".picoclaw", "deltachat", "mychan")
-	if got := resolveDataDir("", "mychan"); got != want {
-		t.Errorf("default data dir = %q, want %q", got, want)
-	}
-}
-
 func TestHandleMessageMarksSeenOnlyAfterDispatch(t *testing.T) {
 	tests := []struct {
-		name        string
-		chatType    string
-		mentionOnly bool
-		closeBus    bool
-		wantSeen    bool
+		name           string
+		chatType       string
+		contactRequest bool
+		mentionOnly    bool
+		closeBus       bool
+		acceptFails    bool
+		wantCalls      []string
 	}{
-		{name: "successful dispatch", chatType: chatTypeSingle, wantSeen: true},
+		{name: "successful dispatch", chatType: "Single", wantCalls: []string{"markseen_msgs"}},
+		{
+			name:           "contact request accepted before seen",
+			chatType:       "Single",
+			contactRequest: true,
+			wantCalls:      []string{"accept_chat", "markseen_msgs"},
+		},
+		{
+			name:           "failed contact request acceptance stays unseen",
+			chatType:       "Single",
+			contactRequest: true,
+			acceptFails:    true,
+			wantCalls:      []string{"accept_chat"},
+		},
 		{name: "ignored group trigger", chatType: "Group", mentionOnly: true},
-		{name: "failed local publish", chatType: chatTypeSingle, closeBus: true},
+		{name: "failed local publish", chatType: "Single", closeBus: true},
 	}
 
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			messageID := int64(42 + i)
-			chat := dcChat{ID: 99, Name: "chat", ChatType: tt.chatType}
+			chat := dcChat{ID: 99, Name: "chat", ChatType: tt.chatType, IsContactRequest: tt.contactRequest}
 			msgBus := bus.NewMessageBus()
 			if tt.closeBus {
 				msgBus.Close()
@@ -198,7 +173,7 @@ func TestHandleMessageMarksSeenOnlyAfterDispatch(t *testing.T) {
 			ch.accountID = 7
 			ch.selfAddr = "bot@example.org"
 
-			markSeen := make(chan struct{}, 1)
+			calls := make(chan rpcRequest, 4)
 			rpc, cleanup := newMockRPC(t, func(req rpcRequest) string {
 				switch req.Method {
 				case "get_message":
@@ -210,8 +185,14 @@ func TestHandleMessageMarksSeenOnlyAfterDispatch(t *testing.T) {
 					})
 				case "get_full_chat_by_id":
 					return rpcResult(req, chat)
+				case "accept_chat":
+					calls <- req
+					if tt.acceptFails {
+						return rpcUnexpectedMethod(req)
+					}
+					return rpcResult(req, nil)
 				case "markseen_msgs":
-					markSeen <- struct{}{}
+					calls <- req
 					return rpcResult(req, nil)
 				default:
 					return rpcUnexpectedMethod(req)
@@ -222,101 +203,44 @@ func TestHandleMessageMarksSeenOnlyAfterDispatch(t *testing.T) {
 
 			ch.handleMessage(messageID)
 
-			gotSeen := false
-			select {
-			case <-markSeen:
-				gotSeen = true
-			default:
+			var gotCalls []rpcRequest
+			for {
+				select {
+				case call := <-calls:
+					gotCalls = append(gotCalls, call)
+				default:
+					goto drained
+				}
 			}
-			if gotSeen != tt.wantSeen {
-				t.Fatalf("markseen called = %v, want %v", gotSeen, tt.wantSeen)
+
+		drained:
+			if len(gotCalls) != len(tt.wantCalls) {
+				t.Fatalf("calls = %v, want %v", rpcMethods(gotCalls), tt.wantCalls)
+			}
+			for i, want := range tt.wantCalls {
+				if gotCalls[i].Method != want {
+					t.Fatalf("calls = %v, want %v", rpcMethods(gotCalls), tt.wantCalls)
+				}
+			}
+			if tt.contactRequest && len(gotCalls) > 0 {
+				if params := gotCalls[0].Params; len(params) != 2 ||
+					params[0] != float64(7) || params[1] != float64(chat.ID) {
+					t.Fatalf("accept_chat params = %#v, want account 7 chat %d", params, chat.ID)
+				}
 			}
 		})
 	}
 }
 
-func TestDeltaChatSettingsDecode(t *testing.T) {
-	raw := []byte(`{
-		"enabled": true,
-		"type": "deltachat",
-		"allow_from": ["alice@example.org"],
-		"settings": {
-			"email": "bot@example.org",
-			"display_name": "PicoBot",
-			"avatar_image": "/tmp/picobot.png",
-			"allow_crosspost": true,
-			"imap_port": 993
-		}
-	}`)
-	var bc config.Channel
-	if err := json.Unmarshal(raw, &bc); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	bc.Type = config.ChannelDeltaChat
-	decoded, err := bc.GetDecoded()
-	if err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	cfg, ok := decoded.(*config.DeltaChatSettings)
-	if !ok {
-		t.Fatalf("decoded type = %T, want *config.DeltaChatSettings", decoded)
-	}
-	if cfg.Email != "bot@example.org" {
-		t.Errorf("email = %q, want bot@example.org", cfg.Email)
-	}
-	if cfg.DisplayName != "PicoBot" {
-		t.Errorf("display_name = %q, want PicoBot", cfg.DisplayName)
-	}
-	if cfg.AvatarImage != "/tmp/picobot.png" {
-		t.Errorf("avatar_image = %q, want /tmp/picobot.png", cfg.AvatarImage)
-	}
-	if cfg.IMAPPort != 993 {
-		t.Errorf("imap_port = %d, want 993", cfg.IMAPPort)
-	}
-	if !cfg.AllowCrosspost {
-		t.Error("allow_crosspost = false, want true")
-	}
-}
-
-func TestEnsureAccountReconfiguresConfiguredAccountWhenSettingsChange(t *testing.T) {
+func TestEnsureAccountRejectsUnconfiguredAccount(t *testing.T) {
 	ch := newTestChannel(t)
-	ch.config.DisplayName = "New Bot"
-	ch.config.IMAPServer = "imap.example.org"
-	ch.config.IMAPPort = 993
-	ch.config.SMTPServer = "smtp.example.org"
-	ch.config.SMTPPort = 587
-
-	configureCalls := 0
-	accountConfigCalls := 0
-	var capturedConfig map[string]any
 
 	rpc, cleanup := newMockRPC(t, func(req rpcRequest) string {
 		switch req.Method {
 		case "get_all_accounts":
 			return rpcResult(req, []dcAccount{{ID: 7, Kind: "Configured", Addr: "bot@example.org"}})
 		case "is_configured":
-			return rpcResult(req, true)
-		case "get_config":
-			key, _ := req.Params[1].(string)
-			current := map[string]*string{
-				"addr":        strPtr("bot@example.org"),
-				"mail_pw":     strPtr("old-pw"),
-				"displayname": strPtr("Old Bot"),
-			}
-			return rpcResult(req, current[key])
-		case "batch_set_config":
-			if cfg, ok := req.Params[1].(map[string]any); ok {
-				if _, ok := cfg["mail_pw"]; ok {
-					accountConfigCalls++
-					capturedConfig = cfg
-				}
-			}
-			return rpcResult(req, nil)
-		case "configure":
-			configureCalls++
-			return rpcResult(req, nil)
-		case "select_account", "start_io":
-			return rpcResult(req, nil)
+			return rpcResult(req, false)
 		default:
 			return rpcUnexpectedMethod(req)
 		}
@@ -324,94 +248,17 @@ func TestEnsureAccountReconfiguresConfiguredAccountWhenSettingsChange(t *testing
 	defer cleanup()
 	ch.rpc = rpc
 
-	if err := ch.ensureAccount(context.Background()); err != nil {
-		t.Fatalf("ensureAccount: %v", err)
+	err := ch.ensureAccount(context.Background())
+	if err == nil {
+		t.Fatal("expected not-configured error")
 	}
-	if configureCalls != 1 {
-		t.Fatalf("configure calls = %d, want 1", configureCalls)
-	}
-	if accountConfigCalls != 1 {
-		t.Fatalf("account batch_set_config calls = %d, want 1", accountConfigCalls)
-	}
-	if capturedConfig["mail_pw"] != "pw" {
-		t.Errorf("mail_pw = %v, want pw", capturedConfig["mail_pw"])
-	}
-	if capturedConfig["mail_server"] != "imap.example.org" {
-		t.Errorf("mail_server = %v, want imap.example.org", capturedConfig["mail_server"])
-	}
-	if capturedConfig["mail_port"] != "993" {
-		t.Errorf("mail_port = %v, want 993", capturedConfig["mail_port"])
-	}
-	if capturedConfig["send_server"] != "smtp.example.org" {
-		t.Errorf("send_server = %v, want smtp.example.org", capturedConfig["send_server"])
-	}
-	if capturedConfig["send_port"] != "587" {
-		t.Errorf("send_port = %v, want 587", capturedConfig["send_port"])
-	}
-}
-
-func TestEnsureAccountSkipsConfiguredAccountWhenSettingsMatch(t *testing.T) {
-	ch := newTestChannel(t)
-	ch.config.DisplayName = "Pico Bot"
-	ch.config.IMAPServer = "imap.example.org"
-	ch.config.IMAPPort = 993
-	ch.config.SMTPServer = "smtp.example.org"
-	ch.config.SMTPPort = 587
-
-	configureCalls := 0
-	accountConfigCalls := 0
-
-	rpc, cleanup := newMockRPC(t, func(req rpcRequest) string {
-		switch req.Method {
-		case "get_all_accounts":
-			return rpcResult(req, []dcAccount{{ID: 7, Kind: "Configured", Addr: "bot@example.org"}})
-		case "is_configured":
-			return rpcResult(req, true)
-		case "get_config":
-			key, _ := req.Params[1].(string)
-			current := map[string]*string{
-				"addr":        strPtr("bot@example.org"),
-				"mail_pw":     strPtr("pw"),
-				"displayname": strPtr("Pico Bot"),
-				"mail_server": strPtr("imap.example.org"),
-				"mail_port":   strPtr("993"),
-				"send_server": strPtr("smtp.example.org"),
-				"send_port":   strPtr("587"),
-			}
-			return rpcResult(req, current[key])
-		case "batch_set_config":
-			if cfg, ok := req.Params[1].(map[string]any); ok {
-				if _, ok := cfg["mail_pw"]; ok {
-					accountConfigCalls++
-				}
-			}
-			return rpcResult(req, nil)
-		case "configure":
-			configureCalls++
-			return rpcResult(req, nil)
-		case "select_account", "start_io":
-			return rpcResult(req, nil)
-		default:
-			return rpcUnexpectedMethod(req)
-		}
-	})
-	defer cleanup()
-	ch.rpc = rpc
-
-	if err := ch.ensureAccount(context.Background()); err != nil {
-		t.Fatalf("ensureAccount: %v", err)
-	}
-	if configureCalls != 0 {
-		t.Fatalf("configure calls = %d, want 0", configureCalls)
-	}
-	if accountConfigCalls != 0 {
-		t.Fatalf("account batch_set_config calls = %d, want 0", accountConfigCalls)
+	if !strings.Contains(err.Error(), "is not configured") {
+		t.Fatalf("error = %v, want not-configured error", err)
 	}
 }
 
 func TestEnsureAccountCreatesBootstrapAccountAndStops(t *testing.T) {
 	ch := newTestChannel(t)
-	ch.config.Password = config.SecureString{}
 	ch.config.Email = "@mehl.cloud"
 
 	rpc, cleanup := newMockRPC(t, func(req rpcRequest) string {
@@ -447,9 +294,40 @@ func TestEnsureAccountCreatesBootstrapAccountAndStops(t *testing.T) {
 	}
 }
 
-func TestEnsureAccountUsesConfiguredAccountWithoutPassword(t *testing.T) {
+func TestJoinInviteLinkUsesConfiguredJoinInviteLink(t *testing.T) {
 	ch := newTestChannel(t)
-	ch.config.Password = config.SecureString{}
+	ch.accountID = 7
+	ch.config.JoinInviteLink = "DCACCOUNT:https://example.org/new"
+
+	rpc, cleanup := newMockRPC(t, func(req rpcRequest) string {
+		switch req.Method {
+		case "secure_join":
+			if req.Params[0] != float64(7) {
+				t.Fatalf("account id = %v, want 7", req.Params[0])
+			}
+			if req.Params[1] != "DCACCOUNT:https://example.org/new" {
+				t.Fatalf("invite link = %v", req.Params[1])
+			}
+			return rpcResult(req, int64(42))
+		case "accept_chat":
+			if req.Params[0] != float64(7) || req.Params[1] != float64(42) {
+				t.Fatalf("accept_chat params = %#v, want account 7 chat 42", req.Params)
+			}
+			return rpcResult(req, nil)
+		default:
+			return rpcUnexpectedMethod(req)
+		}
+	})
+	defer cleanup()
+	ch.rpc = rpc
+
+	if err := ch.joinInviteLink(context.Background()); err != nil {
+		t.Fatalf("joinInviteLink: %v", err)
+	}
+}
+
+func TestEnsureAccountUsesConfiguredAccount(t *testing.T) {
+	ch := newTestChannel(t)
 	ch.config.DisplayName = "Local Bot"
 	avatar := filepath.Join(t.TempDir(), "avatar.png")
 	if err := os.WriteFile(avatar, []byte("png"), 0o644); err != nil {
@@ -458,6 +336,7 @@ func TestEnsureAccountUsesConfiguredAccountWithoutPassword(t *testing.T) {
 	ch.config.AvatarImage = avatar
 
 	profileConfigCalls := 0
+	mdnsConfigured := false
 	rpc, cleanup := newMockRPC(t, func(req rpcRequest) string {
 		switch req.Method {
 		case "get_all_accounts":
@@ -467,6 +346,10 @@ func TestEnsureAccountUsesConfiguredAccountWithoutPassword(t *testing.T) {
 		case "batch_set_config":
 			cfg, _ := req.Params[1].(map[string]any)
 			if _, ok := cfg["bot"]; ok {
+				if cfg["bot"] != "1" || cfg["mdns_enabled"] != "1" {
+					t.Fatalf("bot config = %#v, want bot and mdns_enabled set to 1", cfg)
+				}
+				mdnsConfigured = true
 				return rpcResult(req, nil)
 			}
 			profileConfigCalls++
@@ -477,7 +360,12 @@ func TestEnsureAccountUsesConfiguredAccountWithoutPassword(t *testing.T) {
 				t.Fatalf("selfavatar = %v, want %s", cfg["selfavatar"], avatar)
 			}
 			return rpcResult(req, nil)
-		case "select_account", "start_io":
+		case "select_account":
+			return rpcResult(req, nil)
+		case "start_io":
+			if !mdnsConfigured {
+				return rpcUnexpectedMethod(req)
+			}
 			return rpcResult(req, nil)
 		default:
 			return rpcUnexpectedMethod(req)
@@ -499,7 +387,6 @@ func TestEnsureAccountUsesConfiguredAccountWithoutPassword(t *testing.T) {
 
 func TestEnsureAccountSkipsMissingAvatarImage(t *testing.T) {
 	ch := newTestChannel(t)
-	ch.config.Password = config.SecureString{}
 	ch.config.AvatarImage = filepath.Join(t.TempDir(), "missing.png")
 
 	profileConfigCalls := 0
@@ -532,9 +419,8 @@ func TestEnsureAccountSkipsMissingAvatarImage(t *testing.T) {
 	}
 }
 
-func TestEnsureAccountRequiresPasswordWhenAccountMissing(t *testing.T) {
+func TestEnsureAccountRequiresConfiguredAccountWhenAccountMissing(t *testing.T) {
 	ch := newTestChannel(t)
-	ch.config.Password = config.SecureString{}
 
 	rpc, cleanup := newMockRPC(t, func(req rpcRequest) string {
 		switch req.Method {
@@ -549,68 +435,10 @@ func TestEnsureAccountRequiresPasswordWhenAccountMissing(t *testing.T) {
 
 	err := ch.ensureAccount(context.Background())
 	if err == nil {
-		t.Fatal("expected password-required error")
+		t.Fatal("expected not-configured error")
 	}
 	if !strings.Contains(err.Error(), "is not configured") {
 		t.Fatalf("error = %v, want not-configured error", err)
-	}
-}
-
-func TestEnsureAccountClearsRemovedOptionalSettings(t *testing.T) {
-	ch := newTestChannel(t)
-
-	var capturedConfig map[string]any
-
-	rpc, cleanup := newMockRPC(t, func(req rpcRequest) string {
-		switch req.Method {
-		case "get_all_accounts":
-			return rpcResult(req, []dcAccount{{ID: 7, Kind: "Configured", Addr: "bot@example.org"}})
-		case "is_configured":
-			return rpcResult(req, true)
-		case "get_config":
-			key, _ := req.Params[1].(string)
-			current := map[string]*string{
-				"addr":        strPtr("bot@example.org"),
-				"mail_pw":     strPtr("pw"),
-				"displayname": strPtr("Old Bot"),
-				"mail_server": strPtr("imap.example.org"),
-				"mail_port":   strPtr("993"),
-				"send_server": strPtr("smtp.example.org"),
-				"send_port":   strPtr("587"),
-			}
-			return rpcResult(req, current[key])
-		case "batch_set_config":
-			if cfg, ok := req.Params[1].(map[string]any); ok {
-				if _, ok := cfg["mail_pw"]; ok {
-					capturedConfig = cfg
-				}
-			}
-			return rpcResult(req, nil)
-		case "configure", "select_account", "start_io":
-			return rpcResult(req, nil)
-		default:
-			return rpcUnexpectedMethod(req)
-		}
-	})
-	defer cleanup()
-	ch.rpc = rpc
-
-	if err := ch.ensureAccount(context.Background()); err != nil {
-		t.Fatalf("ensureAccount: %v", err)
-	}
-	if capturedConfig == nil {
-		t.Fatal("account batch_set_config was not called")
-	}
-	for _, key := range []string{"mail_server", "mail_port", "send_server", "send_port"} {
-		if value, ok := capturedConfig[key]; !ok || value != nil {
-			t.Errorf("%s = %v (present %v), want explicit null", key, value, ok)
-		}
-	}
-	if capturedConfig["addr"] != "bot@example.org" {
-		t.Errorf("addr = %v, want bot@example.org", capturedConfig["addr"])
-	}
-	if capturedConfig["mail_pw"] != "pw" {
-		t.Errorf("mail_pw = %v, want pw", capturedConfig["mail_pw"])
 	}
 }
 
@@ -686,7 +514,6 @@ func newTestChannelWithBus(t *testing.T, msgBus *bus.MessageBus, configure func(
 	}
 	cfg := &config.DeltaChatSettings{
 		Email:         "bot@example.org",
-		Password:      *config.NewSecureString("pw"),
 		RPCServerPath: fakeServer,
 		DataDir:       t.TempDir(),
 	}
@@ -730,10 +557,6 @@ func rpcResult(req rpcRequest, result any) string {
 
 func rpcUnexpectedMethod(req rpcRequest) string {
 	return `{"jsonrpc":"2.0","id":` + itoa(req.ID) + `,"error":{"code":-32601,"message":"unexpected method"}}`
-}
-
-func strPtr(value string) *string {
-	return &value
 }
 
 // TestMessageDataJSON pins the camelCase keys and omitempty behavior expected by
@@ -1251,4 +1074,12 @@ func TestVoiceCapabilities(t *testing.T) {
 	if !caps.ASR || !caps.TTS {
 		t.Errorf("VoiceCapabilities() = %+v, want both ASR and TTS true", caps)
 	}
+}
+
+func rpcMethods(requests []rpcRequest) []string {
+	methods := make([]string, len(requests))
+	for i, req := range requests {
+		methods[i] = req.Method
+	}
+	return methods
 }

--- a/pkg/channels/deltachat/handler.go
+++ b/pkg/channels/deltachat/handler.go
@@ -93,7 +93,8 @@ func (c *DeltaChatChannel) handleMessage(messageID int64) {
 		logger.DebugCF("deltachat", "Drop: device message", map[string]any{"chat_id": msg.ChatID})
 		return
 	}
-	isGroup := chat.ChatType != chatTypeSingle
+	// Possible ChatTypes are: "Single", "Group", "Mailinglist", "OutBroadcast", "InBroadcast"
+	isGroup := chat.ChatType != "Single"
 
 	logger.DebugCF("deltachat", "Inbound message", map[string]any{
 		"message_id": messageID,
@@ -227,10 +228,28 @@ func (c *DeltaChatChannel) handleMessage(messageID int64) {
 		})
 		return
 	}
+	c.markProcessedMessageSeen(messageID, chat)
+}
+
+func (c *DeltaChatChannel) markProcessedMessageSeen(messageID int64, chat *dcChat) {
+	if chat.IsContactRequest {
+		if _, err := c.rpc.call(c.ctx, "accept_chat", c.accountID, chat.ID); err != nil {
+			logger.WarnCF("deltachat", "Failed to accept contact request before marking message seen", map[string]any{
+				"message_id": messageID,
+				"chat_id":    chat.ID,
+				"error":      err.Error(),
+			})
+			return
+		}
+		logger.DebugCF("deltachat", "Accepted contact request before marking message seen", map[string]any{
+			"message_id": messageID,
+			"chat_id":    chat.ID,
+		})
+	}
 	if _, err := c.rpc.call(c.ctx, "markseen_msgs", c.accountID, []int64{messageID}); err != nil {
 		logger.WarnCF("deltachat", "Failed to mark message seen", map[string]any{
 			"message_id": messageID,
-			"chat_id":    chatID,
+			"chat_id":    chat.ID,
 			"error":      err.Error(),
 		})
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -599,29 +599,15 @@ type MatrixSettings struct {
 	CryptoPassphrase   string       `json:"crypto_passphrase,omitempty"    yaml:"-"`
 }
 
-// DeltaChatSettings configures the Delta Chat channel. Delta Chat is an
-// email-based, end-to-end encrypted messenger; PicoClaw talks to a local
-// `deltachat-rpc-server` process over JSON-RPC (stdio).
-//
-// Email is the only required setting. A full address selects an already
-// configured account in DataDir; a first-run marker such as "@nine.testrun.org"
-// creates a chatmail account and tells the user which full email to save.
-// Mailbox credentials stay in the Delta Chat account store. DisplayName and
-// AvatarImage are optional profile settings applied on startup. Password remains
-// only for legacy PicoClaw-managed email configuration.
 type DeltaChatSettings struct {
-	Email          string       `json:"email"                     yaml:"-"                  env:"PICOCLAW_CHANNELS_DELTACHAT_EMAIL"`
-	Password       SecureString `json:"password,omitzero"         yaml:"password,omitempty" env:"PICOCLAW_CHANNELS_DELTACHAT_PASSWORD"`
-	DisplayName    string       `json:"display_name,omitempty"    yaml:"-"                  env:"PICOCLAW_CHANNELS_DELTACHAT_DISPLAY_NAME"`
-	AvatarImage    string       `json:"avatar_image,omitempty"    yaml:"-"                  env:"PICOCLAW_CHANNELS_DELTACHAT_AVATAR_IMAGE"`
-	DataDir        string       `json:"data_dir,omitempty"        yaml:"-"                  env:"PICOCLAW_CHANNELS_DELTACHAT_DATA_DIR"`
-	RPCServerPath  string       `json:"rpc_server_path,omitempty" yaml:"-"                  env:"PICOCLAW_CHANNELS_DELTACHAT_RPC_SERVER_PATH"`
-	InviteLink     string       `json:"invite_link,omitempty"     yaml:"-"                  env:"PICOCLAW_CHANNELS_DELTACHAT_INVITE_LINK"`
-	AllowCrosspost bool         `json:"allow_crosspost,omitempty" yaml:"-"                  env:"PICOCLAW_CHANNELS_DELTACHAT_ALLOW_CROSSPOST"`
-	IMAPServer     string       `json:"imap_server,omitempty"     yaml:"-"`
-	IMAPPort       int          `json:"imap_port,omitempty"       yaml:"-"`
-	SMTPServer     string       `json:"smtp_server,omitempty"     yaml:"-"`
-	SMTPPort       int          `json:"smtp_port,omitempty"       yaml:"-"`
+	Email          string `json:"email"                      yaml:"-" env:"PICOCLAW_CHANNELS_DELTACHAT_EMAIL"`
+	DisplayName    string `json:"display_name,omitempty"     yaml:"-" env:"PICOCLAW_CHANNELS_DELTACHAT_DISPLAY_NAME"`
+	AvatarImage    string `json:"avatar_image,omitempty"     yaml:"-" env:"PICOCLAW_CHANNELS_DELTACHAT_AVATAR_IMAGE"`
+	DataDir        string `json:"data_dir,omitempty"         yaml:"-" env:"PICOCLAW_CHANNELS_DELTACHAT_DATA_DIR"`
+	RPCServerPath  string `json:"rpc_server_path,omitempty"  yaml:"-" env:"PICOCLAW_CHANNELS_DELTACHAT_RPC_SERVER_PATH"`
+	JoinInviteLink string `json:"join_invite_link,omitempty" yaml:"-" env:"PICOCLAW_CHANNELS_DELTACHAT_JOIN_INVITE_LINK"`
+	ShowInviteLink bool   `json:"show_invite_link"           yaml:"-" env:"PICOCLAW_CHANNELS_DELTACHAT_SHOW_INVITE_LINK"`
+	AllowCrosspost bool   `json:"allow_crosspost,omitempty"  yaml:"-" env:"PICOCLAW_CHANNELS_DELTACHAT_ALLOW_CROSSPOST"`
 }
 
 type LINESettings struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1043,11 +1043,87 @@ func TestDefaultConfig_DeltaChatExample(t *testing.T) {
 	if settings.Email != "@nine.testrun.org" {
 		t.Fatalf("DefaultConfig().deltachat.settings.email = %q, want @nine.testrun.org", settings.Email)
 	}
-	if settings.Password.String() != "" {
-		t.Fatal("DefaultConfig().deltachat.settings.password should be empty")
-	}
 	if settings.DisplayName == "" {
 		t.Fatal("DefaultConfig().deltachat.settings.display_name should be populated")
+	}
+	if !settings.ShowInviteLink {
+		t.Fatal("DefaultConfig().deltachat.settings.show_invite_link should default to true")
+	}
+	assertDeltaChatSettingsKeys(t, deltachat.Settings)
+}
+
+func TestConfigExample_DeltaChatExample(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "config", "config.example.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(config.example.json) error: %v", err)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("Unmarshal(config.example.json) error: %v", err)
+	}
+
+	deltachat := cfg.Channels.Get(ChannelDeltaChat)
+	if deltachat == nil {
+		t.Fatal("config.example.json missing deltachat channel")
+	}
+	if deltachat.Enabled {
+		t.Fatal("config.example.json deltachat channel should be disabled")
+	}
+	if deltachat.Type != ChannelDeltaChat {
+		t.Fatalf("config.example.json deltachat.type = %q, want %q", deltachat.Type, ChannelDeltaChat)
+	}
+	if !deltachat.GroupTrigger.MentionOnly {
+		t.Fatal("config.example.json deltachat should use mention-only group trigger")
+	}
+	assertDeltaChatSettingsKeys(t, deltachat.Settings)
+}
+
+func assertDeltaChatSettingsKeys(t *testing.T, raw RawNode) {
+	t.Helper()
+
+	var settings map[string]any
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		t.Fatalf("decode deltachat settings: %v", err)
+	}
+	for _, key := range []string{
+		"email",
+		"display_name",
+		"avatar_image",
+		"data_dir",
+		"rpc_server_path",
+		"join_invite_link",
+		"show_invite_link",
+		"allow_crosspost",
+	} {
+		if _, ok := settings[key]; !ok {
+			t.Fatalf("deltachat.settings missing %q", key)
+		}
+	}
+}
+
+func TestInitChannelListDeltaChatShowInviteLinkEnvOverride(t *testing.T) {
+	t.Setenv("PICOCLAW_CHANNELS_DELTACHAT_SHOW_INVITE_LINK", "false")
+
+	channels := ChannelsConfig{
+		ChannelDeltaChat: &Channel{
+			Type:     ChannelDeltaChat,
+			Settings: RawNode(`{"email":"bot@example.org","show_invite_link":true}`),
+		},
+	}
+	if err := InitChannelList(channels); err != nil {
+		t.Fatalf("InitChannelList: %v", err)
+	}
+	decoded, err := channels.Get(ChannelDeltaChat).GetDecoded()
+	if err != nil {
+		t.Fatalf("GetDecoded: %v", err)
+	}
+	settings, ok := decoded.(*DeltaChatSettings)
+	if !ok {
+		t.Fatalf("decoded settings type = %T, want *DeltaChatSettings", decoded)
+	}
+	if settings.ShowInviteLink {
+		t.Fatal("ShowInviteLink should honor env override false")
 	}
 }
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -552,8 +552,14 @@ func defaultChannels() ChannelsConfig {
 		"deltachat": map[string]any{
 			"group_trigger": map[string]any{"mention_only": true},
 			"settings": map[string]any{
-				"email":        "@nine.testrun.org",
-				"display_name": "PicoClaw Bot",
+				"email":            "@nine.testrun.org",
+				"display_name":     "PicoClaw Bot",
+				"avatar_image":     "",
+				"data_dir":         "",
+				"rpc_server_path":  "",
+				"join_invite_link": "",
+				"show_invite_link": true,
+				"allow_crosspost":  false,
 			},
 		},
 		"line": map[string]any{


### PR DESCRIPTION
- Drop legacy features, no fallbacks and outdated tests
- Reference official relay list website instead of harcoded copy
- Drop password-based email configuration, secrets must live in the jsonrpc
- Rename `invite_link` → `join_invite_link` and add `show_invite_link`
- Add full deltachat section to config.example.json
- Update defaults to include all settings keys with zero values
- Update documentation to reflect the simplified chatmail-only setup

## 📝 Description

<!-- Please briefly describe the changes and purpose of this PR -->

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **Hardware:** MacBook Pro M1 Max
- **OS:** macOS 26
- **Model/Provider:** gemma4:31b
- **Channels:** Deltachat


## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

<!-- Please paste relevant screenshots or logs here -->

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.