### PR TITLE
fix: bump Go to 1.25.12 to remediate stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sipeed/picoclaw
 
-go 1.25.11
+go 1.25.12
 
 require (
 	fyne.io/systray v1.12.2


### PR DESCRIPTION
## 📝 Description

Bump the pinned Go toolchain from 1.25.11 to 1.25.12 so GitHub Actions picks up the fixed standard library release.

This remediates the two `govulncheck` findings reported in CI:
- `GO-2026-5856` in `crypto/tls`
- `GO-2026-4970` in `os`

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Closes the CI `govulncheck` failure for `GO-2026-5856` and `GO-2026-4970`.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://pkg.go.dev/vuln/GO-2026-5856, https://pkg.go.dev/vuln/GO-2026-4970
- **Reasoning:** The reported vulnerabilities come from the Go standard library bundled with Go `1.25.11`. This repository pins the Go version in `go.mod`, and the PR/build/release workflows resolve `actions/setup-go` from that file, so bumping `go.mod` to `1.25.12` moves CI onto the patched stdlib release without changing application dependencies.

## 🧪 Test Environment
- **Hardware:** Apple Silicon Mac
- **OS:** macOS
- **Model/Provider:** N/A
- **Channels:** N/A

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- Ran `go test -tags goolm,stdjson ./...`
- Local run still reports unrelated existing failures in `pkg/fileutil` and `pkg/tools`; no failures were caused by this version bump.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
