### PR TITLE
fix(agent): clear routed agent session

### DIFF
--- a/pkg/agent/agent_command.go
+++ b/pkg/agent/agent_command.go
@@ -333,7 +333,16 @@ func (al *AgentLoop) buildCommandsRuntime(
 			if opts == nil {
 				return fmt.Errorf("process options not available")
 			}
-			return al.clearAgentSessionContext(ctx, agent, opts.SessionKey)
+			// /clear can arrive before any turn has persisted session scope
+			// metadata (runAgentLoop records it per turn), so record it here to
+			// let the ContextManager resolve which agent owns the session.
+			ensureSessionMetadata(
+				agent.Sessions,
+				opts.Dispatch.SessionKey,
+				opts.Dispatch.SessionScope,
+				opts.Dispatch.SessionAliases,
+			)
+			return al.contextManager.Clear(ctx, opts.SessionKey)
 		}
 
 		rt.AskSideQuestion = func(ctx context.Context, question string) (string, error) {
@@ -361,40 +370,6 @@ func (al *AgentLoop) buildCommandsRuntime(
 		}
 	}
 	return rt
-}
-
-type contextStoreClearer interface {
-	ClearContextStore(ctx context.Context, sessionKey string) error
-}
-
-func (al *AgentLoop) clearAgentSessionContext(
-	ctx context.Context,
-	agent *AgentInstance,
-	sessionKey string,
-) error {
-	if agent == nil || agent.Sessions == nil {
-		return fmt.Errorf("sessions not initialized")
-	}
-	if al != nil && al.registry != nil && agent == al.registry.GetDefaultAgent() {
-		if al.contextManager != nil {
-			return al.contextManager.Clear(ctx, sessionKey)
-		}
-		return clearAgentSessionStore(agent, sessionKey)
-	}
-	if al != nil && al.contextManager != nil {
-		if clearer, ok := al.contextManager.(contextStoreClearer); ok {
-			if err := clearer.ClearContextStore(ctx, sessionKey); err != nil {
-				return err
-			}
-		}
-	}
-	return clearAgentSessionStore(agent, sessionKey)
-}
-
-func clearAgentSessionStore(agent *AgentInstance, sessionKey string) error {
-	agent.Sessions.SetHistory(sessionKey, []providers.Message{})
-	agent.Sessions.SetSummary(sessionKey, "")
-	return agent.Sessions.Save(sessionKey)
 }
 
 func summarizeMCPToolParameters(schema any) []commands.MCPToolParameterInfo {

--- a/pkg/agent/agent_command.go
+++ b/pkg/agent/agent_command.go
@@ -333,7 +333,7 @@ func (al *AgentLoop) buildCommandsRuntime(
 			if opts == nil {
 				return fmt.Errorf("process options not available")
 			}
-			return al.contextManager.Clear(ctx, opts.SessionKey)
+			return al.clearAgentSessionContext(ctx, agent, opts.SessionKey)
 		}
 
 		rt.AskSideQuestion = func(ctx context.Context, question string) (string, error) {
@@ -361,6 +361,40 @@ func (al *AgentLoop) buildCommandsRuntime(
 		}
 	}
 	return rt
+}
+
+type contextStoreClearer interface {
+	ClearContextStore(ctx context.Context, sessionKey string) error
+}
+
+func (al *AgentLoop) clearAgentSessionContext(
+	ctx context.Context,
+	agent *AgentInstance,
+	sessionKey string,
+) error {
+	if agent == nil || agent.Sessions == nil {
+		return fmt.Errorf("sessions not initialized")
+	}
+	if al != nil && al.registry != nil && agent == al.registry.GetDefaultAgent() {
+		if al.contextManager != nil {
+			return al.contextManager.Clear(ctx, sessionKey)
+		}
+		return clearAgentSessionStore(agent, sessionKey)
+	}
+	if al != nil && al.contextManager != nil {
+		if clearer, ok := al.contextManager.(contextStoreClearer); ok {
+			if err := clearer.ClearContextStore(ctx, sessionKey); err != nil {
+				return err
+			}
+		}
+	}
+	return clearAgentSessionStore(agent, sessionKey)
+}
+
+func clearAgentSessionStore(agent *AgentInstance, sessionKey string) error {
+	agent.Sessions.SetHistory(sessionKey, []providers.Message{})
+	agent.Sessions.SetSummary(sessionKey, "")
+	return agent.Sessions.Save(sessionKey)
 }
 
 func summarizeMCPToolParameters(schema any) []commands.MCPToolParameterInfo {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -3365,6 +3365,105 @@ func TestProcessMessage_CommandOutcomes(t *testing.T) {
 	}
 }
 
