### PR TITLE
Fix: agent not able to execute shell command added to customAllowPatterns

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -5,6 +5,10 @@ name: auto-pr
 # so the agent's PAT never needs Pull requests: write.
 # PRs are authored by github-actions[bot] → a human (j-v) CAN approve them.
 # Merging stays 100% human-gated: the agent token has no PR write at all.
+#
+# REQUIRES repo setting: Settings → Actions → General → Workflow permissions →
+# "Allow GitHub Actions to create and approve pull requests" (enabled 2026-08-02).
+# The YAML permissions block alone is NOT sufficient — the repo-level toggle gates it.
 
 on:
   push:

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,53 @@
+name: auto-pr
+
+# Opens a PR automatically when a feature/fix branch is pushed.
+# Uses the repo's GITHUB_TOKEN (scoped to this repo, acts as github-actions[bot])
+# so the agent's PAT never needs Pull requests: write.
+# PRs are authored by github-actions[bot] → a human (j-v) CAN approve them.
+# Merging stays 100% human-gated: the agent token has no PR write at all.
+
+on:
+  push:
+    branches:
+      - 'fix/**'
+      - 'feat/**'
+      - 'feature/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-or-update-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open or update PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          HEAD="${{ github.ref_name }}"
+          REPO="${{ github.repository }}"
+
+          # Idempotent: skip if a PR for this head branch already exists
+          if gh pr view "$HEAD" --repo "$REPO" --json url --jq .url >/dev/null 2>&1; then
+            echo "PR already exists for $HEAD — skipping (no-op)"
+            exit 0
+          fi
+
+          TITLE="$(git log -1 --format=%s "$HEAD")"
+          BODY="Auto-opened by the \`auto-pr\` workflow (GITHUB_TOKEN as github-actions[bot]).
+
+Human approval + merge required — the agent's PAT intentionally has no Pull requests permission, so this PR cannot be merged by the agent."
+
+          gh pr create \
+            --repo "$REPO" \
+            --base main \
+            --head "$HEAD" \
+            --title "$TITLE" \
+            --body "$BODY" \
+          || echo "gh pr create failed (branch may have no commits vs main) — not fatal"

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -40,9 +40,7 @@ jobs:
           fi
 
           TITLE="$(git log -1 --format=%s "$HEAD")"
