### PR TITLE
feat(i18n): add Czech translations for code wrap options

### DIFF
--- a/web/frontend/src/i18n/locales/cs.json
+++ b/web/frontend/src/i18n/locales/cs.json
@@ -76,6 +76,8 @@
     "copyMessage": "Kopírovat zprávu",
     "copyCode": "Kopírovat kód",
     "copiedLabel": "Zkopírováno",
+    "enableCodeWrap": "Zalamovat řádky",
+    "disableCodeWrap": "Vypnout zalamování",
     "expandCode": "Rozbalit kód",
     "collapseCode": "Sbalit kód",
     "history": "Historie",


### PR DESCRIPTION
## 📝 Description

  Adds Czech translations for two keys introduced in v0.3.1 that were missing from the Czech locale:
  - `chat.enableCodeWrap`: "Zalamovat řádky"
  - `chat.disableCodeWrap`: "Vypnout zalamování"

  ## 🗣️  Type of Change
  - [ ] 🐞 Bug fix
  - [x] ✨ New feature
  - [ ] 📖 Documentation update
  - [ ] ⚡ Code refactoring

  ## 🤖 AI Code Generation
  - [ ] 🤖 Fully AI-generated
  - [x] 🛠️  Mostly AI-generated (AI draft, Human verified/modified)
  - [ ] 👨‍💻ostly Human-written

  ## 🔗 Related Issue

  Follows up on #2932 (Czech locale, merged in v0.3.0).

  ## 📚 Technical Context (Skip for Docs)
  - **Reference URL:** `web/frontend/src/i18n/locales/en.json`
  - **Reasoning:** Keys were added after the original Czech PR was merged.

  ## 🧪  Test Environment
  - **Hardware:** Raspberry Pi 5
  - **OS:** Raspberry Pi OS (Debian 12)
  - **Model/Provider:** claude-sonnet
  - **Channels:** —

  ## ☑️  Checklist
  - [x] My code/docs follow the style of this project.
  - [x] I have performed a self-review of my own changes.
  - [x] I have updated the documentation accordingly.
