### PR TITLE
- fix scope bug for refresh agy token

### DIFF
--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -444,7 +444,7 @@ func RefreshAccessToken(cred *AuthCredential, cfg OAuthProviderConfig) (*AuthCre
 		"client_id":     {cfg.ClientID},
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {cred.RefreshToken},
-		"scope":         {"openid profile email"},
+		"scope":         {cfg.Scopes},
 	}
 	if cfg.ClientSecret != "" {
 		data.Set("client_secret", cfg.ClientSecret)

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -231,6 +231,8 @@ func TestExchangeCodeForTokens(t *testing.T) {
 }
 
 func TestRefreshAccessToken(t *testing.T) {
+	expectedScope := "https://www.googleapis.com/auth/cloud-platform custom-scope"
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/oauth/token" {
 			http.Error(w, "not found", http.StatusNotFound)
@@ -241,6 +243,10 @@ func TestRefreshAccessToken(t *testing.T) {
 		if r.FormValue("grant_type") != "refresh_token" {
 			http.Error(w, "invalid grant_type", http.StatusBadRequest)
 			return
+		}
+
+		if gotScope := r.FormValue("scope"); gotScope != expectedScope {
+			t.Errorf("Server received scope = %q, want %q", gotScope, expectedScope)
 		}
 
 		resp := map[string]any{
@@ -255,6 +261,7 @@ func TestRefreshAccessToken(t *testing.T) {
 	cfg := OAuthProviderConfig{
 		Issuer:   server.URL,
 		ClientID: "test-client",
+		Scopes:   expectedScope,
 	}
 
 	cred := &AuthCredential{


### PR DESCRIPTION
## 📝 Description

When using antigravity, primary auth succeeds, but the token refresh failed (the scope was passed incorrectly), leading to the error: Error processing message: LLM call failed after retries: antigravity API error (PERMISSION_DENIED): Request had insufficient authentication scopes.

## 🗣️ Type of Change
- [+] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [+] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue
None

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
- **Reasoning:**

## 🧪 Test Environment
- **OS:** Docker
- **Model/Provider:** Antigravity

## ☑️ Checklist
- [+] My code/docs follow the style of this project.
- [+] I have performed a self-review of my own changes.
