### PR TITLE
fix: security and robustness hardening (MQTT TLS, OAuth timeouts, bounded search reads)

### DIFF
--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -37,6 +37,11 @@ type LoginBrowserOptions struct {
 var (
 	openBrowserFunc             = OpenBrowser
 	browserLoginInput io.Reader = os.Stdin
+
+	// oauthHTTPClient bounds all OAuth token requests; the default client
+	// has no timeout and can hang device-code polling and token refresh
+	// indefinitely.
+	oauthHTTPClient = &http.Client{Timeout: 30 * time.Second}
 )
 
 func OpenAIOAuthConfig() OAuthProviderConfig {
@@ -253,7 +258,7 @@ func RequestDeviceCode(cfg OAuthProviderConfig) (*DeviceCodeInfo, error) {
 		"client_id": cfg.ClientID,
 	})
 
-	resp, err := http.Post(
+	resp, err := oauthHTTPClient.Post(
 		cfg.Issuer+"/api/accounts/deviceauth/usercode",
 		"application/json",
 		strings.NewReader(string(reqBody)),
@@ -344,7 +349,7 @@ func LoginDeviceCode(cfg OAuthProviderConfig) (*AuthCredential, error) {
 		"client_id": cfg.ClientID,
 	})
 
-	resp, err := http.Post(
+	resp, err := oauthHTTPClient.Post(
 		cfg.Issuer+"/api/accounts/deviceauth/usercode",
 		"application/json",
 		strings.NewReader(string(reqBody)),
@@ -403,7 +408,7 @@ func pollDeviceCode(cfg OAuthProviderConfig, deviceAuthID, userCode string) (*Au
 		"user_code":      userCode,
 	})
 
-	resp, err := http.Post(
+	resp, err := oauthHTTPClient.Post(
 		cfg.Issuer+"/api/accounts/deviceauth/token",
 		"application/json",
 		strings.NewReader(string(reqBody)),
@@ -455,7 +460,7 @@ func RefreshAccessToken(cred *AuthCredential, cfg OAuthProviderConfig) (*AuthCre
 		tokenURL = cfg.TokenURL
 	}
 
-	resp, err := http.PostForm(tokenURL, data)
+	resp, err := oauthHTTPClient.PostForm(tokenURL, data)
 	if err != nil {
 		return nil, fmt.Errorf("refreshing token: %w", err)
 	}
@@ -551,7 +556,7 @@ func ExchangeCodeForTokens(cfg OAuthProviderConfig, code, codeVerifier, redirect
 		provider = "google-antigravity"
 	}
 
-	resp, err := http.PostForm(tokenURL, data)
+	resp, err := oauthHTTPClient.PostForm(tokenURL, data)
 	if err != nil {
 		return nil, fmt.Errorf("exchanging code for tokens: %w", err)
 	}

--- a/pkg/channels/mqtt/mqtt.go
+++ b/pkg/channels/mqtt/mqtt.go
@@ -80,7 +80,9 @@ func (c *MQTTChannel) Start(ctx context.Context) error {
 	opts.SetAutoReconnect(true)
 	opts.SetConnectRetry(true)
 	opts.SetConnectRetryInterval(5 * time.Second)
-	opts.SetTLSConfig(&tls.Config{InsecureSkipVerify: true}) //nolint:gosec
+	opts.SetTLSConfig(&tls.Config{
+		InsecureSkipVerify: c.cfg.TLSInsecureSkipVerify, //nolint:gosec // opt-in via config, default verifies
+	})
 
 	if c.cfg.Username.String() != "" {
 		opts.SetUsername(c.cfg.Username.String())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -736,6 +736,10 @@ type MQTTSettings struct {
 	ClientID    string       `json:"client_id,omitempty"    yaml:"-"                  env:"PICOCLAW_CHANNELS_MQTT_CLIENT_ID"`
 	KeepAlive   int          `json:"keep_alive,omitempty"   yaml:"-"                  env:"PICOCLAW_CHANNELS_MQTT_KEEP_ALIVE"`
 	QoS         int          `json:"qos,omitempty"          yaml:"-"                  env:"PICOCLAW_CHANNELS_MQTT_QOS"`
+	// TLSInsecureSkipVerify disables TLS certificate verification when
+	// connecting to the broker. Only enable for brokers with self-signed
+	// certificates on trusted networks.
+	TLSInsecureSkipVerify bool `json:"tls_insecure_skip_verify,omitempty" yaml:"-" env:"PICOCLAW_CHANNELS_MQTT_TLS_INSECURE_SKIP_VERIFY"`
 }
 
 // SlackWebhookSettings configures the output-only Slack webhook channel.

--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -37,6 +37,10 @@ const (
 
 	defaultMaxChars = 50000
 	maxRedirects    = 5
+
+	// maxSearchResponseBytes caps search API response reads so an oversized
+	// or malicious response cannot exhaust memory.
+	maxSearchResponseBytes = 2 << 20
 )
 
 // Pre-compiled regexes for HTML text extraction
@@ -314,7 +318,7 @@ func (p *BraveSearchProvider) Search(
 			continue
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxSearchResponseBytes))
 		_ = resp.Body.Close()
 
 		if err != nil {
@@ -447,7 +451,7 @@ func (p *TavilySearchProvider) Search(
 			continue
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxSearchResponseBytes))
 		_ = resp.Body.Close()
 
 		if err != nil {
@@ -998,7 +1002,7 @@ func (p *DuckDuckGoSearchProvider) Search(
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSearchResponseBytes))
 	if err != nil {
 		return "", fmt.Errorf("failed to read response: %w", err)
 	}
@@ -1146,7 +1150,7 @@ func (p *PerplexitySearchProvider) Search(
 			continue
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxSearchResponseBytes))
 		_ = resp.Body.Close()
 
 		if err != nil {


### PR DESCRIPTION
## Summary

Three small hardening fixes found while auditing for security/performance issues:

### 1. MQTT: verify TLS certificates by default (`pkg/channels/mqtt/mqtt.go`)
The channel hardcoded `InsecureSkipVerify: true`, disabling certificate verification for **every** broker connection — credentials could be intercepted via MITM. Certificates are now verified by default, with a new opt-in `tls_insecure_skip_verify` setting (`PICOCLAW_CHANNELS_MQTT_TLS_INSECURE_SKIP_VERIFY`) for self-signed brokers on trusted networks.

> Note: users currently relying on self-signed broker certs will need to set the new option — secure-by-default seemed like the right trade.

### 2. OAuth: bound token requests with a 30s timeout (`pkg/auth/oauth.go`)
Device-code login/polling, token exchange, and token refresh used `http.Post`/`http.PostForm` on the default client, which has no timeout — a stalled connection hangs these flows indefinitely. All five call sites now go through a shared client with a 30s timeout.

### 3. Web search: cap response reads at 2MB (`pkg/tools/integration/web.go`)
Brave, Tavily, DuckDuckGo, and Perplexity providers read API responses with unbounded `io.ReadAll`, so an oversized or malicious response could exhaust memory. They now use `io.LimitReader` via a shared `maxSearchResponseBytes` constant, matching the 1–2MB limits the other providers in the same file already apply. (WebFetchTool is untouched — it already uses `http.MaxBytesReader` and depends on its error type.)

## Testing
- `go build -tags goolm ./...` passes
- `go test ./pkg/channels/mqtt/... ./pkg/auth/... ./pkg/tools/integration/... ./pkg/config/...` passes