+func TestProcessMessage_ClearCommandClearsRoutedAgentSession(t *testing.T) {
+	workspace := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         filepath.Join(workspace, "default"),
+				ModelName:         "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+			},
+			List: []config.AgentConfig{
+				{
+					ID:        "main",
+					Default:   true,
+					Workspace: filepath.Join(workspace, "main"),
+				},
+				{
+					ID:        "support",
+					Workspace: filepath.Join(workspace, "support"),
+				},
+			},
+			Dispatch: &config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:  "support-dingtalk",
+						Agent: "support",
+						When: config.DispatchSelector{
+							Channel: "dingtalk",
+						},
+					},
+				},
+			},
+		},
+		Session: config.SessionConfig{
+			Dimensions: []string{"chat"},
+		},
+	}
+
+	al := NewAgentLoop(cfg, bus.NewMessageBus(), &countingMockProvider{response: "LLM reply"})
+	mainAgent, ok := al.registry.GetAgent("main")
+	if !ok {
+		t.Fatal("expected main agent")
+	}
+	supportAgent, ok := al.registry.GetAgent("support")
+	if !ok {
+		t.Fatal("expected support agent")
+	}
+
+	msg := testInboundMessage(bus.InboundMessage{
+		Context: bus.InboundContext{
+			Channel:  "dingtalk",
+			ChatID:   "chat1",
+			ChatType: "direct",
+			SenderID: "user1",
+		},
+		Content: "/clear",
+	})
+	route, routedAgent, err := al.resolveMessageRoute(msg)
+	if err != nil {
+		t.Fatalf("resolveMessageRoute() error = %v", err)
+	}
+	if routedAgent != supportAgent {
+		t.Fatalf("routed agent = %s, want support", routedAgent.ID)
+	}
+	sessionKey := al.allocateRouteSession(route, msg).SessionKey
+
+	mainHistory := []providers.Message{{Role: "user", Content: "main history"}}
+	supportHistory := []providers.Message{{Role: "user", Content: "support history"}}
+	mainAgent.Sessions.SetHistory(sessionKey, mainHistory)
+	mainAgent.Sessions.SetSummary(sessionKey, "main summary")
+	supportAgent.Sessions.SetHistory(sessionKey, supportHistory)
+	supportAgent.Sessions.SetSummary(sessionKey, "support summary")
+
+	response, err := al.processMessage(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("processMessage() error = %v", err)
+	}
+	if response != "Chat history cleared!" {
+		t.Fatalf("response = %q, want clear confirmation", response)
+	}
+
+	if got := supportAgent.Sessions.GetHistory(sessionKey); len(got) != 0 {
+		t.Fatalf("support history len = %d, want 0", len(got))
+	}
+	if got := supportAgent.Sessions.GetSummary(sessionKey); got != "" {
+		t.Fatalf("support summary = %q, want empty", got)
+	}
+	if got := mainAgent.Sessions.GetHistory(sessionKey); len(got) != len(mainHistory) {
+		t.Fatalf("main history len = %d, want %d", len(got), len(mainHistory))
+	} else if got[0].Role != mainHistory[0].Role {
+		t.Fatalf("main history[0].Role = %q, want %q", got[0].Role, mainHistory[0].Role)
+	} else if got[0].Content != mainHistory[0].Content {
+		t.Fatalf("main history[0].Content = %q, want %q", got[0].Content, mainHistory[0].Content)
+	}
+	if got := mainAgent.Sessions.GetSummary(sessionKey); got != "main summary" {
+		t.Fatalf("main summary = %q, want %q", got, "main summary")
+	}
+}
+
 func TestProcessMessage_MCPCommandsHandledWithoutLLMCall(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "agent-test-*")
 	if err != nil {

--- a/pkg/agent/context_legacy.go
+++ b/pkg/agent/context_legacy.go
@@ -63,7 +63,9 @@ func (m *legacyContextManager) Ingest(_ context.Context, _ *IngestRequest) error
 }
 
 func (m *legacyContextManager) Clear(_ context.Context, sessionKey string) error {
-	agent := m.al.registry.GetDefaultAgent()
+	// Routed (non-default) agents keep history in their own session store,
+	// so resolve the owning agent instead of assuming the default one.
+	agent := m.al.agentForSession(sessionKey)
 	if agent == nil || agent.Sessions == nil {
 		return fmt.Errorf("sessions not initialized")
 	}

--- a/pkg/agent/context_manager_test.go
+++ b/pkg/agent/context_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -658,6 +659,91 @@ func TestIngestCalledDuringTurn(t *testing.T) {
 	}
 }
 
