### PR TITLE
refactor(seahorse): use strings.Builder in compaction string helpers

### DIFF
--- a/pkg/seahorse/short_bench_test.go
+++ b/pkg/seahorse/short_bench_test.go
@@ -334,3 +334,37 @@ func BenchmarkBootstrap_500Messages(b *testing.B) {
 		}
 	}
 }
+
+// --- Compaction formatting benchmarks ---
+
+func benchSummaryMessages(n int) []Message {
+	msgs := make([]Message, n)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := range msgs {
+		msgs[i] = Message{
+			Role:       "user",
+			Content:    fmt.Sprintf("Conversation message %d with enough content to summarize.", i),
+			CreatedAt:  base.Add(time.Duration(i) * time.Minute),
+			TokenCount: 15,
+		}
+	}
+	return msgs
+}
+
+func BenchmarkFormatMessagesForSummary(b *testing.B) {
+	msgs := benchSummaryMessages(200)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = formatMessagesForSummary(msgs)
+	}
+}
+
+func BenchmarkTruncateSummary(b *testing.B) {
+	msgs := benchSummaryMessages(200)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = truncateSummary(msgs)
+	}
+}

--- a/pkg/seahorse/short_compaction.go
+++ b/pkg/seahorse/short_compaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/sipeed/picoclaw/pkg/logger"
@@ -744,20 +745,20 @@ func (e *CompactionEngine) runCondensedLoop(ctx context.Context, convID int64) {
 // --- Helper functions ---
 
 func formatMessagesForSummary(messages []Message) string {
-	var result string
+	var b strings.Builder
 	for _, m := range messages {
 		ts := m.CreatedAt.Format("2006-01-02 15:04 MST")
 		content := m.Content
 		if content == "" && len(m.Parts) > 0 {
 			content = partsToReadableContent(m.Parts)
 		}
-		result += fmt.Sprintf("[%s]\n%s\n\n", ts, content)
+		fmt.Fprintf(&b, "[%s]\n%s\n\n", ts, content)
 	}
-	return result
+	return b.String()
 }
 
 func formatSummariesForCondensation(summaries []Summary) string {
-	var result string
+	var b strings.Builder
 	for _, s := range summaries {
 		earliest := ""
 		if s.EarliestAt != nil {
@@ -767,9 +768,9 @@ func formatSummariesForCondensation(summaries []Summary) string {
 		if s.LatestAt != nil {
 			latest = s.LatestAt.Format("2006-01-02")
 		}
-		result += fmt.Sprintf("[%s - %s]\n%s\n\n", earliest, latest, s.Content)
+		fmt.Fprintf(&b, "[%s - %s]\n%s\n\n", earliest, latest, s.Content)
 	}
-	return result
+	return b.String()
 }
 
 func buildLeafSummaryPrompt(sourceText, previousSummary string, targetTokens int) string {
@@ -847,14 +848,16 @@ Output requirements:
 }
 
 func truncateSummary(messages []Message) string {
-	content := ""
+	var b strings.Builder
 	for _, m := range messages {
 		c := m.Content
 		if c == "" && len(m.Parts) > 0 {
 			c = partsToReadableContent(m.Parts)
 		}
-		content += c + "\n"
+		b.WriteString(c)
+		b.WriteByte('\n')
 	}
+	content := b.String()
 	if len(content) > 2048 {
 		content = content[:2048]
 	}
@@ -863,10 +866,12 @@ func truncateSummary(messages []Message) string {
 }
 
 func truncateCondensedSummaries(summaries []Summary) string {
-	content := ""
+	var b strings.Builder
 	for _, s := range summaries {
-		content += s.Content + "\n"
+		b.WriteString(s.Content)
+		b.WriteByte('\n')
 	}
+	content := b.String()
 	if len(content) > 2048 {
 		content = content[:2048]
 	}


### PR DESCRIPTION
## 📝 Description

The seahorse compaction helpers assemble prompt text from **every message in a chunk** using `result += fmt.Sprintf(...)` / `content += s`. That pattern is O(n²): each `+=` allocates a new backing array and copies the whole accumulated string. This PR switches the four helpers to `strings.Builder` (amortised O(n), single growing buffer).

Output is **byte-identical** to the previous implementation (verified against the old code for `n = 0, 1, 7, 200`).

Functions changed (all unexported helpers, no API change):
`formatMessagesForSummary`, `formatSummariesForCondensation`, `truncateSummary`, `truncateCondensedSummaries`.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written

## 🔗 Related Issue

N/A — self-contained allocation cleanup on the context-compaction path.

## 📚 Technical Context

- **Reasoning:** `+=` on a growing string is quadratic in the number of iterations; `strings.Builder` grows one backing buffer and appends in place. These helpers run during context compaction on chunks that can hold hundreds of messages, so this is directly on-brand for PicoClaw's low-memory goals.

Benchmarks (200 messages, `go1.26`, `darwin/arm64`, `-benchmem`):

| function | before | after | speedup | memory |
|---|---|---|---|---|
| `formatMessagesForSummary` | 375µs · 1.78 MB · 1004 allocs | 53µs · 95 KB · 615 allocs | **7.1×** | **−94.7%** |
| `truncateSummary` | 254µs · 1.24 MB · 204 allocs | 10µs · 49 KB · 15 allocs | **25×** | **−96%** |

Reproduce:
```
go test -run='^$' -bench='BenchmarkFormatMessagesForSummary|BenchmarkTruncateSummary' -benchmem ./pkg/seahorse/
```
(Both benchmarks are added in this PR.)

## 🧪 Test Environment
- **Hardware:** Apple Silicon (arm64)
- **OS:** macOS 15
- **Model/Provider:** N/A — pure refactor, no LLM calls exercised
- **Channels:** N/A

Verification: `go vet ./pkg/seahorse/` and `go test ./pkg/seahorse/` pass; `gofmt -s` clean. Existing `parts_roundtrip_test.go` (which asserts the output of `formatMessagesForSummary` and `truncateSummary`) still passes.

## ☑️ Checklist
- [x] My code follows the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly. _(N/A — internal helpers, no documented behavior changes.)_
