### PR TITLE
fix(providers): capture the prompt cache token usage in Anthropic providers

### DIFF
--- a/pkg/providers/anthropic/provider.go
+++ b/pkg/providers/anthropic/provider.go
@@ -392,6 +392,8 @@ func parseResponse(resp *anthropic.Message) *LLMResponse {
 			PromptTokens:     int(resp.Usage.InputTokens),
 			CompletionTokens: int(resp.Usage.OutputTokens),
 			TotalTokens:      int(resp.Usage.InputTokens + resp.Usage.OutputTokens),
+			CacheReadInputTokens:    int(resp.Usage.CacheReadInputTokens),
+			CacheCreationInputTokens: int(resp.Usage.CacheCreationInputTokens), 
 		},
 	}
 }

--- a/pkg/providers/protocoltypes/types.go
+++ b/pkg/providers/protocoltypes/types.go
@@ -53,6 +53,9 @@ type UsageInfo struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+	CacheReadInputTokens    int `json:"cache_read_input_tokens"`   
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+
 }
 
 // CacheControl marks a content block for LLM-side prefix caching.


### PR DESCRIPTION
## 📝 Description
The Anthropic SDK provider (pkg/providers/anthropic/provider.go) and Anthropic Messages API provider (pkg/providers/anthropic_messages/provider.go) discard cache-related token metrics returned by Claude, making it impossible for operators to:
- Check if the prompt cache is working 
- Monitor cost savings from cached tokens (charged at 0.1× input price vs. 0.25× for cache writes)
- Debug caching breakpoints
- Track cache effectiveness over time

<!-- Please briefly describe the changes and purpose of this PR -->

## Fix 
Step 1: Add two cache token fields to protocoltypes.UsageInfo:
```CacheReadInputTokens```
```CacheCreationInputTokens```
Step 2: Extract these values in both Anthropic providers' parseResponse() functions.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

<!-- Please link the related issue(s) (e.g., Fixes #123, Closes #456) -->
#3227 