### PR TITLE
fix(agent): prefer verbatim model matches over provider-alias splits when resolving refs

### DIFF
--- a/pkg/agent/model_resolution.go
+++ b/pkg/agent/model_resolution.go
@@ -101,6 +101,12 @@ func lookupModelConfigByRef(cfg *config.Config, raw string, defaultProvider ...s
 	if len(defaultProvider) > 0 {
 		fallbackProvider = effectiveDefaultProvider(defaultProvider[0])
 	}
+
+	// Match tiers, strongest first: a verbatim configured model string always
+	// wins over split-based interpretations, so model IDs that embed a known
+	// provider alias (e.g. OpenRouter's "google/gemini-...") resolve to their
+	// configured entry instead of the alias provider (#3252).
+	var bareMatch, keyMatch *config.ModelConfig
 	for i := range cfg.ModelList {
 		mc := cfg.ModelList[i]
 		if mc == nil {
@@ -110,21 +116,23 @@ func lookupModelConfigByRef(cfg *config.Config, raw string, defaultProvider ...s
 		if fullModel == "" {
 			continue
 		}
-		protocol, modelID := modelProviderAndIDForResolution(fallbackProvider, mc)
 		if fullModel == raw {
 			return mc
 		}
-		if modelID == raw {
+		protocol, modelID := modelProviderAndIDForResolution(fallbackProvider, mc)
+		if bareMatch == nil && modelID == raw {
 			if fallbackProvider == "" || providers.NormalizeProvider(protocol) == fallbackProvider {
-				return mc
+				bareMatch = mc
 			}
 		}
-		if rawKey != "" && providers.ModelKey(protocol, modelID) == rawKey {
-			return mc
+		if keyMatch == nil && rawKey != "" && providers.ModelKey(protocol, modelID) == rawKey {
+			keyMatch = mc
 		}
 	}
-
-	return nil
+	if bareMatch != nil {
+		return bareMatch
+	}
+	return keyMatch
 }
 
 func resolveModelCandidate(

--- a/pkg/agent/model_resolution_test.go
+++ b/pkg/agent/model_resolution_test.go
@@ -56,6 +56,57 @@ func TestResolvedCandidateModelName_UsesCandidateDisplayName(t *testing.T) {
 	}
 }
 
+func TestLookupModelConfigByRef_PrefersVerbatimModelOverAliasSplit(t *testing.T) {
+	cfg := &config.Config{
+		ModelList: []*config.ModelConfig{
+			{
+				ModelName: "gemini-direct",
+				Provider:  "gemini",
+				Model:     "gemini-3.1-flash-lite-preview",
+			},
+			{
+				ModelName: "openrouter-gemini",
+				Provider:  "openrouter",
+				Model:     "google/gemini-3.1-flash-lite-preview",
+			},
+		},
+	}
+
+	got := lookupModelConfigByRef(cfg, "google/gemini-3.1-flash-lite-preview", "openai")
+
+	if got == nil {
+		t.Fatal("lookupModelConfigByRef() = nil, want model config")
+	}
+	if got.ModelName != "openrouter-gemini" {
+		t.Fatalf(
+			"model_name = %q, want %q (verbatim model match must beat provider-alias split)",
+			got.ModelName,
+			"openrouter-gemini",
+		)
+	}
+}
+
+func TestLookupModelConfigByRef_AliasSplitStillResolvesConfiguredEntry(t *testing.T) {
+	cfg := &config.Config{
+		ModelList: []*config.ModelConfig{
+			{
+				ModelName: "gemini-direct",
+				Provider:  "gemini",
+				Model:     "gemini-3.1-flash-lite-preview",
+			},
+		},
+	}
+
+	got := lookupModelConfigByRef(cfg, "google/gemini-3.1-flash-lite-preview", "openai")
+
+	if got == nil {
+		t.Fatal("lookupModelConfigByRef() = nil, want model config")
+	}
+	if got.ModelName != "gemini-direct" {
+		t.Fatalf("model_name = %q, want %q", got.ModelName, "gemini-direct")
+	}
+}
+
 func TestResolveActiveModelConfig_PrefersCandidateIdentityKey(t *testing.T) {
 	cfg := &config.Config{
 		ModelList: []*config.ModelConfig{


### PR DESCRIPTION
## 📝 Description

`lookupModelConfigByRef` (pkg/agent/model_resolution.go) resolved model references in a single pass that mixed three match types (verbatim model string, bare model ID, and split-based `ModelKey`). Because of that, an earlier `model_list` entry could win via a provider-alias split against a later entry that matches the reference **verbatim**.

Concrete failure (from #3252): with

```json
[
  { "model_name": "gemini-direct",     "provider": "gemini",     "model": "gemini-3.1-flash-lite-preview" },
  { "model_name": "openrouter-gemini", "provider": "openrouter", "model": "google/gemini-3.1-flash-lite-preview" }
]
```

referencing `google/gemini-3.1-flash-lite-preview` resolved to the **gemini** entry instead of the openrouter one: the `google` → `gemini` alias split turns the raw ref into the key `gemini/gemini-3.1-flash-lite-preview`, which collides with the first entry before the loop ever reaches the verbatim match on the second entry. The wrong provider/model is then used downstream.

This PR restructures the lookup into explicit match tiers, strongest first:

1. `model_name` lookup (unchanged)
2. verbatim `model` string match
3. bare model ID match (with the existing default-provider guard)
4. split-based `ModelKey` match

This also brings agent-side resolution in line with the gateway, which already matches in tiered passes (`findSignatureModelConfigs` in web/backend/api/gateway.go: ModelName → verbatim Model → bare ref → provider ref).

Note on scope: the issue suggests changing `splitKnownProviderModel` itself, but the legacy `provider/model` split is documented, contract-level behavior (see the `ExtractProtocol` examples, e.g. `"nvidia/z-ai/glm-5.1" -> ("nvidia", "z-ai/glm-5.1")`). Disabling it for any model containing `/` would break those cases. The actual defect is the match priority at the resolution layer, which is what this PR fixes; legacy alias splitting still applies when no verbatim entry exists (covered by a regression test).

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #3252

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/3252
- **Reasoning:** Model IDs that embed a known provider alias (OpenRouter-style slugs like `google/...`, `anthropic/...`) must resolve to their configured entry instead of being reinterpreted through the alias. A verbatim configured model string is strictly more specific than any split-based interpretation, so it must win regardless of `model_list` order.

## 🧪 Test Environment
- **Hardware:** Mac (local development machine)
- **OS:** macOS (Darwin 25.5)
- **Model/Provider:** n/a — provider-agnostic resolution logic, verified with unit tests
- **Channels:** n/a

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

New test against the previous code (reproduces the issue):

```
=== RUN   TestLookupModelConfigByRef_PrefersVerbatimModelOverAliasSplit
    model_resolution_test.go:81: model_name = "gemini-direct", want "openrouter-gemini" (verbatim model match must beat provider-alias split)
--- FAIL: TestLookupModelConfigByRef_PrefersVerbatimModelOverAliasSplit (0.00s)
```

After the fix:

```
=== RUN   TestLookupModelConfigByRef_PrefersVerbatimModelOverAliasSplit
--- PASS: TestLookupModelConfigByRef_PrefersVerbatimModelOverAliasSplit (0.00s)
=== RUN   TestLookupModelConfigByRef_AliasSplitStillResolvesConfiguredEntry
--- PASS: TestLookupModelConfigByRef_AliasSplitStillResolvesConfiguredEntry (0.00s)
ok      github.com/sipeed/picoclaw/pkg/agent    74.306s   (full package)
ok      github.com/sipeed/picoclaw/pkg/providers 2.665s
```

`gofmt` clean, `go vet` clean, full build with default Makefile tags (`goolm,stdjson`) passes.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly. (n/a — internal resolution logic, no user-facing docs affected)
