### PR TITLE
fix(channels): prevent SplitMessage hang on oversized fence headers

### DIFF
--- a/pkg/channels/split.go
+++ b/pkg/channels/split.go
@@ -111,6 +111,13 @@ func SplitMessage(content string, maxLen int) []string {
 							msgEnd = unclosedIdx
 						} else {
 							splitAt := min(start+maxLen-5, totalLen)
+							// Close/reopen reconstruction must consume at least one body rune beyond the reinserted header newline.
+							if splitAt <= headerEndIdx+1 {
+								rawEnd := min(start+maxLen, totalLen)
+								messages = append(messages, string(runes[start:rawEnd]))
+								start = rawEnd
+								continue
+							}
 							chunk := strings.TrimRight(string(runes[start:splitAt]), " \t\n\r") + "\n```"
 							messages = append(messages, chunk)
 							remaining := strings.TrimSpace(header + "\n" + string(runes[splitAt:totalLen]))

--- a/pkg/channels/split_test.go
+++ b/pkg/channels/split_test.go
@@ -1,8 +1,13 @@
 package channels
 
 import (
+	"context"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
+	"unicode/utf8"
 )
 
 func TestSplitMessage(t *testing.T) {
@@ -144,6 +149,77 @@ func TestSplitMessage(t *testing.T) {
 				tc.checkContent(t, got)
 			}
 		})
+	}
+}
+
+func TestSplitMessage_OversizedFenceHeader(t *testing.T) {
+	const (
+		helperEnv = "PICOCLAW_SPLITMESSAGE_HANG_HELPER"
+		maxLen    = 400
+	)
+
+	exactIssueContent := "```" + strings.Repeat("a", 500) + "\nbody\n```"
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "exact issue 3264 reproducer",
+			content: exactIssueContent,
+		},
+		{
+			name:    "split point equals body start",
+			content: "```" + strings.Repeat("a", 391) + "\nbody\n```",
+		},
+		{
+			name:    "multibyte oversized header",
+			content: "```" + strings.Repeat("\u754c", 500) + "\nbody\n```",
+		},
+	}
+
+	if os.Getenv(helperEnv) == "1" {
+		for _, tc := range tests {
+			SplitMessage(tc.content, maxLen)
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestSplitMessage_OversizedFenceHeader$")
+	cmd.Env = append(os.Environ(), helperEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("SplitMessage helper timed out; oversized fence header did not terminate\n%s", output)
+	}
+	if err != nil {
+		t.Fatalf("SplitMessage helper failed: %v\n%s", err, output)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assertRawSplitPreserved(t, tc.content, maxLen, SplitMessage(tc.content, maxLen))
+		})
+	}
+}
+
+func assertRawSplitPreserved(t *testing.T, content string, maxLen int, chunks []string) {
+	t.Helper()
+
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d: %q", len(chunks), chunks)
+	}
+	for i, chunk := range chunks {
+		if !utf8.ValidString(chunk) {
+			t.Errorf("chunk %d is not valid UTF-8: %q", i, chunk)
+		}
+		if got := len([]rune(chunk)); got > maxLen {
+			t.Errorf("chunk %d has %d runes, exceeds maxLen %d", i, got, maxLen)
+		}
+	}
+	if got := strings.Join(chunks, ""); got != content {
+		t.Errorf("joined chunks differ from source: got %q, want %q", got, content)
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

Fix `SplitMessage` hanging when an opening fenced-code info string exceeds `maxLen`. When fence close/reopen reconstruction cannot consume body content, the splitter now falls back to a bounded raw split so it always makes progress.

Adds regression coverage for the reported reproducer, the body-boundary case, and multibyte headers.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)

## 🔗 Related Issue

Fixes #3264

## 📚 Technical Context
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/3264
- **Reasoning:** Reconstructing an oversized fence header could leave the remaining input unchanged; a bounded raw split guarantees forward progress.

## 🧪 Test Environment
- **Hardware:** x86_64 development host
- **OS:** Linux
- **Model/Provider:** OpenCode Go / `DeepSeek V4 Flash`
- **Channels:** Shared channel splitter

Tests:
- `go test -count=1 ./pkg/channels`
- `go test -count=1 -race -run 'TestSplitMessage' ./pkg/channels`
- Live `picoclaw agent` smoke test with `DeepSeek V4 Flash` via OpenCode Go

## ☑️ Checklist
- [x] My code follows the style of this project.
- [x] I have performed a self-review of my changes.
- [x] No documentation update is required for this internal bug fix.
