### PR TITLE
Support agent-specific runtime overrides

### DIFF
--- a/pkg/agent/instance.go
+++ b/pkg/agent/instance.go
@@ -130,12 +130,17 @@ func NewAgentInstance(
 	sessions := initSessionStore(sessionsDir)
 
 	mcpDiscoveryActive := agentHasDiscoverableMCPServers(cfg, agentMCPServerAllowlist)
+	splitOnMarker := defaults.SplitOnMarker
+	if agentCfg != nil && agentCfg.SplitOnMarker != nil {
+		splitOnMarker = *agentCfg.SplitOnMarker
+	}
+
 	contextBuilder := NewContextBuilder(workspace).
 		WithToolDiscovery(
 			mcpDiscoveryActive && cfg.Tools.MCP.Discovery.UseBM25,
 			mcpDiscoveryActive && cfg.Tools.MCP.Discovery.UseRegex,
 		).
-		WithSplitOnMarker(cfg.Agents.Defaults.SplitOnMarker)
+		WithSplitOnMarker(splitOnMarker)
 
 	agentID := routing.DefaultAgentID
 	agentName := ""
@@ -160,6 +165,9 @@ func NewAgentInstance(
 	}
 
 	maxTokens := defaults.MaxTokens
+	if agentCfg != nil && agentCfg.MaxTokens > 0 {
+		maxTokens = agentCfg.MaxTokens
+	}
 	if maxTokens == 0 {
 		maxTokens = 8192
 	}
@@ -188,11 +196,17 @@ func NewAgentInstance(
 	thinkingLevelConfigured := isConfiguredThinkingLevel(thinkingLevelStr)
 
 	summarizeMessageThreshold := defaults.SummarizeMessageThreshold
+	if agentCfg != nil && agentCfg.SummarizeMessageThreshold > 0 {
+		summarizeMessageThreshold = agentCfg.SummarizeMessageThreshold
+	}
 	if summarizeMessageThreshold == 0 {
 		summarizeMessageThreshold = 20
 	}
 
 	summarizeTokenPercent := defaults.SummarizeTokenPercent
+	if agentCfg != nil && agentCfg.SummarizeTokenPercent > 0 {
+		summarizeTokenPercent = agentCfg.SummarizeTokenPercent
+	}
 	if summarizeTokenPercent == 0 {
 		summarizeTokenPercent = 75
 	}

--- a/pkg/agent/instance_test.go
+++ b/pkg/agent/instance_test.go
@@ -45,6 +45,46 @@ func TestNewAgentInstance_UsesDefaultsTemperatureAndMaxTokens(t *testing.T) {
 	}
 }
 
+func TestNewAgentInstance_UsesAgentOverrides(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:                 tmpDir,
+				ModelName:                 "default-model",
+				MaxTokens:                 8192,
+				MaxToolIterations:         5,
+				SummarizeMessageThreshold: 40,
+				SummarizeTokenPercent:     75,
+				SplitOnMarker:             true,
+			},
+		},
+	}
+
+	splitOnMarker := false
+	agent := NewAgentInstance(&config.AgentConfig{
+		ID:                        "rodolfo-rfreire",
+		Workspace:                 tmpDir,
+		MaxTokens:                 2048,
+		SummarizeMessageThreshold: 6,
+		SummarizeTokenPercent:     30,
+		SplitOnMarker:             &splitOnMarker,
+	}, &cfg.Agents.Defaults, cfg, &mockProvider{})
+
+	if agent.MaxTokens != 2048 {
+		t.Fatalf("MaxTokens = %d, want 2048", agent.MaxTokens)
+	}
+	if agent.SummarizeMessageThreshold != 6 {
+		t.Fatalf("SummarizeMessageThreshold = %d, want 6", agent.SummarizeMessageThreshold)
+	}
+	if agent.SummarizeTokenPercent != 30 {
+		t.Fatalf("SummarizeTokenPercent = %d, want 30", agent.SummarizeTokenPercent)
+	}
+	if agent.ContextBuilder.splitOnMarker {
+		t.Fatal("ContextBuilder.splitOnMarker = true, want false")
+	}
+}
+
 func TestNewAgentInstance_DefaultsTemperatureWhenZero(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "agent-instance-test-*")
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -312,13 +312,17 @@ func (m AgentModelConfig) MarshalJSON() ([]byte, error) {
 }
 
 type AgentConfig struct {
-	ID        string            `json:"id"`
-	Default   bool              `json:"default,omitempty"`
-	Name      string            `json:"name,omitempty"`
-	Workspace string            `json:"workspace,omitempty"`
-	Model     *AgentModelConfig `json:"model,omitempty"`
-	Skills    []string          `json:"skills,omitempty"`
-	Subagents *SubagentsConfig  `json:"subagents,omitempty"`
+	ID                        string            `json:"id"`
+	Default                   bool              `json:"default,omitempty"`
+	Name                      string            `json:"name,omitempty"`
+	Workspace                 string            `json:"workspace,omitempty"`
+	Model                     *AgentModelConfig `json:"model,omitempty"`
+	Skills                    []string          `json:"skills,omitempty"`
+	Subagents                 *SubagentsConfig  `json:"subagents,omitempty"`
+	MaxTokens                 int               `json:"max_tokens,omitempty"`
+	SummarizeMessageThreshold int               `json:"summarize_message_threshold,omitempty"`
+	SummarizeTokenPercent     int               `json:"summarize_token_percent,omitempty"`
+	SplitOnMarker             *bool             `json:"split_on_marker,omitempty"`
 }
 
 type SubagentsConfig struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -105,7 +105,11 @@ func TestAgentConfig_FullParse(t *testing.T) {
 				},
 				"subagents": {
 					"allow_agents": ["sales"]
-				}
+				},
+				"max_tokens": 2048,
+				"summarize_message_threshold": 6,
+				"summarize_token_percent": 30,
+				"split_on_marker": false
 			}
 			]
 		},
@@ -146,6 +150,18 @@ func TestAgentConfig_FullParse(t *testing.T) {
 	}
 	if support.Subagents == nil || len(support.Subagents.AllowAgents) != 1 {
 		t.Errorf("support.Subagents = %+v", support.Subagents)
+	}
+	if support.MaxTokens != 2048 {
+		t.Errorf("support.MaxTokens = %d, want 2048", support.MaxTokens)
+	}
+	if support.SummarizeMessageThreshold != 6 {
+		t.Errorf("support.SummarizeMessageThreshold = %d, want 6", support.SummarizeMessageThreshold)
+	}
+	if support.SummarizeTokenPercent != 30 {
+		t.Errorf("support.SummarizeTokenPercent = %d, want 30", support.SummarizeTokenPercent)
+	}
+	if support.SplitOnMarker == nil || *support.SplitOnMarker {
+		t.Errorf("support.SplitOnMarker = %v, want false", support.SplitOnMarker)
 	}
 
 	if len(cfg.Session.Dimensions) != 1 || cfg.Session.Dimensions[0] != "sender" {

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"maps"
 	"net/http"
 	"net/url"


### PR DESCRIPTION
Summary:
- allow agents.list entries to define max_tokens, summarization thresholds, and split_on_marker
- apply those per-agent overrides when building AgentInstance
- remove an unused openai_compat import from current main so the touched agent package can compile

Tests:
- go test ./pkg/config
- go test -tags goolm,stdjson ./pkg/agent -run TestNewAgentInstance_UsesAgentOverrides (interrupted after hanging without output after compilation started)