### PR TITLE
fix(auth): make browser OAuth login survive real-world callback conditions

### DIFF
--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -105,7 +105,7 @@ func LoginBrowserWithOptions(cfg OAuthProviderConfig, opts LoginBrowserOptions) 
 
 	if !opts.NoBrowser {
 		callbackResultCh := make(chan callbackResult, 1)
-		listener, actualPort, err := listenOAuthCallback(cfg.Port)
+		listeners, actualPort, err := listenOAuthCallback(cfg.Port)
 		if err != nil {
 			return nil, fmt.Errorf("starting callback server on port %d: %w", cfg.Port, err)
 		}
@@ -114,10 +114,14 @@ func LoginBrowserWithOptions(cfg OAuthProviderConfig, opts LoginBrowserOptions) 
 		callbackPort = actualPort
 		resultCh = callbackResultCh
 
+		// Serve on every bound address (IPv4 and IPv6 loopback) so the callback
+		// works regardless of how the browser resolves "localhost".
 		server := &http.Server{Handler: oauthCallbackHandler(state, callbackResultCh)}
-		go func() {
-			_ = server.Serve(listener)
-		}()
+		for _, l := range listeners {
+			go func(l net.Listener) {
+				_ = server.Serve(l)
+			}(l)
+		}
 		defer func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
@@ -151,6 +155,13 @@ func LoginBrowserWithOptions(cfg OAuthProviderConfig, opts LoginBrowserOptions) 
 	go func() {
 		reader := bufio.NewReader(browserLoginInput)
 		input, _ := reader.ReadString('\n')
+		// When stdin is not a terminal (systemd unit, piped command, `nohup`),
+		// the read returns EOF immediately. Treating that as "canceled" used to
+		// kill the browser flow before the user could even open the URL, so an
+		// empty read is ignored and the callback server keeps waiting.
+		if strings.TrimSpace(input) == "" {
+			return
+		}
 		select {
 		case manualCh <- strings.TrimSpace(input):
 		case <-manualDone:
@@ -179,9 +190,22 @@ func LoginBrowserWithOptions(cfg OAuthProviderConfig, opts LoginBrowserOptions) 
 			return nil, fmt.Errorf("could not find authorization code in input")
 		}
 		return ExchangeCodeForTokens(cfg, code, pkce.CodeVerifier, redirectURI)
-	case <-time.After(5 * time.Minute):
-		return nil, fmt.Errorf("authentication timed out after 5 minutes")
+	case <-time.After(browserLoginTimeout()):
+		return nil, fmt.Errorf("authentication timed out after %s", browserLoginTimeout())
 	}
+}
+
+// browserLoginTimeout returns how long to wait for the OAuth callback.
+// Headless setups need time to move the URL to another machine and set up a
+// tunnel, so the default is generous; PICOCLAW_OAUTH_TIMEOUT overrides it
+// (any duration Go can parse, e.g. "5m", "30m").
+func browserLoginTimeout() time.Duration {
+	if raw := os.Getenv("PICOCLAW_OAUTH_TIMEOUT"); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 15 * time.Minute
 }
 
 func oauthCallbackRedirectURI(port int) string {
@@ -191,9 +215,11 @@ func oauthCallbackRedirectURI(port int) string {
 func oauthCallbackHandler(state string, resultCh chan<- callbackResult) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/auth/callback", func(w http.ResponseWriter, r *http.Request) {
+		// A stale browser tab replaying an older callback, a prefetch, or any other
+		// unrelated request must not abort the login that is currently in flight.
+		// Reject it locally and keep waiting for the real callback.
 		if r.URL.Query().Get("state") != state {
-			resultCh <- callbackResult{err: fmt.Errorf("state mismatch")}
-			http.Error(w, "State mismatch", http.StatusBadRequest)
+			http.Error(w, "State mismatch (stale or unrelated callback ignored)", http.StatusBadRequest)
 			return
 		}
 
@@ -212,19 +238,30 @@ func oauthCallbackHandler(state string, resultCh chan<- callbackResult) http.Han
 	return mux
 }
 
-func listenOAuthCallback(port int) (net.Listener, int, error) {
-	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+// listenOAuthCallback binds the callback port on both IPv4 and IPv6 loopback.
+// Browsers differ in how they resolve "localhost" (macOS Safari prefers ::1),
+// and an IPv4-only listener makes the callback fail with "cannot connect to
+// server" even though the login itself succeeded. IPv6 is best-effort: hosts
+// without it still get a working IPv4 listener.
+func listenOAuthCallback(port int) ([]net.Listener, int, error) {
+	v4, err := net.Listen("tcp4", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return nil, 0, err
 	}
 
-	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	tcpAddr, ok := v4.Addr().(*net.TCPAddr)
 	if !ok {
-		_ = listener.Close()
-		return nil, 0, fmt.Errorf("unexpected listener address type %T", listener.Addr())
+		_ = v4.Close()
+		return nil, 0, fmt.Errorf("unexpected listener address type %T", v4.Addr())
+	}
+	actualPort := tcpAddr.Port
+
+	listeners := []net.Listener{v4}
+	if v6, err := net.Listen("tcp6", fmt.Sprintf("[::1]:%d", actualPort)); err == nil {
+		listeners = append(listeners, v6)
 	}
 
-	return listener, tcpAddr.Port, nil
+	return listeners, actualPort, nil
 }
 
 type callbackResult struct {

--- a/pkg/auth/oauth_callback_test.go
+++ b/pkg/auth/oauth_callback_test.go
@@ -1,0 +1,145 @@
+package auth
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// serveCallback starts the callback handler on every loopback listener,
+// mirroring what LoginBrowserWithOptions does.
+func serveCallback(t *testing.T, state string) (int, chan callbackResult) {
+	t.Helper()
+
+	listeners, port, err := listenOAuthCallback(0)
+	if err != nil {
+		t.Fatalf("listenOAuthCallback: %v", err)
+	}
+
+	resultCh := make(chan callbackResult, 4)
+	server := &http.Server{Handler: oauthCallbackHandler(state, resultCh)}
+	for _, l := range listeners {
+		go func(l net.Listener) { _ = server.Serve(l) }(l)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	return port, resultCh
+}
+
+// The callback must be reachable however the browser resolves "localhost".
+// An IPv4-only listener made the redirect fail on hosts that prefer ::1.
+func TestOAuthCallbackListensOnBothLoopbackFamilies(t *testing.T) {
+	listeners, port, err := listenOAuthCallback(0)
+	if err != nil {
+		t.Fatalf("listenOAuthCallback: %v", err)
+	}
+	defer func() {
+		for _, l := range listeners {
+			_ = l.Close()
+		}
+	}()
+
+	if len(listeners) < 2 {
+		t.Skip("host has no IPv6 loopback; IPv4-only listener is expected here")
+	}
+
+	for _, host := range []string{"127.0.0.1", "[::1]"} {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), 2*time.Second)
+		if err != nil {
+			t.Fatalf("dial %s:%d: %v", host, port, err)
+		}
+		_ = conn.Close()
+	}
+}
+
+// A stale tab replaying an old callback used to push an error onto the result
+// channel, aborting the login in flight. It must be rejected locally instead.
+func TestOAuthCallbackIgnoresStateMismatch(t *testing.T) {
+	port, resultCh := serveCallback(t, "good-state")
+	base := fmt.Sprintf("http://127.0.0.1:%d/auth/callback", port)
+
+	resp, err := http.Get(base + "?state=stale-state&code=stale-code")
+	if err != nil {
+		t.Fatalf("stale callback request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("stale callback status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	select {
+	case r := <-resultCh:
+		t.Fatalf("stale callback aborted the login: %+v", r)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// The real callback still completes afterwards.
+	resp, err = http.Get(base + "?state=good-state&code=real-code")
+	if err != nil {
+		t.Fatalf("real callback request: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case r := <-resultCh:
+		if r.err != nil || r.code != "real-code" {
+			t.Fatalf("got %+v, want code real-code", r)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("real callback never delivered")
+	}
+}
+
+// Without a TTY the manual-paste reader hits EOF immediately. That must not
+// cancel the browser flow before the user has opened the URL.
+func TestLoginBrowserEmptyStdinDoesNotCancel(t *testing.T) {
+	origInput := browserLoginInput
+	origOpen := openBrowserFunc
+	t.Cleanup(func() {
+		browserLoginInput = origInput
+		openBrowserFunc = origOpen
+	})
+
+	browserLoginInput = strings.NewReader("") // EOF, as under systemd
+	openBrowserFunc = func(string) error { return nil }
+
+	t.Setenv("PICOCLAW_OAUTH_TIMEOUT", "1s")
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := LoginBrowserWithOptions(OAuthProviderConfig{
+			Issuer:   "https://example.invalid/o/oauth2/v2",
+			ClientID: "test-client",
+			Port:     0,
+		}, LoginBrowserOptions{})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("got %v, want a timeout (empty stdin must not cancel)", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("login did not return")
+	}
+}
+
+func TestBrowserLoginTimeoutOverride(t *testing.T) {
+	if got := browserLoginTimeout(); got != 15*time.Minute {
+		t.Fatalf("default timeout = %s, want 15m", got)
+	}
+
+	t.Setenv("PICOCLAW_OAUTH_TIMEOUT", "30m")
+	if got := browserLoginTimeout(); got != 30*time.Minute {
+		t.Fatalf("override timeout = %s, want 30m", got)
+	}
+
+	t.Setenv("PICOCLAW_OAUTH_TIMEOUT", "not-a-duration")
+	if got := browserLoginTimeout(); got != 15*time.Minute {
+		t.Fatalf("invalid override timeout = %s, want fallback 15m", got)
+	}
+}


### PR DESCRIPTION
## Problem

`picoclaw auth login --provider <oauth-provider>` fails on almost every headless / remote setup, and each failure happens *after* the user has already approved consent — the authorization code is burned and the whole flow has to restart.

Four independent causes, all found while authenticating Antigravity on a remote VM (related: #3274, #3278):

### 1. Callback listener binds IPv4 loopback only

`listenOAuthCallback` binds `127.0.0.1` only. Browsers that resolve `localhost` to `::1` first — Safari on macOS does — get connection refused, so the redirect ends in "cannot connect to server" even though the login succeeded on the provider's side. This also breaks the standard `ssh -L` workaround unless the user happens to forward the right family.

### 2. A stale callback kills the login in flight

Any request with a mismatched `state` pushes a fatal error onto the result channel:

```go
if r.URL.Query().Get("state") != state {
    resultCh <- callbackResult{err: fmt.Errorf("state mismatch")}
```

So an old browser tab replaying a previous callback (or a prefetch, or a port scan) aborts the *current* login. In practice this is easy to hit: retry the login, an old tab reloads, and the fresh session dies with `login failed: state mismatch` — invalidating the code the user just obtained.

The state check is CSRF protection for the request; it should reject that request, not the session.

### 3. `manual input canceled` fires immediately without a TTY

The manual-paste goroutine treats stdin EOF as an explicit cancel:

```go
input, _ := reader.ReadString('\n')
// ...
case manualInput := <-manualCh:
    if manualInput == "" {
        return nil, fmt.Errorf("manual input canceled")
```

Under systemd, a pipe, or `nohup`, `ReadString` returns EOF instantly, so the login aborts before the user can even open the URL — which is exactly the headless case the manual-paste path exists to serve.

### 4. Five-minute timeout is too short for the headless path

The message tells the user to complete login in a local browser and paste the redirect URL back. Moving the URL to another machine and setting up a tunnel routinely takes longer than five minutes.

## Changes

- Bind both loopback families on the same port. IPv6 is best-effort, so hosts without it keep working with IPv4 only.
- Reject state-mismatched callbacks with `400` and keep waiting for the real one.
- Ignore empty stdin reads instead of treating them as a cancel.
- Default timeout 5m → 15m, overridable with `PICOCLAW_OAUTH_TIMEOUT` (any `time.ParseDuration` value).

No config, CLI, or provider changes; behaviour is unchanged for a normal desktop login that succeeds on the first try.

## Tests

Four regression tests in `pkg/auth/oauth_callback_test.go`, one per bug — dual-family reachability (skips where there is no IPv6 loopback), stale callback followed by a successful real callback, empty-stdin login reaching the timeout instead of cancelling, and the timeout override. `go test ./pkg/auth/` passes.

## Verification

Built and deployed on the VM where the original failures occurred; `picoclaw auth login --provider antigravity` now completes through an `ssh -L 51121:localhost:51121` tunnel without any of the four failure modes.
