### PR TITLE
feat(whatsapp): add native typing presence

### DIFF
--- a/pkg/channels/whatsapp_native/whatsapp_command_test.go
+++ b/pkg/channels/whatsapp_native/whatsapp_command_test.go
@@ -4,9 +4,11 @@ package whatsapp
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
@@ -57,5 +59,116 @@ func TestHandleIncoming_DoesNotConsumeGenericCommandsLocally(t *testing.T) {
 		if inbound.Content != "/new" {
 			t.Fatalf("content=%q", inbound.Content)
 		}
+	}
+}
+
+func TestStartTypingSendsComposingThenPausedOnce(t *testing.T) {
+	originalSend := sendWhatsAppChatPresence
+	states := make(chan types.ChatPresence, 4)
+	sendWhatsAppChatPresence = func(
+		ctx context.Context,
+		client *whatsmeow.Client,
+		jid types.JID,
+		state types.ChatPresence,
+	) error {
+		states <- state
+		return nil
+	}
+	t.Cleanup(func() { sendWhatsAppChatPresence = originalSend })
+
+	channel := &WhatsAppNativeChannel{
+		BaseChannel: channels.NewBaseChannel("whatsapp_native", config.WhatsAppSettings{}, bus.NewMessageBus(), nil),
+		client:      &whatsmeow.Client{},
+	}
+	channel.SetRunning(true)
+
+	stop, err := channel.StartTyping(context.Background(), "1001")
+	if err != nil {
+		t.Fatalf("StartTyping() error: %v", err)
+	}
+	if state := <-states; state != types.ChatPresenceComposing {
+		t.Fatalf("initial presence = %q, want %q", state, types.ChatPresenceComposing)
+	}
+
+	stop()
+	stop()
+	if state := <-states; state != types.ChatPresencePaused {
+		t.Fatalf("stopped presence = %q, want %q", state, types.ChatPresencePaused)
+	}
+	select {
+	case state := <-states:
+		t.Fatalf("unexpected extra presence after idempotent stop: %q", state)
+	case <-time.After(25 * time.Millisecond):
+	}
+}
+
+func TestStartTypingRefreshesComposing(t *testing.T) {
+	originalSend := sendWhatsAppChatPresence
+	originalInterval := whatsappTypingRefreshInterval
+	whatsappTypingRefreshInterval = 10 * time.Millisecond
+	states := make(chan types.ChatPresence, 8)
+	sendWhatsAppChatPresence = func(
+		ctx context.Context,
+		client *whatsmeow.Client,
+		jid types.JID,
+		state types.ChatPresence,
+	) error {
+		states <- state
+		return nil
+	}
+	t.Cleanup(func() {
+		sendWhatsAppChatPresence = originalSend
+		whatsappTypingRefreshInterval = originalInterval
+	})
+
+	channel := &WhatsAppNativeChannel{
+		BaseChannel: channels.NewBaseChannel("whatsapp_native", config.WhatsAppSettings{}, bus.NewMessageBus(), nil),
+		client:      &whatsmeow.Client{},
+	}
+	channel.SetRunning(true)
+
+	stop, err := channel.StartTyping(context.Background(), "1001")
+	if err != nil {
+		t.Fatalf("StartTyping() error: %v", err)
+	}
+	defer stop()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case state := <-states:
+			if state != types.ChatPresenceComposing {
+				t.Fatalf("presence %d = %q, want %q", i, state, types.ChatPresenceComposing)
+			}
+		case <-time.After(250 * time.Millisecond):
+			t.Fatalf("timeout waiting for composing presence %d", i)
+		}
+	}
+}
+
+func TestStartTypingReturnsInitialPresenceError(t *testing.T) {
+	originalSend := sendWhatsAppChatPresence
+	wantErr := errors.New("presence unavailable")
+	sendWhatsAppChatPresence = func(
+		ctx context.Context,
+		client *whatsmeow.Client,
+		jid types.JID,
+		state types.ChatPresence,
+	) error {
+		return wantErr
+	}
+	t.Cleanup(func() { sendWhatsAppChatPresence = originalSend })
+
+	channel := &WhatsAppNativeChannel{
+		BaseChannel: channels.NewBaseChannel("whatsapp_native", config.WhatsAppSettings{}, bus.NewMessageBus(), nil),
+		client:      &whatsmeow.Client{},
+	}
+	channel.SetRunning(true)
+
+	stop, err := channel.StartTyping(context.Background(), "1001")
+	if stop == nil {
+		t.Fatal("StartTyping() returned nil stop function")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("StartTyping() error = %v, want %v", err, wantErr)
 	}
 }

--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -43,7 +43,20 @@ const (
 	reconnectInitial    = 5 * time.Second
 	reconnectMax        = 5 * time.Minute
 	reconnectMultiplier = 2.0
+
+	whatsappTypingStopTimeout = 5 * time.Second
 )