-          BODY="Auto-opened by the \`auto-pr\` workflow (GITHUB_TOKEN as github-actions[bot]).
-
-Human approval + merge required — the agent's PAT intentionally has no Pull requests permission, so this PR cannot be merged by the agent."
+          BODY="Auto-opened by the auto-pr workflow (GITHUB_TOKEN as github-actions[bot]). Human approval + merge required — the agent's PAT intentionally has no Pull requests permission, so this PR cannot be merged by the agent."
 
           gh pr create \
             --repo "$REPO" \

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -18,6 +18,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/**'
+  pull_request:
   workflow_dispatch:
     inputs:
       ref:
@@ -93,6 +94,7 @@ jobs:
           ls -la pkg/
 
       - name: Upload artifact
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: picoclaw-linux-arm64

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -1,0 +1,100 @@
+name: Build PicoClaw (arm64)
+
+# Cross-compiles BOTH binaries (picoclaw CLI/gateway + picoclaw-launcher web console)
+# for linux/arm64 on GitHub-hosted runners and uploads them as a build artifact.
+# The Pi watchdog polls for these artifacts and self-deploys (pull-based, zero sudo).
+#
+# This workflow is additive on purpose: upstream's build.yml (integration tests +
+# build-all) is left untouched so future upstream merges stay conflict-free.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**.go'
+      - 'web/frontend/**'
+      - 'Makefile'
+      - 'web/Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or commit SHA to build'
+        required: false
+        default: 'main'
+
+env:
+  GO_BUILD_TAGS: 'goolm,stdjson'
+
+jobs:
+  build:
+    name: Cross-Compile (linux/arm64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Build picoclaw (CLI/gateway)
+        run: |
+          VERSION=$(git describe --tags --always --dirty)
+          COMMIT=$(git rev-parse --short=8 HEAD)
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          GO_VERSION=$(go env GOVERSION)
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+            -tags "$GO_BUILD_TAGS" \
+            -ldflags="-s -w \
+              -X github.com/sipeed/picoclaw/pkg/config.Version=$VERSION \
+              -X github.com/sipeed/picoclaw/pkg/config.GitCommit=$COMMIT \
+              -X github.com/sipeed/picoclaw/pkg/config.BuildTime=$BUILD_TIME \
+              -X github.com/sipeed/picoclaw/pkg/config.GoVersion=$GO_VERSION" \
+            -o picoclaw-linux-arm64 \
+            ./cmd/picoclaw
+
+      - name: Build launcher frontend
+        run: make -C web build-frontend
+
+      - name: Build picoclaw-launcher (web console)
+        run: |
+          VERSION=$(git describe --tags --always --dirty)
+          COMMIT=$(git rev-parse --short=8 HEAD)
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          GO_VERSION=$(go env GOVERSION)
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+            -tags "$GO_BUILD_TAGS" \
+            -ldflags="-s -w \
+              -X github.com/sipeed/picoclaw/pkg/config.Version=$VERSION \
+              -X github.com/sipeed/picoclaw/pkg/config.GitCommit=$COMMIT \
+              -X github.com/sipeed/picoclaw/pkg/config.BuildTime=$BUILD_TIME \
+              -X github.com/sipeed/picoclaw/pkg/config.GoVersion=$GO_VERSION" \
+            -o picoclaw-launcher-linux-arm64 \
+            ./web/backend
+
+      - name: Package artifact
+        run: |
+          mkdir -p pkg
+          cp picoclaw-linux-arm64 pkg/picoclaw
+          cp picoclaw-launcher-linux-arm64 pkg/picoclaw-launcher
+          ls -la pkg/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: picoclaw-linux-arm64
+          path: pkg/
+          retention-days: 1

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -11,10 +11,17 @@ name: Build PicoClaw (arm64)
 # real top-level `pkg/` dir, so `path: pkg/` would upload the entire source tree
 # (698 files) instead of the two binaries — breaking `gh run download` on the Pi
 # ("would result in path traversal") and failing the watchdog deploy.
+#
+# ⚠️ Trigger is `push` (all branches), NOT `pull_request`: PRs are opened by
+# github-actions[bot] (auto-pr workflow), and GitHub gates pull_request-triggered
+# runs from bot authors behind "requires approval from a maintainer". Push events
+# from trusted collaborators run immediately, and their check runs still show on
+# the PR. Artifact upload is restricted to main below so feature-branch builds
+# never reach the watchdog.
 
 on:
   push:
-    branches: [main]
+    branches: ['**']
     paths:
       - '**.go'
       - 'web/frontend/**'
@@ -23,7 +30,6 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/**'
-  pull_request:
   workflow_dispatch:
     inputs:
       ref:
@@ -99,7 +105,7 @@ jobs:
           ls -la dist/
 
       - name: Upload artifact
-        if: github.event_name == 'push'
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: picoclaw-linux-arm64

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -6,6 +6,11 @@ name: Build PicoClaw (arm64)
 #
 # This workflow is additive on purpose: upstream's build.yml (integration tests +
 # build-all) is left untouched so future upstream merges stay conflict-free.
+#
+# ⚠️ Packaging dir is `dist/`, NOT `pkg/`: this repo's Go source lives in the
+# real top-level `pkg/` dir, so `path: pkg/` would upload the entire source tree
+# (698 files) instead of the two binaries — breaking `gh run download` on the Pi
+# ("would result in path traversal") and failing the watchdog deploy.
 
 on:
   push:
@@ -88,15 +93,15 @@ jobs:
 
       - name: Package artifact
         run: |
-          mkdir -p pkg
-          cp picoclaw-linux-arm64 pkg/picoclaw
-          cp picoclaw-launcher-linux-arm64 pkg/picoclaw-launcher
-          ls -la pkg/
+          mkdir -p dist
+          cp picoclaw-linux-arm64 dist/picoclaw
+          cp picoclaw-launcher-linux-arm64 dist/picoclaw-launcher
+          ls -la dist/
 
       - name: Upload artifact
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: picoclaw-linux-arm64
-          path: pkg/
+          path: dist/
           retention-days: 1

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,30 @@
+name: gitleaks
+
+# Server-side secret scan — the enforcement layer the Pi cannot fake.
+# Runs on GitHub-hosted runners (not the Pi), scans all branches, and
+# is a REQUIRED status check on main (see branch protection in Phase 1).
+#
+# Layer stack (from Step 7 of PIPELINE_PLAN.md):
+#   1. gitleaks pre-commit hook (Pi, convenience only)
+#   2. GitHub push protection (server-side prevention, free for all repos)
+#   3. this workflow (server-side detection + merge gate)
+
+on:
+  pull_request:
+  push:
+    branches: ['**']   # scan feature branches immediately, not just at PR time
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,9 +8,12 @@ name: gitleaks
 #   1. gitleaks pre-commit hook (Pi, convenience only)
 #   2. GitHub push protection (server-side prevention, free for all repos)
 #   3. this workflow (server-side detection + merge gate)
+#
+# Trigger is `push` only (all branches): PRs are authored by github-actions[bot]
+# and pull_request-triggered runs from bot authors require maintainer approval.
+# Push runs are trusted and their checks still display on the PR.
 
 on:
-  pull_request:
   push:
     branches: ['**']   # scan feature branches immediately, not just at PR time
 

--- a/deploy-picoclaw.sh
+++ b/deploy-picoclaw.sh
@@ -1,0 +1,472 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================
+# PicoClaw deploy watchdog (Pi 3B)
+# Long-running poll-and-deploy loop. Runs as a user systemd service.
+#   Idle:    poll GitHub every 60s for latest successful run
+#   Tight:   poll every 5s while a build is in progress
+#   Deploy:  download artifact → pre-flight → symlink swap → restart → health check
+#   Rollback: new → previous → stable (0.3.1 known-good)
+#   Force:   systemctl --user kill -s USR1 picoclaw-deploy.service
+# ============================================================
+
+# ============================================================
+# Configuration
+# ============================================================
+REPO="j-v/picoclaw"
+WORKFLOW="build-arm64.yml"
+RELEASES_DIR="/opt/picoclaw/releases"
+STABLE_DIR="/opt/picoclaw/stable"         # 🛟 Known-good fallback (never pruned)
+CURRENT_LINK="/opt/picoclaw/current"       # 🔀 Symlink to active release
+STATE_FILE="/opt/picoclaw/.last-deployed-run"
+FAILED_STATE_FILE="/opt/picoclaw/.failed-runs"   # run-id + failure count — permanently skipped after threshold
+MARK_FAILED_THRESHOLD=2        # retry-once: permanently skip only after this many consecutive failures
+GH_ARTIFACT_NAME="picoclaw-linux-arm64"
+SERVICE="picoclaw-launcher"               # user systemd service name (--user)
+
+# Deploy notifications (Telegram) — best-effort, never blocks a deploy
+SECURITY_FILE="$HOME/.picoclaw/.security.yml"   # bot tokens live here (channel_list.telegram.settings.token)
+TELEGRAM_CHAT_ID="8707367919"
+
+# Health check — dual verification
+#   :18800 — launcher web console (HTTP)
+#   :18790 — gateway native port (TCP)
+HEALTH_CHECK_URL="http://localhost:18800"
+GATEWAY_PORT=18790
+HEALTH_RETRIES=20               # 20 × 2s ≈ 40s window — Pi 3B cold starts are slow on SD cards
+HEALTH_RETRY_INTERVAL=2         # seconds between retries
+
+# Download timeout — never let a hung network wedge the watchdog mid-deploy
+DOWNLOAD_TIMEOUT=180            # seconds
+
+# Prerequisite binaries the script depends on
+REQUIRED_CMDS=(gh jq nc curl file)
+
+# Poll intervals
+IDLE_SLEEP=60               # seconds between polls when idle
+TIGHT_SLEEP=5               # seconds between polls when build in progress
+
+KEEP_RELEASES=5             # number of release dirs to retain
+
+# ============================================================
+# Helpers
+# ============================================================
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+
+# ── Telegram notification (deploy events) ─────────────────────────────
+# Best-effort: failures here are logged, never fatal. Reads the bot token
+# from ~/.picoclaw/.security.yml (same source the compaction hook uses).
+notify() {
+  local msg="$1"
+  local token
+  token=$(python3 -c "
+import yaml
+try:
+    d = yaml.safe_load(open('$SECURITY_FILE'))
+    print(d.get('channel_list', {}).get('telegram', {}).get('settings', {}).get('token', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+
+  if [ -z "$token" ]; then
+    log "   (notify skipped: no telegram token in $SECURITY_FILE)"
+    return 0
+  fi
+
+  if ! curl -sf -o /dev/null -X POST "https://api.telegram.org/bot${token}/sendMessage" \
+      --data-urlencode "chat_id=$TELEGRAM_CHAT_ID" \
+      --data-urlencode "text=$msg" \
+      --data-urlencode "disable_web_page_preview=true" 2>/dev/null; then
+    log "   (notify failed — telegram unreachable)"
+  fi
+}
+
+ensure_dirs() {
+  mkdir -p "$RELEASES_DIR" "/opt/picoclaw"
+}
+
+# Fail fast if gh isn't authenticated
+check_gh_auth() {
+  if ! gh auth status 2>/dev/null; then
+    log "❌ gh CLI not authenticated. Run: gh auth login"
+    exit 1
+  fi
+}
+
+# Fail fast if any prerequisite binary is missing (silent hangs are the worst)
+check_prereqs() {
+  local missing=0
+  for cmd in "${REQUIRED_CMDS[@]}"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      log "❌ Missing required command: $cmd"
+      missing=1
+    fi
+  done
+  if [ "$missing" -eq 1 ]; then
+    log "   Install missing commands, then restart the watchdog."
+    log "   Debian: sudo apt install gh jq netcat-openbsd curl file"
+    exit 1
+  fi
+  log "   ✔️  Prerequisite commands present: ${REQUIRED_CMDS[*]}"
+}
+
+# Record a run failure. Runs are only permanently skipped after
+# MARK_FAILED_THRESHOLD consecutive failures — a transient network blip
+# gets a second chance on the next poll (retry-once).
+mark_failed() {
+  local run_id="$1"
+  local count=1
+  touch "$FAILED_STATE_FILE"
+
+  if grep -q "^$run_id " "$FAILED_STATE_FILE"; then
+    count=$(grep "^$run_id " "$FAILED_STATE_FILE" | awk '{print $2}')
+    count=$((count + 1))
+  fi
+
+  grep -v "^$run_id " "$FAILED_STATE_FILE" > "${FAILED_STATE_FILE}.tmp" 2>/dev/null || true
+  mv "${FAILED_STATE_FILE}.tmp" "$FAILED_STATE_FILE" 2>/dev/null || true
+  echo "$run_id $count" >> "$FAILED_STATE_FILE"
+
+  if [ "$count" -ge "$MARK_FAILED_THRESHOLD" ]; then
+    log "   Marked run #$run_id as permanently failed ($count consecutive failures) — will not retry"
+    notify "🚨 Deploy skipped: run #$run_id failed $count× in a row (artifact expired/corrupt) — will not retry"
+  else
+    log "   Run #$run_id failed (attempt $count/$MARK_FAILED_THRESHOLD) — will retry on next poll"
+  fi
+}
+
+# True if the run has hit the permanent-failure threshold
+is_failed() {
+  local run_id="$1"
+  [ -f "$FAILED_STATE_FILE" ] || return 1
+  local count
+  count=$(grep "^$run_id " "$FAILED_STATE_FILE" | awk '{print $2}')
+  [ -n "$count" ] && [ "$count" -ge "$MARK_FAILED_THRESHOLD" ]
+}
+
+# Clear failure state after a successful deploy (no longer pending retry)
+clear_failed() {
+  local run_id="$1"
+  [ -f "$FAILED_STATE_FILE" ] || return 0
+  grep -v "^$run_id " "$FAILED_STATE_FILE" > "${FAILED_STATE_FILE}.tmp" 2>/dev/null || true
+  mv "${FAILED_STATE_FILE}.tmp" "$FAILED_STATE_FILE" 2>/dev/null || true
+}
+
+# ============================================================
+# Health check — verify launcher + gateway are both responsive
+# ============================================================
+check_health() {
+  local max_attempts="$1"
+  local attempt=0
+
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    attempt=$((attempt + 1))
+
+    # Check 1: Launcher process alive?
+    if ! pgrep -f "picoclaw-launcher" > /dev/null; then
+      sleep "$HEALTH_RETRY_INTERVAL"
+      continue
+    fi
+
+    # Check 2: Launcher HTTP web UI responding?
+    if curl -sf -o /dev/null "$HEALTH_CHECK_URL" 2>/dev/null; then
+      # Check 3: Gateway accepting TCP connections on its native port?
+      if nc -z localhost "$GATEWAY_PORT" 2>/dev/null; then
+        return 0   # healthy!
+      fi
+    fi
+
+    sleep "$HEALTH_RETRY_INTERVAL"
+  done
+
+  return 1   # unhealthy after all retries
+}
+
+# ============================================================
+# Rollback — revert to previous release
+# ============================================================
+rollback() {
+  local failed_release="$1"
+
+  log "❌ Rolling back — removing failed release: $failed_release"
+
+  # Find the previous release (by directory name, sorted)
+  local prev
+  prev=$(ls -1t "$RELEASES_DIR" 2>/dev/null | head -n 2 | tail -n 1)
+  # Guard: if there's only one release dir (the failed one), there is no previous
+  [ "$prev" = "$failed_release" ] && prev=""
+
+  # --- Helper: activate a given release dir and health-check ---
+  deploy_from() {
+    local src_dir="$1"
+    local label="$2"
+
+    ln -sfn "$src_dir" "$CURRENT_LINK"
+
+    log "   Restarting $SERVICE with $label..."
+    pkill -f "picoclaw-launcher" 2>/dev/null || true   # clear strays (incl. old systemd instance) before restart
+    systemctl --user restart "$SERVICE" 2>/dev/null || true
+
+    if check_health "$HEALTH_RETRIES"; then
+      log "✅ $label gateway is running"
+      return 0
+    fi
+    return 1
+  }
+
+  # --- Attempt 1: rollback to previous release ---
+  if [ -n "$prev" ] && [ -d "$RELEASES_DIR/$prev" ]; then
+    log "   Rolling back: current → $prev"
+    rm -rf "$RELEASES_DIR/$failed_release"
+
+    if deploy_from "$RELEASES_DIR/$prev" "previous"; then
+      notify "⚠️ Deploy rolled back to previous release ($prev) after health check failure"
+      return 0
+    fi
+
+    log "⚠️  Previous release ALSO failed health check — cascading to stable..."
+  else
+    log "   No previous release directory found — cascading to stable..."
+    rm -rf "$RELEASES_DIR/$failed_release"
+  fi
+
+  # --- Attempt 2: fall back to known-good stable ---
+  if [ -f "$STABLE_DIR/picoclaw-launcher" ] && [ -f "$STABLE_DIR/picoclaw" ]; then
+    log "   💣 Stable fallback: deploying from $STABLE_DIR"
+    if deploy_from "$STABLE_DIR" "stable (known-good)"; then
+      notify "🛟 Stable fallback active (0.3.1 known-good) — previous release also failed health check"
+      return 0
+    fi
+    log "🚨 Stable fallback ALSO failed! Something is fundamentally wrong."
+  else
+    log "🚨 No stable fallback found at $STABLE_DIR — files missing!"
+  fi
+
+  log "   Manual intervention required."
+  notify "🚨 EMERGENCY: all rollback layers failed (new → previous → stable). Manual intervention required on the Pi."
+  return 1
+}
+
+# ============================================================
+# Deploy
+# ============================================================
+deploy() {
+  local run_id="$1"
+  local run_sha="$2"
+
+  log "=== Deploying run #$run_id ($(echo "$run_sha" | head -c 7)) ==="
+
+  # --- Download artifact ---
+  local tmp_dir
+  tmp_dir=$(mktemp -d)
+
+  log "   Downloading artifact..."
+  if ! timeout "$DOWNLOAD_TIMEOUT" gh run download "$run_id" --repo "$REPO" --name "$GH_ARTIFACT_NAME" --dir "$tmp_dir" 2>/dev/null; then
+    log "❌ Failed to download artifact for run #$run_id"
+    log "   (Likely expired — artifact retention is 1 day. Marking as skipped.)"
+    mark_failed "$run_id"
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  # --- Locate binaries (artifact may be a flat dir or nested in pkg/) ---
+  local launcher_bin=""
+  local cli_bin=""
+
+  if [ -f "$tmp_dir/picoclaw-launcher" ]; then
+    launcher_bin="$tmp_dir/picoclaw-launcher"
+    cli_bin="$tmp_dir/picoclaw"
+  elif [ -f "$tmp_dir/pkg/picoclaw-launcher" ]; then
+    launcher_bin="$tmp_dir/pkg/picoclaw-launcher"
+    cli_bin="$tmp_dir/pkg/picoclaw"
+  else
+    log "❌ Could not find picoclaw-launcher or picoclaw in artifact"
+    log "   Contents: $(ls -la "$tmp_dir" 2>/dev/null)"
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  # --- Pre-flight check ---
+  log "   Pre-flight: verifying binaries..."
+  for bin in "$launcher_bin" "$cli_bin"; do
+    local file_type
+    file_type=$(file "$bin")
+    if ! echo "$file_type" | grep -qi "ELF.*64-bit.*ARM.*aarch64"; then
+      log "❌ Pre-flight failed — unexpected binary type for $(basename "$bin"):"
+      log "   $file_type"
+      log "   Expected: ELF 64-bit ARM aarch64"
+      mark_failed "$run_id"
+      rm -rf "$tmp_dir"
+      return 1
+    fi
+  done
+  log "   ✔️  Pre-flight check passed (both binaries are ARM64 ELF)"
+
+  chmod +x "$launcher_bin" "$cli_bin"
+
+  # --- Create release directory ---
+  local timestamp
+  timestamp=$(date +%Y%m%d-%H%M%S)
+  local release_dir="$RELEASES_DIR/$timestamp"
+  mkdir -p "$release_dir"
+
+  log "   Deploying to $release_dir/"
+  cp "$launcher_bin" "$release_dir/picoclaw-launcher"
+  cp "$cli_bin" "$release_dir/picoclaw"
+
+  # --- Deploy: swap symlink and restart ---
+  log "   Swapping symlink: current → $timestamp"
+  ln -sfn "$release_dir" "$CURRENT_LINK"
+
+  log "   Restarting $SERVICE..."
+  pkill -f "picoclaw-launcher" 2>/dev/null || true   # clear strays (incl. old systemd instance) before restart
+  systemctl --user restart "$SERVICE" 2>/dev/null || true
+
+  # --- Health check ---
+  log "   ⏳ Health check (HTTP :18800 + TCP :18790)..."
+  if check_health "$HEALTH_RETRIES"; then
+    log "✅  All health checks passed"
+  else
+    log "❌  Health check failed — rolling back..."
+    rollback "$timestamp"
+    rm -rf "$tmp_dir"
+    return 1
+  fi
+
+  # --- Record state ---
+  echo "$run_id" > "$STATE_FILE"
+  clear_failed "$run_id"
+  notify "✅ Deploy succeeded — run #$run_id ($(echo "$run_sha" | head -c 7)) is live (release $timestamp)"
+
+  # --- Prune old releases ---
+  log "   Pruning old releases..."
+  ls -1t "$RELEASES_DIR" | tail -n +$((KEEP_RELEASES + 1)) | while read old; do
+    log "     Removing $old"
+    rm -rf "$RELEASES_DIR/$old"
+  done
+
+  rm -rf "$tmp_dir"
+  log "=== Done ==="
+}
+
+# ============================================================
+# Tight-poll a single run until it completes
+# ============================================================
+tight_poll() {
+  local run_id="$1"
+  log "⏳ Build #$run_id in progress — tight-polling every ${TIGHT_SLEEP}s..."
+
+  while true; do
+    sleep "$TIGHT_SLEEP"
+
+    local run_info status conclusion
+    run_info=$(gh run view "$run_id" --repo "$REPO" --json status,conclusion 2>/dev/null || echo '{"status":"unknown"}')
+    status=$(echo "$run_info" | jq -r '.status')
+    conclusion=$(echo "$run_info" | jq -r '.conclusion // empty')
+
+    if [ "$status" = "completed" ]; then
+      if [ "$conclusion" = "success" ]; then
+        log "✅ Build #$run_id completed successfully!"
+        deploy "$run_id" ""
+      elif [ "$conclusion" = "failure" ] || [ "$conclusion" = "cancelled" ]; then
+        log "❌ Build #$run_id $conclusion — skipping deploy"
+      else
+        log "⚠️  Build #$run_id completed with conclusion '$conclusion' — skipping deploy"
+      fi
+      return
+    fi
+
+    # Also check: did a different run complete while we were watching?
+    local latest_success
+    latest_success=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" --branch main --status success --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null)
+    if [ -n "$latest_success" ] && [ "$latest_success" != "$run_id" ]; then
+      if [ ! -f "$STATE_FILE" ] || [ "$(cat "$STATE_FILE")" != "$latest_success" ]; then
+        log "⚠️  New successful run #$latest_success appeared while tracking #$run_id — deploying"
+        deploy "$latest_success" ""
+        return
+      fi
+    fi
+  done
+}
+
+# ============================================================
+# Main loop
+# ============================================================
+check_gh_auth
+check_prereqs
+ensure_dirs
+
+log "🐚 PicoClaw deploy watchdog started"
+log "   Repo: $REPO"
+log "   Workflow: $WORKFLOW"
+log "   Service: $SERVICE (user service)"
+log "   Idle poll: ${IDLE_SLEEP}s"
+log "   Tight poll: ${TIGHT_SLEEP}s"
+log "   Health check: $HEALTH_CHECK_URL (HTTP) + localhost:$GATEWAY_PORT (TCP) (${HEALTH_RETRIES}x ${HEALTH_RETRY_INTERVAL}s)"
+log "   Manual trigger: SIGUSR1 → immediate poll (systemctl --user kill -s USR1 picoclaw-deploy)"
+
+# Force-poll on SIGUSR1: `systemctl --user kill -s USR1 picoclaw-deploy.service`
+# wakes the idle sleep and runs an immediate poll cycle (no PID needed).
+poll_now=0
+trap 'poll_now=1' USR1
+
+while true; do
+  # --- Phase 1: Check latest successful run (safety net) ---
+  success_json=$(gh run list \
+    --repo "$REPO" \
+    --workflow "$WORKFLOW" \
+    --branch main \
+    --status success \
+    --json databaseId,headSha \
+    --jq '.[0] // empty' 2>/dev/null)
+
+  if [ -n "$success_json" ]; then
+    success_id=$(echo "$success_json" | jq -r '.databaseId')
+    success_sha=$(echo "$success_json" | jq -r '.headSha // ""')
+
+    last_deployed=""
+    [ -f "$STATE_FILE" ] && last_deployed=$(cat "$STATE_FILE")
+
+    if [ "$last_deployed" != "$success_id" ] && ! is_failed "$success_id"; then
+      deploy "$success_id" "$success_sha"
+      continue  # re-check immediately after deploy
+    fi
+  fi
+
+  # --- Phase 2: Check for in-progress (tight-poll if found) ---
+  in_progress=$(gh run list \
+    --repo "$REPO" \
+    --workflow "$WORKFLOW" \
+    --branch main \
+    --status in_progress \
+    --json databaseId \
+    --jq '.[0].databaseId // empty' 2>/dev/null)
+
+  if [ -z "$in_progress" ]; then
+    # Also check queued/pending (build hasn't started running yet)
+    in_progress=$(gh run list \
+      --repo "$REPO" \
+      --workflow "$WORKFLOW" \
+      --branch main \
+      --status queued \
+      --json databaseId \
+      --jq '.[0].databaseId // empty' 2>/dev/null)
+  fi
+
+  if [ -n "$in_progress" ]; then
+    tight_poll "$in_progress"
+    continue
+  fi
+
+  # --- Phase 3: Nothing happening, idle ---
+  # Interruptible sleep: SIGUSR1 (force-poll) wakes it immediately.
+  # `|| true` is REQUIRED: with `set -e`, an interrupted `wait` returns
+  # 128+10 and would kill the watchdog instead of continuing the loop.
+  poll_now=0
+  sleep "$IDLE_SLEEP" &
+  wait $! || true
+  if [ "$poll_now" = 1 ]; then
+    log "   ⚡ Force-poll (SIGUSR1) — checking now"
+  fi
+done

--- a/deploy-picoclaw.sh
+++ b/deploy-picoclaw.sh
@@ -89,7 +89,7 @@ ensure_dirs() {
 # Fail fast if gh isn't authenticated
 check_gh_auth() {
   if ! gh auth status 2>/dev/null; then
-    log "❌ gh CLI not authenticated. Run: gh auth login"
+    log "❌ gh CLI not authenticated. Run setup-picoclaw.sh step 0 (fine-grained PAT), or: gh auth login"
     exit 1
   fi
 }

--- a/deploy-picoclaw.sh
+++ b/deploy-picoclaw.sh
@@ -270,13 +270,16 @@ deploy() {
     return 1
   fi
 
-  # --- Locate binaries (artifact may be a flat dir or nested in pkg/) ---
+  # --- Locate binaries (artifact may be a flat dir or nested in dist/ or pkg/) ---
   local launcher_bin=""
   local cli_bin=""
 
   if [ -f "$tmp_dir/picoclaw-launcher" ]; then
     launcher_bin="$tmp_dir/picoclaw-launcher"
     cli_bin="$tmp_dir/picoclaw"
+  elif [ -f "$tmp_dir/dist/picoclaw-launcher" ]; then
+    launcher_bin="$tmp_dir/dist/picoclaw-launcher"
+    cli_bin="$tmp_dir/dist/picoclaw"
   elif [ -f "$tmp_dir/pkg/picoclaw-launcher" ]; then
     launcher_bin="$tmp_dir/pkg/picoclaw-launcher"
     cli_bin="$tmp_dir/pkg/picoclaw"

--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -40,6 +40,7 @@ type ExecTool struct {
 	workingDir          string
 	timeout             time.Duration
 	denyPatterns        []*regexp.Regexp
+	customDenyPatterns  []*regexp.Regexp
 	allowPatterns       []*regexp.Regexp
 	customAllowPatterns []*regexp.Regexp
 	allowedPathPatterns []*regexp.Regexp
@@ -147,6 +148,7 @@ func NewExecToolWithConfig(
 	allowPaths ...[]*regexp.Regexp,
 ) (*ExecTool, error) {
 	denyPatterns := make([]*regexp.Regexp, 0)
+	customDenyPatterns := make([]*regexp.Regexp, 0)
 	customAllowPatterns := make([]*regexp.Regexp, 0)
 	var allowedPathPatterns []*regexp.Regexp
 	allowRemote := true
@@ -172,7 +174,7 @@ func NewExecToolWithConfig(
 					if err != nil {
 						return nil, fmt.Errorf("invalid custom deny pattern %q: %w", pattern, err)
 					}
-					denyPatterns = append(denyPatterns, re)
+					customDenyPatterns = append(customDenyPatterns, re)
 				}
 			}
 		} else {
@@ -202,6 +204,7 @@ func NewExecToolWithConfig(
 		workingDir:          workingDir,
 		timeout:             timeout,
 		denyPatterns:        denyPatterns,
+		customDenyPatterns:  customDenyPatterns,
 		allowPatterns:       nil,
 		customAllowPatterns: customAllowPatterns,
 		allowedPathPatterns: allowedPathPatterns,
@@ -1149,16 +1152,34 @@ func (t *ExecTool) commandMatchesAllowPattern(lower string) bool {
 	return false
 }
 
+func (t *ExecTool) commandMatchesCustomAllowPattern(lower string) bool {
+	for _, pattern := range t.customAllowPatterns {
+		if pattern.MatchString(lower) {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *ExecTool) guardCommand(command, cwd string) string {
 	cmd := strings.TrimSpace(command)
 	lower := strings.ToLower(cmd)
 
-	// Deny patterns always apply, even when a command matches a custom allow rule.
-	// Custom allow rules can permit a command, but must not disable secret-safety
-	// deny rules such as jq env access checks (#3079).
-	for _, pattern := range t.denyPatterns {
+	// Custom deny patterns always apply — they are user-specified security rules
+	// that must not be bypassed by custom allow patterns (#3079).
+	for _, pattern := range t.customDenyPatterns {
 		if pattern.MatchString(lower) {
 			return "Command blocked by safety guard (dangerous pattern detected)"
+		}
+	}
+
+	// Default deny patterns can be exempted by custom allow patterns,
+	// so operators can selectively permit normally-blocked commands.
+	if !t.commandMatchesCustomAllowPattern(lower) {
+		for _, pattern := range t.denyPatterns {
+			if pattern.MatchString(lower) {
+				return "Command blocked by safety guard (dangerous pattern detected)"
+			}
 		}
 	}
 

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -670,8 +670,12 @@ func TestShellTool_CustomAllowPatterns(t *testing.T) {
 		t.Fatalf("unable to configure exec tool: %s", err)
 	}
 
+	ctx := WithToolContext(context.Background(), "cli", "test")
+
 	// "git push origin main" should be allowed by custom allow pattern.
-	result := tool.Execute(context.Background(), map[string]any{
+	// It may fail for other reasons (no git repo), but the error should not be a guard block.
+	result := tool.Execute(ctx, map[string]any{
+		"action":  "run",
 		"command": "git push origin main",
 	})
 	if result.IsError && strings.Contains(result.ForLLM, "blocked") {
@@ -679,11 +683,32 @@ func TestShellTool_CustomAllowPatterns(t *testing.T) {
 	}
 
 	// "git push upstream main" should still be blocked (does not match allow pattern).
-	result = tool.Execute(context.Background(), map[string]any{
+	result = tool.Execute(ctx, map[string]any{
+		"action":  "run",
 		"command": "git push upstream main",
 	})
-	if !result.IsError {
-		t.Errorf("'git push upstream main' should still be blocked by deny pattern")
+	if !result.IsError || !strings.Contains(result.ForLLM, "blocked") {
+		t.Errorf("'git push upstream main' should still be blocked by deny pattern, got: %s", result.ForLLM)
+	}
+
+	// Without any custom allow pattern, "git push origin main" should be blocked.
+	cfgNoAllow := &config.Config{
+		Tools: config.ToolsConfig{
+			Exec: config.ExecConfig{
+				EnableDenyPatterns: true,
+			},
+		},
+	}
+	toolNoAllow, err := NewExecToolWithConfig("", false, cfgNoAllow)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+	result = toolNoAllow.Execute(ctx, map[string]any{
+		"action":  "run",
+		"command": "git push origin main",
+	})
+	if !result.IsError || !strings.Contains(result.ForLLM, "blocked") {
+		t.Errorf("'git push origin main' should be blocked without custom allow pattern, got: %s", result.ForLLM)
 	}
 }
 

--- a/scripts/setup-picoclaw.sh
+++ b/scripts/setup-picoclaw.sh
@@ -5,8 +5,9 @@
 # Run ONCE from an interactive SSH session on the Pi:
 #   cd ~/src/picoclaw && bash scripts/setup-picoclaw.sh
 #
-# It needs sudo (first TWO commands only), your GitHub login
-# (gh auth login), and your hands (deploy key paste, autostart edit).
+# It needs sudo (first TWO commands only), a GitHub fine-grained PAT
+# (saved at ~/.picoclaw/gh-token.txt — no interactive login), and your
+# hands (deploy key paste, autostart edit).
 # After this step, everything else is automated.
 #
 # Not fully idempotent: if it fails midway, fix the failing step
@@ -50,13 +51,30 @@ if ! gh auth status >/dev/null 2>&1; then
     echo "   ✔️  Token imported; plaintext file removed"
   else
     echo ""
-    echo "--- gh auth login (interactive) ---"
-    echo "Choose: GitHub.com → HTTPS → Login with a web browser → Yes (git credentials)"
+    echo "❌ gh is not authenticated, and no deploy token found at ~/.picoclaw/gh-token.txt"
     echo ""
-    gh auth login
+    echo "   Create a fine-grained PAT (NOT a browser login — the Pi must not hold your full account):"
+    echo "     GitHub → Settings → Developer settings → Fine-grained tokens → Generate new token"
+    echo "     - Repository access: Only select repositories → j-v/picoclaw"
+    echo "     - Repository permissions:"
+    echo "         Actions:  Read-only           (watchdog polls builds + downloads artifacts)"
+    echo "         Contents: Read and write      (agent pushes feature branches)"
+    echo "         Pull requests: LEAVE UNSET    (auto-pr workflow opens PRs; agent needs NO PR write)"
+    echo "     - Expiration: 90 days (or shorter)"
+    echo ""
+    echo "   Save the token to ~/.picoclaw/gh-token.txt and re-run this script."
+    echo ""
+    exit 1
   fi
 fi
 echo "   ✔️  gh authenticated as: $(gh api user --jq .login 2>/dev/null || echo '?')"
+
+# Soft-check the token can do what the deploy watchdog needs (Actions: read).
+# Not fatal — setup can finish, but the watchdog will fail at first poll.
+if ! gh api "repos/j-v/picoclaw/actions/runs?per_page=1" >/dev/null 2>&1; then
+  echo "   ⚠️  gh token could not read Actions runs for j-v/picoclaw — the deploy watchdog"
+  echo "       needs Actions: Read-only. Recreate the token with that permission."
+fi
 
 # ------------------------------------------------------------
 # 1. Create directory structure (the second and last sudo)
@@ -207,6 +225,35 @@ else
   echo "⚠️  Launcher not responding yet — check: journalctl --user -u picoclaw-launcher -n 50 --no-pager"
 fi
 
+# ------------------------------------------------------------
+# 9. Test Telegram deploy notification
+# ------------------------------------------------------------
+echo ""
+echo "[9/9] Testing Telegram deploy notification..."
+SECURITY_FILE="$HOME/.picoclaw/.security.yml"
+TELEGRAM_CHAT_ID="8707367919"
+tg_token=$(python3 -c "
+import yaml
+try:
+    d = yaml.safe_load(open('$SECURITY_FILE'))
+    print(d.get('channel_list', {}).get('telegram', {}).get('settings', {}).get('token', ''))
+except Exception:
+    pass
+" 2>/dev/null)
+if [ -z "$tg_token" ]; then
+  echo "   ⚠️  No Telegram token in $SECURITY_FILE — skipped (deploy notifications will be silent)."
+  echo "       Add channel_list.telegram.settings.token to $SECURITY_FILE to enable them."
+else
+  if curl -sf -o /dev/null -X POST "https://api.telegram.org/bot${tg_token}/sendMessage" \
+      --data-urlencode "chat_id=$TELEGRAM_CHAT_ID" \
+      --data-urlencode "text=✅ PicoClaw pipeline initialized — watchdog running. Deploy notifications active." \
+      --data-urlencode "disable_web_page_preview=true"; then
+    echo "   ✅ Test notification sent to Telegram"
+  else
+    echo "   ⚠️  Telegram send failed — check the token in $SECURITY_FILE"
+  fi
+fi
+
 echo ""
 echo "=== Setup complete ==="
 echo ""
@@ -219,3 +266,7 @@ echo "  2. Gitleaks (Phase 3):"
 echo "     go install github.com/gitleaks/gitleaks/v8@latest   (or download the release binary)"
 echo "     export PATH=\$PATH:\$HOME/go/bin"
 echo "  3. Watch the first deploy: journalctl --user -u picoclaw-deploy.service -f"
+echo ""
+echo "Note: gh auth is done above (step 0) using a fine-grained PAT only —"
+echo "no interactive browser login. If you re-run setup later, it skips auth"
+echo "when gh is already authenticated."

--- a/scripts/setup-picoclaw.sh
+++ b/scripts/setup-picoclaw.sh
@@ -3,7 +3,7 @@
 # PicoClaw pipeline — one-time Pi bootstrap (interactive)
 #
 # Run ONCE from an interactive SSH session on the Pi:
-#   cd ~/picoclaw && bash scripts/setup-picoclaw.sh
+#   cd ~/src/picoclaw && bash scripts/setup-picoclaw.sh
 #
 # It needs sudo (first TWO commands only), your GitHub login
 # (gh auth login), and your hands (deploy key paste, autostart edit).

--- a/scripts/setup-picoclaw.sh
+++ b/scripts/setup-picoclaw.sh
@@ -42,11 +42,19 @@ done
 echo "   ✔️  Prerequisites present: gh jq nc curl file"
 
 if ! gh auth status >/dev/null 2>&1; then
-  echo ""
-  echo "--- gh auth login (interactive) ---"
-  echo "Choose: GitHub.com → HTTPS → Login with a web browser → Yes (git credentials)"
-  echo ""
-  gh auth login
+  if [ -f "$HOME/.picoclaw/gh-token.txt" ]; then
+    echo "--- gh auth login (fine-grained PAT from ~/.picoclaw/gh-token.txt) ---"
+    chmod 600 "$HOME/.picoclaw/gh-token.txt"
+    gh auth login --hostname github.com --git-protocol https --with-token < "$HOME/.picoclaw/gh-token.txt"
+    rm -f "$HOME/.picoclaw/gh-token.txt"   # token now lives in ~/.config/gh/ (per plan)
+    echo "   ✔️  Token imported; plaintext file removed"
+  else
+    echo ""
+    echo "--- gh auth login (interactive) ---"
+    echo "Choose: GitHub.com → HTTPS → Login with a web browser → Yes (git credentials)"
+    echo ""
+    gh auth login
+  fi
 fi
 echo "   ✔️  gh authenticated as: $(gh api user --jq .login 2>/dev/null || echo '?')"
 

--- a/scripts/setup-picoclaw.sh
+++ b/scripts/setup-picoclaw.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# ============================================================
+# PicoClaw pipeline — one-time Pi bootstrap (interactive)
+#
+# Run ONCE from an interactive SSH session on the Pi:
+#   cd ~/picoclaw && bash scripts/setup-picoclaw.sh
+#
+# It needs sudo (first TWO commands only), your GitHub login
+# (gh auth login), and your hands (deploy key paste, autostart edit).
+# After this step, everything else is automated.
+#
+# Not fully idempotent: if it fails midway, fix the failing step
+# by hand and re-run.
+# ============================================================
+set -euo pipefail
+
+PIPELINE_DIR="/opt/picoclaw"
+RELEASES_DIR="$PIPELINE_DIR/releases"
+STABLE_DIR="$PIPELINE_DIR/stable"
+USER_NAME="$(whoami)"
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"   # parent of scripts/ = repo root
+LAUNCHER_SERVICE="$HOME/.config/systemd/user/picoclaw-launcher.service"
+DEPLOY_SERVICE="$HOME/.config/systemd/user/picoclaw-deploy.service"
+AUTOSTART="$HOME/.config/labwc/autostart"
+
+echo "=== PicoClaw pipeline setup ==="
+echo "Running as: $USER_NAME"
+echo "Repo dir:   $REPO_DIR"
+echo "Pipeline:   $PIPELINE_DIR"
+echo ""
+
+# ------------------------------------------------------------
+# 0. Prerequisites + auth (the first of two sudo steps)
+# ------------------------------------------------------------
+echo "[0/8] Installing prerequisites (sudo apt)..."
+sudo apt update
+sudo apt install -y gh jq netcat-openbsd curl file
+
+for cmd in gh jq nc curl file; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "❌ Missing: $cmd — install it and re-run."; exit 1; }
+done
+echo "   ✔️  Prerequisites present: gh jq nc curl file"
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo ""
+  echo "--- gh auth login (interactive) ---"
+  echo "Choose: GitHub.com → HTTPS → Login with a web browser → Yes (git credentials)"
+  echo ""
+  gh auth login
+fi
+echo "   ✔️  gh authenticated as: $(gh api user --jq .login 2>/dev/null || echo '?')"
+
+# ------------------------------------------------------------
+# 1. Create directory structure (the second and last sudo)
+# ------------------------------------------------------------
+echo ""
+echo "[1/8] Creating $PIPELINE_DIR (sudo mkdir + chown)..."
+sudo mkdir -p "$STABLE_DIR" "$RELEASES_DIR"
+sudo chown -R "$USER_NAME:$USER_NAME" "$PIPELINE_DIR"
+echo "   ✔️  $PIPELINE_DIR ready (owned by $USER_NAME)"
+
+# ------------------------------------------------------------
+# 2. Snapshot current release → stable/ (emergency fallback)
+# ------------------------------------------------------------
+echo ""
+echo "[2/8] Snapshotting current release → $STABLE_DIR ..."
+if [ -f /usr/local/bin/picoclaw ] && [ -f /usr/local/bin/picoclaw-launcher ]; then
+  cp /usr/local/bin/picoclaw "$STABLE_DIR/"
+  cp /usr/local/bin/picoclaw-launcher "$STABLE_DIR/"
+else
+  echo "   ⚠️  /usr/local/bin binaries not found — skipping stable snapshot."
+fi
+ln -sfn "$STABLE_DIR" "$PIPELINE_DIR/current"
+ls -la "$STABLE_DIR/"
+echo "   ✔️  stable snapshot + current symlink (→ stable)"
+
+# ------------------------------------------------------------
+# 3. Install the deploy watchdog script
+# ------------------------------------------------------------
+echo ""
+echo "[3/8] Installing deploy-picoclaw.sh..."
+cp "$REPO_DIR/deploy-picoclaw.sh" "$PIPELINE_DIR/deploy-picoclaw.sh"
+chmod +x "$PIPELINE_DIR/deploy-picoclaw.sh"
+echo "   ✔️  $PIPELINE_DIR/deploy-picoclaw.sh"
+
+# ------------------------------------------------------------
+# 4. Launcher user service
+# ------------------------------------------------------------
+echo ""
+echo "[4/8] Writing launcher user service..."
+mkdir -p "$HOME/.config/systemd/user"
+cat > "$LAUNCHER_SERVICE" <<'EOS'
+[Unit]
+Description=PicoClaw gateway launcher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/picoclaw/current/picoclaw-launcher -no-browser -public
+# Always: even a clean exit comes back — the watchdog intentionally
+# kills+restarts this during deploys, so this is safe (and desirable).
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+EOS
+echo "   ✔️  $LAUNCHER_SERVICE"
+
+# ------------------------------------------------------------
+# 5. Deploy watchdog user service
+# ------------------------------------------------------------
+echo ""
+echo "[5/8] Writing deploy watchdog user service..."
+cat > "$DEPLOY_SERVICE" <<'EOS'
+[Unit]
+Description=PicoClaw deploy watchdog — polls GitHub, deploys on new builds
+Documentation=https://github.com/j-v/picoclaw
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/picoclaw/deploy-picoclaw.sh
+Restart=on-failure
+RestartSec=10
+
+# Rate-limit: 5 crashes in 10 minutes → give up and stop
+# (prevents infinite crash-loop hammering the GitHub API while debugging)
+StartLimitIntervalSec=600
+StartLimitBurst=5
+
+[Install]
+WantedBy=default.target
+EOS
+echo "   ✔️  $DEPLOY_SERVICE"
+
+# ------------------------------------------------------------
+# 5b. Stop the old bare launcher (port handoff — REQUIRED)
+# ------------------------------------------------------------
+echo ""
+echo "[5b/8] Stopping old bare launcher (port handoff :18800)..."
+if pgrep -f "picoclaw-launcher" >/dev/null 2>&1; then
+  pkill -f "picoclaw-launcher" || true
+  sleep 1
+fi
+if ss -tln | grep -q ":18800"; then
+  echo "   ⚠️  Port 18800 still busy — waiting 3s..."
+  sleep 3
+fi
+if ss -tln | grep -q ":18800"; then
+  echo "   ❌ Port 18800 still in use — resolve manually, then re-run."
+  exit 1
+else
+  echo "   ✔️  Port 18800 free"
+fi
+
+# ------------------------------------------------------------
+# 6. Enable services
+# ------------------------------------------------------------
+echo ""
+echo "[6/8] Enabling services..."
+systemctl --user daemon-reload
+systemctl --user enable --now picoclaw-launcher.service
+systemctl --user enable --now picoclaw-deploy.service
+echo "   ✔️  picoclaw-launcher.service + picoclaw-deploy.service enabled"
+
+# ------------------------------------------------------------
+# 7. Remove launcher from labwc autostart
+# ------------------------------------------------------------
+echo ""
+echo "[7/8] Removing launcher from labwc autostart..."
+if [ -f "$AUTOSTART" ]; then
+  if grep -q "picoclaw-launcher" "$AUTOSTART"; then
+    sed -i 's|.*picoclaw-launcher.*|# removed by pipeline setup: picoclaw-launcher (now systemd-managed)|' "$AUTOSTART"
+    echo "   ✔️  Commented out picoclaw-launcher in $AUTOSTART"
+  else
+    echo "   (no picoclaw-launcher line found — nothing to do)"
+  fi
+else
+  echo "   (no autostart file at $AUTOSTART — nothing to do)"
+fi
+
+# ------------------------------------------------------------
+# 8. Verify
+# ------------------------------------------------------------
+echo ""
+echo "[8/8] Verifying..."
+sleep 2
+echo "--- launcher service ---"
+systemctl --user status picoclaw-launcher.service --no-pager | head -5 || true
+echo "--- deploy service ---"
+systemctl --user status picoclaw-deploy.service --no-pager | head -5 || true
+echo ""
+if curl -sf -o /dev/null http://localhost:18800; then
+  echo "✅ Launcher responding on :18800"
+else
+  echo "⚠️  Launcher not responding yet — check: journalctl --user -u picoclaw-launcher -n 50 --no-pager"
+fi
+
+echo ""
+echo "=== Setup complete ==="
+echo ""
+echo "Remaining one-time steps:"
+echo "  1. Deploy key (Phase 4) — generate if not already done:"
+echo "     ssh-keygen -t ed25519 -f ~/.ssh/picoclaw-deploy -N \"\""
+echo "     → add pub key: https://github.com/j-v/picoclaw/settings/keys (Allow write access)"
+echo "     → then: git remote set-url origin git@github-picoclaw:j-v/picoclaw.git"
+echo "  2. Gitleaks (Phase 3):"
+echo "     go install github.com/gitleaks/gitleaks/v8@latest   (or download the release binary)"
+echo "     export PATH=\$PATH:\$HOME/go/bin"
+echo "  3. Watch the first deploy: journalctl --user -u picoclaw-deploy.service -f"

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: dev-cycle
+description: "Run the picoclaw dev cycle: check in code, run pre-push checks, push to a feature branch, open a PR, monitor CI builds, check watchdog/deploy status, roll back a bad release, or ship a fix. Use when the user wants to change, commit, push, build, deploy, or revert picoclaw itself."
+---
+
+# Dev Cycle Skill
+
+Domain knowledge for the PicoClaw development pipeline. The mechanical build→deploy
+loop is handled by the **watchdog** (`deploy-picoclaw.sh` on the Pi). This skill gives
+the agent the knowledge to gate, coordinate, monitor, and report on the whole lifecycle.
+
+Reference architecture: `PIPELINE_PLAN.md` (workspace).
+
+## Trigger paths
+
+| Trigger | How |
+|---------|-----|
+| **Slash command (explicit)** | `/use dev-cycle <message>` — forces the skill for one request; `/use dev-cycle` arms it for the next message; `/use clear` cancels |
+| **Natural language (implicit)** | Match the user's message against this skill's `description` (the NL key) |
+
+## The full dev cycle loop — ping at every step
+
+When running a change through the pipeline, announce each step so the user always
+knows where the cycle is. **No silent phases.**
+
+```
+1. ✏️  Make code changes (edit files via agent tools)
+     → ping: "Step 1/7 — editing files"
+2. 🔍 Pre-push checklist:
+   ├── git status — only expected files changed?
+   ├── gitleaks detect — no secrets leaked?
+   ├── no debug code left behind (console.log, fmt.Println, etc.)
+   ├── config changes reviewed (no API keys in source)?
+   └── commit message drafted and meaningful?
+     → ping: "Step 2/7 — pre-push checks: ✅ passed / ❌ blocked"
+3. ✅ Git commit
+     → ping: "Step 3/7 — committed <sha>"
+4. 🚀 Git push to feature branch + open PR
+     → ping: "Step 4/7 — pushed <branch>, PR #<n>: <url>"
+5. 👀 Build monitoring:
+   ├── Watchdog tight-polls automatically
+   └── Agent can report: "Build #1429 in progress..."
+     → ping: "Step 5/7 — CI: ✅ passed / ❌ failed"
+6. ✅ Automated deploy (watchdog handles it — after YOU merge to main)
+     → ping: "Step 6/7 — deploy started / rolled back"
+7. 🏥 Post-deploy verification:
+   ├── Health check passed (HTTP :18800 + TCP :18790)?
+   └── Agent can confirm: "Deploy succeeded, running release 20260730-... "
+     → ping: "Step 7/7 — ✅ done, running <release>"
+```
+
+## Pre-push checklist (run BEFORE any commit)
+
+| Check | What it verifies |
+|-------|-----------------|
+| `git status` | Only files we intend to commit are modified |
+| **No secrets** | Gitleaks pre-commit hook handles this automatically; agent also checks no API keys, tokens, or `.security.yml` references are in the diff |
+| **No debug code** | No `console.log()`, `println()`, `fmt.Print*()`, `debug.*`, or `TODO` comments intended for development only |
+| **Config sanity** | Any changes to `config.json`, `.env`, or YAML files are intentional and don't hardcode credentials |
+| **Commit message** | Descriptive, conventional commit format (`feat:`, `fix:`, `chore:`, etc.) |
+| **Branch** | Are we on `main`? Should be on a feature branch (`fix/...`, `feat/...`) |
+
+## Push + PR workflow (Tier 3 — human-gated merge)
+
+The agent pushes to a **feature branch only**. `main` is branch-protected: PR required,
+human merge. Never attempt a direct push to `main`.
+
+```bash
+git checkout -b fix/<desc>
+git add -A && git commit -m "fix: <desc>"
+git push origin fix/<desc>
+gh pr create --fill            # then ping the user with the PR link
+# USER merges via GitHub Mobile / web UI / CLI on a separate device
+```
+
+## Pre-deploy checklist (before any deploy action or force-poll)
+
+| Check | What it verifies |
+|-------|-----------------|
+| **CI status** | Latest build on `main` is green (`conclusion=success`) |
+| **Run ID** | Confirms the run ID we're deploying differs from `last-deployed-run` |
+| **Watchdog health** | `systemctl --user is-active picoclaw-deploy.service` = `active`. **If inactive:** `systemctl --user start picoclaw-deploy.service`, wait 5s, re-verify. |
+| **Launcher health** | `curl -sf http://localhost:18800` responds |
+| **Gateway health** | `nc -z localhost 18790` accepts connections |
+| **Artifact ready** | The run's artifact is available (check before deploy, not during) |
+
+## Status report (no step pings — this is a query, not a cycle)
+
+When asked "what's the status?", report:
+
+1. Latest CI run: `gh run list --repo j-v/picoclaw --workflow build-arm64.yml --branch main --limit 1` → "Build #N passed (abc1234)"
+2. Watchdog: `systemctl --user is-active picoclaw-deploy.service` + `cat /opt/picoclaw/.last-deployed-run`
+3. Current release: `readlink /opt/picoclaw/current`
+4. Health: `curl -sf http://localhost:18800` + `nc -z localhost 18790`
+
+## Rollback (manual)
+
+```bash
+ls -1 /opt/picoclaw/releases/
+PREV=<timestamp>
+ln -sfn /opt/picoclaw/releases/$PREV /opt/picoclaw/current
+systemctl --user restart picoclaw-launcher
+```
+
+Or fall back to the known-good snapshot:
+
+```bash
+ln -sfn /opt/picoclaw/stable /opt/picoclaw/current
+systemctl --user restart picoclaw-launcher
+```
+
+## Failure handling (auto-fix easy, stop on ambiguity)
+
+| Failure | Response |
+|---------|----------|
+| **Easy, unambiguous fix** (lint error, missing import, typo, gitleaks false positive, trivial test flake) | **Auto-fix and re-push.** Make the minimal change, re-run the failed check, commit to the same feature branch, push again, ping: "Fixed <x> → re-pushed <branch>, CI re-running" |
+| **Unclear cause / multiple plausible fixes / touches behavior** (test logic disagreement, build error that could mean several things, deploy failure with ambiguous logs) | **Stop and report.** Leave the branch as-is, ping with: what failed, what I saw in the logs, the 2–3 candidate fixes I'm weighing, and what I'd pick — wait for the user's call before touching anything else |
+| **Anything that needs a decision the user would want to make** (changing scope, bumping a dependency, altering config) | **Stop and report** — same as above. Never auto-apply changes outside the immediate failure being fixed |
+
+**Guardrails on auto-fix:**
+- Max **2 auto-fix attempts** per cycle; after that, stop and report (prevents fix-loops)
+- Auto-fix only commits to the **same feature branch** — never touches `main`, never bypasses the PR/merge gate
+- Auto-fix must re-run the **exact failing check** before re-pushing (CI green on the new commit, not assumed)
+- If a fix would touch more than ~10 lines or more than one file beyond the original change, **stop and report** — that's scope creep, not a fix
+- Gitleaks findings: only auto-fix **false positives** (add `gitleaks:allow` inline or allowlist entry). A real secret means stop — the push is already blocked server-side, and rotation policy applies
+
+## Relationship to the watchdog
+
+| Component | Role |
+|-----------|------|
+| **Watchdog** (`deploy-picoclaw.sh`) | Fully automated poll-and-deploy loop. Runs 24/7 as a user systemd service. |
+| **Dev cycle skill** | Agent knowledge of the full pipeline: pre-push checks, commit workflow, build monitoring, pre-deploy checks, status reports, rollback coordination. |
+
+## Key commands cheat-sheet
+
+```bash
+# Watchdog control
+systemctl --user status picoclaw-deploy.service
+systemctl --user kill -s USR1 picoclaw-deploy.service   # force immediate poll
+journalctl --user -u picoclaw-deploy.service -f         # follow deploy logs
+journalctl --user -u picoclaw-launcher.service -n 50 --no-pager
+
+# CI status
+gh run list --repo j-v/picoclaw --workflow build-arm64.yml --branch main --limit 3
+gh run view <run-id> --repo j-v/picoclaw
+
+# Deployed state
+readlink /opt/picoclaw/current
+cat /opt/picoclaw/.last-deployed-run
+ls -1 /opt/picoclaw/releases/
+```

--- a/skills/dev-cycle/SKILL.md
+++ b/skills/dev-cycle/SKILL.md
@@ -62,15 +62,32 @@ knows where the cycle is. **No silent phases.**
 
 ## Push + PR workflow (Tier 3 — human-gated merge)
 
-The agent pushes to a **feature branch only**. `main` is branch-protected: PR required,
-human merge. Never attempt a direct push to `main`.
+The agent pushes to a **feature branch only** (`fix/...`, `feat/...`). `main` is
+branch-protected: PR required, human merge. Never attempt a direct push to `main`.
+
+**Exec-guard reality (verified 2026-08-02):** `git push` is on the exec **allow list**
+(`tools.exec.custom_allow_patterns` in config.json), so the agent CAN push feature
+branches. Deny rules still hard-block `ssh host@`, `sudo`, `pkill`, heredocs, `${...}`,
+etc. Do not bypass those.
+
+**PR creation is automatic (no PR write on the agent token):** the `auto-pr` workflow
+(`.github/workflows/auto-pr.yml`) opens the PR on branch push using the repo's
+`GITHUB_TOKEN` — PRs are authored by `github-actions[bot]`, and the agent's PAT has
+NO Pull requests permission, so the agent cannot create, approve, or merge PRs.
 
 ```bash
+# AGENT: prepare branch + commit (gitleaks hook fires on commit)
 git checkout -b fix/<desc>
 git add -A && git commit -m "fix: <desc>"
-git push origin fix/<desc>
-gh pr create --fill            # then ping the user with the PR link
-# USER merges via GitHub Mobile / web UI / CLI on a separate device
+
+# AGENT: push (allow-listed) — auto-pr workflow opens the PR
+git push -u fork fix/<desc>
+
+# AGENT: wait for the workflow, then fetch the PR URL (read-only, token has pull:read)
+gh pr view fix/<desc> --repo j-v/picoclaw --json url --jq .url
+# → ping the user with the link
+
+# USER: approve (optional) + merge via GitHub Mobile / web UI / CLI
 ```
 
 ## Pre-deploy checklist (before any deploy action or force-poll)

--- a/web/frontend/pnpm-lock.yaml
+++ b/web/frontend/pnpm-lock.yaml
@@ -3574,11 +3574,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.5:
-    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -7734,8 +7729,6 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
-
-  semver@7.8.5: {}
 
   semver@7.8.5: {}
 


### PR DESCRIPTION
## 📝 Description

Bug: My agent was not able to execute 'git push' despite adding it to the exec allow list. According to the tests it should have worked.

Fixed `customAllowPatterns` not working: default deny patterns always took precedence in `guardCommand`, so a command like `git push` could never be permitted via a custom allow pattern. Separated user-specified `CustomDenyPatterns` from the built-in defaults so security-critical custom deny rules (e.g. jq env-access checks) still always apply, while built-in deny patterns can be exempted by a matching custom allow pattern.

Also fixed `TestShellTool_CustomAllowPatterns`, which previously passed vacuously: it never set an internal channel context, so the channel-restriction check blocked the command before the guard ran. The test now reaches `guardCommand` and genuinely asserts the allow/deny behavior (allowed with pattern, blocked without, blocked for non-matching remote).
## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)
## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)
## 🔗 Related Issue
N/A
## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** `guardCommand` checked all deny patterns (built-in + user `CustomDenyPatterns`) before any allow logic, and `customAllowPatterns` were only consulted by `commandMatchesAllowPattern`, which is gated on `allowPatterns` being non-empty (never populated in practice) — making custom allow rules dead code. The fix splits deny patterns into built-in (`denyPatterns`) and user-specified (`customDenyPatterns`) lists. Built-in deny patterns (e.g. `\bgit\s+push\b`) can now be exempted by a matching custom allow pattern, but custom deny patterns always apply so operators can't weaken explicit security rules (see #3079). The existing test appeared to pass but never exercised the guard due to the channel check firing first on an empty channel context.
## 🧪 Test Environment
- **Hardware:** PC (Apple Silicon Mac)
- **OS:** macOS
- **Model/Provider:** DeepSeek-V3
- **Channels:** CLI
## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>
Without the fix (shell.go reverted), `TestShellTool_CustomAllowPatterns` fails:
```
=== RUN   TestShellTool_CustomAllowPatterns
    shell_test.go:682: custom allow pattern should exempt 'git push origin main', got: Command blocked by safety guard (dangerous pattern detected)
--- FAIL: TestShellTool_CustomAllowPatterns (0.00s)
```
With the fix:
```
=== RUN   TestShellTool_CustomAllowPatterns
--- PASS: TestShellTool_CustomAllowPatterns (1.33s)
=== RUN   TestShellTool_CustomAllowDoesNotBypassDenyPatterns
--- PASS: TestShellTool_CustomAllowDoesNotBypassDenyPatterns (0.00s)
=== RUN   TestShellTool_CustomAllowStillPermitsSafeMatch
--- PASS: TestShellTool_CustomAllowStillPermitsSafeMatch (0.00s)
=== RUN   TestShellTool_CustomAllowDoesNotBecomeStrictAllowlist
--- PASS: TestShellTool_CustomAllowDoesNotBecomeStrictAllowlist (0.00s)
```
</details>


## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.