### PR TITLE
fix(feishu): send audio and video with native message types

### DIFF
--- a/pkg/channels/feishu/common.go
+++ b/pkg/channels/feishu/common.go
@@ -42,6 +42,17 @@ func buildMarkdownCard(content string) (string, error) {
 	return string(data), nil
 }
 
+func feishuMediaMessageType(partType string) string {
+	switch partType {
+	case "audio":
+		return larkim.MsgTypeAudio
+	case "video":
+		return larkim.MsgTypeMedia
+	default:
+		return larkim.MsgTypeFile
+	}
+}
+
 // extractJSONStringField unmarshals content as JSON and returns the value of the given string field.
 // Returns "" if the content is invalid JSON or the field is missing/empty.
 func extractJSONStringField(content, field string) string {

--- a/pkg/channels/feishu/common_test.go
+++ b/pkg/channels/feishu/common_test.go
@@ -227,6 +227,26 @@ func TestBuildMarkdownCard(t *testing.T) {
 	}
 }
 
+func TestFeishuMediaMessageType(t *testing.T) {
+	tests := []struct {
+		name     string
+		partType string
+		want     string
+	}{
+		{name: "audio uses native player", partType: "audio", want: larkim.MsgTypeAudio},
+		{name: "video uses native player", partType: "video", want: larkim.MsgTypeMedia},
+		{name: "generic file stays a file", partType: "file", want: larkim.MsgTypeFile},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := feishuMediaMessageType(tt.partType); got != tt.want {
+				t.Errorf("feishuMediaMessageType(%q) = %q, want %q", tt.partType, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestStripMentionPlaceholders(t *testing.T) {
 	strPtr := func(s string) *string { return &s }
 

--- a/pkg/channels/feishu/feishu_64.go
+++ b/pkg/channels/feishu/feishu_64.go
@@ -1214,13 +1214,13 @@ func (c *FeishuChannel) sendFile(ctx context.Context, chatID string, file *os.Fi
 
 	fileKey := *uploadResp.Data.FileKey
 
-	// Send file message
+	// Use Feishu's native message type so audio and video get an inline player.
 	content, _ := json.Marshal(map[string]string{"file_key": fileKey})
 	req := larkim.NewCreateMessageReqBuilder().
 		ReceiveIdType(larkim.CreateMessageV1ReceiveIDTypeChatId).
 		Body(larkim.NewCreateMessageReqBodyBuilder().
 			ReceiveId(chatID).
-			MsgType(larkim.MsgTypeFile).
+			MsgType(feishuMediaMessageType(fileType)).
 			Content(string(content)).
 			Build()).
 		Build()


### PR DESCRIPTION
## 📝 Description

Feishu file uploads already distinguish `opus` audio and `mp4` video, but the send step always used the generic `file` message type. As a result, uploaded audio and video were delivered as downloadable files instead of native playable messages.

This change maps outbound media parts to Feishu message types:

- `audio` → `audio`
- `video` → `media`
- other files → `file`

The upload format and generic-file behavior remain unchanged.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

No linked issue. The bug was reproduced from the current `main` code path, and no open duplicate PR was found before submission.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://open.feishu.cn/document/server-docs/im-v1/message/create?lang=en-US
- **Reasoning:** Feishu requires `audio` and `media` message types to render native players. Uploading as `opus`/`mp4` while sending as `file` discards that rendering behavior.

## 🧪 Test Environment
- **Hardware:** Apple Silicon Mac
- **OS:** macOS (Darwin arm64)
- **Model/Provider:** OpenAI Codex
- **Channels:** Feishu

## 📸 Evidence (Optional)
<details>
<summary>Click to view validation results</summary>

- `go test ./pkg/channels/feishu -run TestFeishuMediaMessageType -count=1` — pass
- `go test ./pkg/channels/feishu -count=1` — pass
- `golangci-lint v2.10.1 run --build-tags goolm,stdjson ./pkg/channels/feishu/...` — 0 issues
- `./scripts/lint-docs.sh` — pass
- Full repository vet completed successfully. The macOS full test run retains three unrelated pre-existing `pkg/tools` failures caused by `/var` versus `/private/var` temporary-path canonicalization; the Feishu package is fully green.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] Documentation is unchanged because this is an internal message-type correction with no configuration or API changes.
