### PR TITLE
refactor(skills): single-pass escapeXML, drop no-op Sprintf

### DIFF
--- a/pkg/skills/loader.go
+++ b/pkg/skills/loader.go
@@ -205,7 +205,7 @@ func (sl *SkillsLoader) BuildSkillsSummary() string {
 		escapedDesc := escapeXML(s.Description)
 		escapedPath := escapeXML(s.Path)
 
-		lines = append(lines, fmt.Sprintf("  <skill>"))
+		lines = append(lines, "  <skill>")
 		lines = append(lines, fmt.Sprintf("    <name>%s</name>", escapedName))
 		lines = append(lines, fmt.Sprintf("    <description>%s</description>", escapedDesc))
 		lines = append(lines, fmt.Sprintf("    <location>%s</location>", escapedPath))
@@ -379,9 +379,14 @@ func splitFrontmatter(content string) (frontmatter, body string) {
 	return frontmatter, body
 }
 
+// xmlEscaper escapes the XML special characters that could break the skills
+// summary markup, in a single pass. Built once; safe for concurrent use.
+var xmlEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+)
+
 func escapeXML(s string) string {
-	s = strings.ReplaceAll(s, "&", "&amp;")
-	s = strings.ReplaceAll(s, "<", "&lt;")
-	s = strings.ReplaceAll(s, ">", "&gt;")
-	return s
+	return xmlEscaper.Replace(s)
 }

--- a/pkg/skills/loader_test.go
+++ b/pkg/skills/loader_test.go
@@ -3,6 +3,7 @@ package skills
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -416,4 +417,33 @@ func TestGetSkillMetadata_IgnoresHTMLCommentBlocks(t *testing.T) {
 	require.NotNil(t, meta)
 	assert.Equal(t, "biomed-skill", meta.Name)
 	assert.Equal(t, "Summarize biomedical papers.", meta.Description)
+}
+
+// TestEscapeXMLGolden pins escapeXML's output. It escapes only &, < and > (the
+// characters that break the skills summary markup); " and ' are left as-is.
+// The single-pass strings.NewReplacer matches the previous sequential
+// strings.ReplaceAll chain byte for byte, including not re-escaping the '&'
+// introduced by < and > replacements.
+func TestEscapeXMLGolden(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"plain", "plain"},
+		{"a & b", "a &amp; b"},
+		{"<tag>", "&lt;tag&gt;"},
+		{"a<b>c&d", "a&lt;b&gt;c&amp;d"},
+		{"already &amp; escaped", "already &amp;amp; escaped"},
+		{`"quotes" and 'apos'`, `"quotes" and 'apos'`}, // only & < > are escaped
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, escapeXML(c.in), "escapeXML(%q)", c.in)
+	}
+}
+
+func BenchmarkEscapeXML(b *testing.B) {
+	s := strings.Repeat("skill <name> & \"desc\" ", 32)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = escapeXML(s)
+	}
 }


### PR DESCRIPTION
## 📝 Description

Two tiny cleanups in `pkg/skills/loader.go`:

1. **`escapeXML`** made **three sequential `strings.ReplaceAll` passes** (three allocations). Replaced with a package-level `strings.NewReplacer` (single pass, built once). **Byte-identical**: it still escapes only `&`, `<`, `>` (not `"`/`'`), and single-pass replacement does not re-escape the `&` introduced by the `<`/`>` replacements. Pinned by the new `TestEscapeXMLGolden`.
2. **`fmt.Sprintf("  <skill>")`** in `BuildSkillsSummary` has no format directives → replaced with the plain string literal `"  <skill>"`.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 📖 Documentation update
- [x] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written

## 🔗 Related Issue

N/A — self-contained cleanup.

## 📚 Technical Context

- **Reasoning:** `strings.NewReplacer` builds its matcher once and replaces in a single pass; the old chain walked the string three times with three intermediate allocations. `escapeXML` runs for every skill name/description/path in the skills summary that is injected into the system prompt.

Benchmark (go1.26, darwin/arm64, `-benchmem`):

| target | before | after | result |
|---|---|---|---|
| `escapeXML` | 1.64µs · 2944 B · 3 allocs | 0.90µs · 2048 B · 2 allocs | **1.8× faster, −30% mem** |

## 🧪 Test Environment
- **Hardware:** Apple Silicon (arm64)
- **OS:** macOS 15
- **Model/Provider:** N/A — pure refactor, no LLM calls exercised
- **Channels:** N/A

Verification: `go vet` + `go test ./pkg/skills/` pass (incl. new `TestEscapeXMLGolden`); `gofmt` clean.

## ☑️ Checklist
- [x] My code follows the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly. _(N/A — internal helper.)_