+
+var whatsappTypingRefreshInterval = 10 * time.Second
+
+var sendWhatsAppChatPresence = func(
+	ctx context.Context,
+	client *whatsmeow.Client,
+	jid types.JID,
+	state types.ChatPresence,
+) error {
+	return client.SendChatPresence(ctx, jid, state, types.ChatPresenceMediaText)
+}
 
 // WhatsAppNativeChannel implements the WhatsApp channel using whatsmeow (in-process, no external bridge).
 type WhatsAppNativeChannel struct {
@@ -405,6 +418,79 @@ func (c *WhatsAppNativeChannel) handleIncoming(evt *events.Message) {
 	}
 
 	c.HandleInboundContext(c.runCtx, chatID, content, mediaPaths, inboundCtx, sender)
+}
+
+// StartTyping implements channels.TypingCapable using WhatsApp's native composing presence.
+func (c *WhatsAppNativeChannel) StartTyping(ctx context.Context, chatID string) (func(), error) {
+	if !c.IsRunning() {
+		return func() {}, nil
+	}
+
+	jid, err := parseJID(chatID)
+	if err != nil {
+		return func() {}, fmt.Errorf("invalid chat id %q: %w", chatID, err)
+	}
+
+	c.mu.Lock()
+	client := c.client
+	c.mu.Unlock()
+	if client == nil {
+		return func() {}, fmt.Errorf("whatsapp connection not established: %w", channels.ErrTemporary)
+	}
+
+	typingCtx, cancel := context.WithCancel(ctx)
+	if err = sendWhatsAppChatPresence(typingCtx, client, jid, types.ChatPresenceComposing); err != nil {
+		cancel()
+		return func() {}, fmt.Errorf("whatsapp start typing: %w", err)
+	}
+
+	ticker := time.NewTicker(whatsappTypingRefreshInterval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-typingCtx.Done():
+				return
+			case <-ticker.C:
+				c.mu.Lock()
+				currentClient := c.client
+				c.mu.Unlock()
+				if currentClient == nil {
+					continue
+				}
+				if refreshErr := sendWhatsAppChatPresence(typingCtx, currentClient, jid, types.ChatPresenceComposing); refreshErr != nil {
+					logger.DebugCF("whatsapp", "Failed to refresh typing indicator", map[string]any{
+						"chat_id": chatID,
+						"error":   refreshErr.Error(),
+					})
+				}
+			}
+		}
+	}()
+
+	var once sync.Once
+	stop := func() {
+		once.Do(func() {
+			cancel()
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), whatsappTypingStopTimeout)
+			defer stopCancel()
+
+			c.mu.Lock()
+			currentClient := c.client
+			c.mu.Unlock()
+			if currentClient == nil {
+				return
+			}
+			if stopErr := sendWhatsAppChatPresence(stopCtx, currentClient, jid, types.ChatPresencePaused); stopErr != nil {
+				logger.DebugCF("whatsapp", "Failed to stop typing indicator", map[string]any{
+					"chat_id": chatID,
+					"error":   stopErr.Error(),
+				})
+			}
+		})
+	}
+
+	return stop, nil
 }
 
 func (c *WhatsAppNativeChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]string, error) {


### PR DESCRIPTION
## 📝 Description

Add native WhatsApp chat presence while PicoClaw prepares a reply.

`WhatsAppNativeChannel` now implements `channels.TypingCapable` and:

- sends `composing` immediately
- refreshes `composing` every 10 seconds for long replies
- sends `paused` when processing finishes
- returns an idempotent stop function
- cancels the refresh goroutine through context cancellation
- logs refresh/stop failures without interrupting message delivery

The websocket bridge channel is unchanged.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #3240

## 📚 Technical Context
- **Reference URL:** #3240
- **Reasoning:** `BaseChannel` already starts any `TypingCapable` implementation during inbound processing and records its stop function. WhatsApp native can use `whatsmeow.Client.SendChatPresence` to integrate with that existing lifecycle.

## 🧪 Test Environment
- **Hardware:** Android arm64 phone
- **OS:** Android / Termux
- **Model/Provider:** Provider-independent
- **Channels:** WhatsApp native

Commands run:

```text
go test -tags whatsapp_native ./pkg/channels/whatsapp_native
go test -count=25 -tags whatsapp_native -run 'TestStartTyping' ./pkg/channels/whatsapp_native
go vet -tags whatsapp_native ./pkg/channels/whatsapp_native
git diff --check
```

Tests cover initial `composing`, periodic refresh, idempotent `paused`, and initial presence errors. The race detector is unavailable in the local Android/arm64 Go toolchain; upstream CI will run on Linux.

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have added focused tests.