+func TestClearCommandRoutedAgentCallsContextManagerClear(t *testing.T) {
+	cleanup := resetCMRegistry()
+	defer cleanup()
+
+	mock := &trackingContextManager{}
+	factory := func(cfg json.RawMessage, al *AgentLoop) (ContextManager, error) {
+		return mock, nil
+	}
+	if err := RegisterContextManager("clear_track_cm", factory); err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	workspace := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         filepath.Join(workspace, "default"),
+				ModelName:         "test-model",
+				MaxTokens:         4096,
+				MaxToolIterations: 10,
+				ContextManager:    "clear_track_cm",
+			},
+			List: []config.AgentConfig{
+				{
+					ID:        "main",
+					Default:   true,
+					Workspace: filepath.Join(workspace, "main"),
+				},
+				{
+					ID:        "support",
+					Workspace: filepath.Join(workspace, "support"),
+				},
+			},
+			Dispatch: &config.DispatchConfig{
+				Rules: []config.DispatchRule{
+					{
+						Name:  "support-dingtalk",
+						Agent: "support",
+						When: config.DispatchSelector{
+							Channel: "dingtalk",
+						},
+					},
+				},
+			},
+		},
+		Session: config.SessionConfig{
+			Dimensions: []string{"chat"},
+		},
+	}
+
+	al := NewAgentLoop(cfg, bus.NewMessageBus(), &simpleMockProvider{response: "done"})
+	if al.contextManager != mock {
+		t.Fatalf("expected mock context manager, got %T", al.contextManager)
+	}
+
+	msg := testInboundMessage(bus.InboundMessage{
+		Context: bus.InboundContext{
+			Channel:  "dingtalk",
+			ChatID:   "chat1",
+			ChatType: "direct",
+			SenderID: "user1",
+		},
+		Content: "/clear",
+	})
+	route, _, err := al.resolveMessageRoute(msg)
+	if err != nil {
+		t.Fatalf("resolveMessageRoute() error = %v", err)
+	}
+	sessionKey := al.allocateRouteSession(route, msg).SessionKey
+
+	if _, err := al.processMessage(context.Background(), msg); err != nil {
+		t.Fatalf("processMessage() error = %v", err)
+	}
+
+	if got := mock.clearCalls.Load(); got != 1 {
+		t.Fatalf("Clear calls = %d, want 1", got)
+	}
+	mock.mu.Lock()
+	gotKey := mock.lastClearKey
+	mock.mu.Unlock()
+	if gotKey != sessionKey {
+		t.Fatalf("Clear session key = %q, want %q", gotKey, sessionKey)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // forceCompression edge cases (via legacy Compact)
 // ---------------------------------------------------------------------------
@@ -712,10 +798,12 @@ type trackingContextManager struct {
 	assembleCalls atomic.Int64
 	compactCalls  atomic.Int64
 	ingestCalls   atomic.Int64
+	clearCalls    atomic.Int64
 	mu            sync.Mutex
 	lastAssemble  *AssembleRequest
 	lastCompact   *CompactRequest
 	lastIngest    *IngestRequest
+	lastClearKey  string
 }
 
 func (m *trackingContextManager) Assemble(_ context.Context, req *AssembleRequest) (*AssembleResponse, error) {
@@ -742,7 +830,13 @@ func (m *trackingContextManager) Ingest(_ context.Context, req *IngestRequest) e
 	return nil
 }
 
-func (m *trackingContextManager) Clear(_ context.Context, _ string) error { return nil }
+func (m *trackingContextManager) Clear(_ context.Context, sessionKey string) error {
+	m.clearCalls.Add(1)
+	m.mu.Lock()
+	m.lastClearKey = sessionKey
+	m.mu.Unlock()
+	return nil
+}
 
 // resetCMRegistry clears the global factory registry and returns a cleanup
 // function that restores the original state after the test.

--- a/pkg/agent/context_seahorse.go
+++ b/pkg/agent/context_seahorse.go
@@ -157,7 +157,7 @@ func (m *seahorseContextManager) Ingest(ctx context.Context, req *IngestRequest)
 
 // Clear removes all stored context for a session (seahorse DB + JSONL).
 func (m *seahorseContextManager) Clear(ctx context.Context, sessionKey string) error {
-	if err := m.engine.ClearSession(ctx, sessionKey); err != nil {
+	if err := m.ClearContextStore(ctx, sessionKey); err != nil {
 		return err
 	}
 	if m.sessions != nil {
@@ -166,6 +166,10 @@ func (m *seahorseContextManager) Clear(ctx context.Context, sessionKey string) e
 		return m.sessions.Save(sessionKey)
 	}
 	return nil
+}
+
+func (m *seahorseContextManager) ClearContextStore(ctx context.Context, sessionKey string) error {
+	return m.engine.ClearSession(ctx, sessionKey)
 }
 
 // bootstrapSession reconciles JSONL session history into seahorse SQLite.

--- a/pkg/agent/context_seahorse.go
+++ b/pkg/agent/context_seahorse.go
@@ -20,6 +20,7 @@ import (
 type seahorseContextManager struct {
 	engine   *seahorse.Engine
 	sessions session.SessionStore // for startup bootstrap
+	al       *AgentLoop           // for resolving the agent that owns a session
 }
 
 // newSeahorseContextManager creates a seahorse-backed ContextManager.
@@ -47,6 +48,7 @@ func newSeahorseContextManager(_ json.RawMessage, al *AgentLoop) (ContextManager
 	mgr := &seahorseContextManager{
 		engine:   engine,
 		sessions: agent.Sessions,
+		al:       al,
 	}
 
 	// Register seahorse tools with the agent's tool registry
@@ -157,19 +159,23 @@ func (m *seahorseContextManager) Ingest(ctx context.Context, req *IngestRequest)
 
 // Clear removes all stored context for a session (seahorse DB + JSONL).
 func (m *seahorseContextManager) Clear(ctx context.Context, sessionKey string) error {
-	if err := m.ClearContextStore(ctx, sessionKey); err != nil {
+	if err := m.engine.ClearSession(ctx, sessionKey); err != nil {
 		return err
 	}
-	if m.sessions != nil {
-		m.sessions.SetHistory(sessionKey, []providers.Message{})
-		m.sessions.SetSummary(sessionKey, "")
-		return m.sessions.Save(sessionKey)
+	// The session may belong to a routed (non-default) agent whose JSONL
+	// store differs from the bootstrap store, so clear the owner's store.
+	sessions := m.sessions
+	if m.al != nil {
+		if agent := m.al.agentForSession(sessionKey); agent != nil && agent.Sessions != nil {
+			sessions = agent.Sessions
+		}
+	}
+	if sessions != nil {
+		sessions.SetHistory(sessionKey, []providers.Message{})
+		sessions.SetSummary(sessionKey, "")
+		return sessions.Save(sessionKey)
 	}
 	return nil
-}
-
-func (m *seahorseContextManager) ClearContextStore(ctx context.Context, sessionKey string) error {
-	return m.engine.ClearSession(ctx, sessionKey)
 }
 
 // bootstrapSession reconciles JSONL session history into seahorse SQLite.

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"maps"
 	"net/http"
 	"net/url"


### PR DESCRIPTION
## 📝 Description

Fix `/clear` when a message is routed to a non-default agent.

Trigger conditions: multiple agents configured → message routed to a non-default agent → user sends `/clear` → expected: current agent session cleared; actual: default agent session cleared.

Previously, `/clear` called the active context manager's `Clear()` method. Both the legacy and seahorse context managers clear the default agent's session store inside `Clear()`, so a routed non-default agent could keep its history while the default agent session was cleared instead.

This changes `/clear` to clear the currently routed agent's session context. The default-agent path still uses the configured context manager, preserving existing behavior such as Seahorse context cleanup.

This PR only changes the `/clear` command path; other legacy context-manager methods keep their existing default-agent behavior.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🔗 Related Issue

No linked issue.

## 📚 Technical Context
- **Reference URL:** N/A
- **Reasoning:** In multi-agent configs, routed agents can have separate workspaces/session stores. `/clear` should clear the session for the agent handling the current routed message.

## 🧪 Test Environment
- **Hardware:** Mac
- **OS:** macOS
- **Model/Provider:** N/A (unit test with mock provider)
- **Channels:** dingtalk (dispatch rule routing to non-default agent)

## 📸 Evidence (Optional)
<details>
<summary>Click to view test output</summary>

```text
--- PASS: TestProcessMessage_ClearCommandClearsRoutedAgentSession
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.