### PR TITLE
Fix: agent not able to execute shell command added to customAllowPatterns

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -40,6 +40,7 @@ type ExecTool struct {
 	workingDir          string
 	timeout             time.Duration
 	denyPatterns        []*regexp.Regexp
+	customDenyPatterns  []*regexp.Regexp
 	allowPatterns       []*regexp.Regexp
 	customAllowPatterns []*regexp.Regexp
 	allowedPathPatterns []*regexp.Regexp
@@ -147,6 +148,7 @@ func NewExecToolWithConfig(
 	allowPaths ...[]*regexp.Regexp,
 ) (*ExecTool, error) {
 	denyPatterns := make([]*regexp.Regexp, 0)
+	customDenyPatterns := make([]*regexp.Regexp, 0)
 	customAllowPatterns := make([]*regexp.Regexp, 0)
 	var allowedPathPatterns []*regexp.Regexp
 	allowRemote := true
@@ -172,7 +174,7 @@ func NewExecToolWithConfig(
 					if err != nil {
 						return nil, fmt.Errorf("invalid custom deny pattern %q: %w", pattern, err)
 					}
-					denyPatterns = append(denyPatterns, re)
+					customDenyPatterns = append(customDenyPatterns, re)
 				}
 			}
 		} else {
@@ -202,6 +204,7 @@ func NewExecToolWithConfig(
 		workingDir:          workingDir,
 		timeout:             timeout,
 		denyPatterns:        denyPatterns,
+		customDenyPatterns:  customDenyPatterns,
 		allowPatterns:       nil,
 		customAllowPatterns: customAllowPatterns,
 		allowedPathPatterns: allowedPathPatterns,
@@ -1149,16 +1152,34 @@ func (t *ExecTool) commandMatchesAllowPattern(lower string) bool {
 	return false
 }
 
+func (t *ExecTool) commandMatchesCustomAllowPattern(lower string) bool {
+	for _, pattern := range t.customAllowPatterns {
+		if pattern.MatchString(lower) {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *ExecTool) guardCommand(command, cwd string) string {
 	cmd := strings.TrimSpace(command)
 	lower := strings.ToLower(cmd)
 
-	// Deny patterns always apply, even when a command matches a custom allow rule.
-	// Custom allow rules can permit a command, but must not disable secret-safety
-	// deny rules such as jq env access checks (#3079).
-	for _, pattern := range t.denyPatterns {
+	// Custom deny patterns always apply — they are user-specified security rules
+	// that must not be bypassed by custom allow patterns (#3079).
+	for _, pattern := range t.customDenyPatterns {
 		if pattern.MatchString(lower) {
 			return "Command blocked by safety guard (dangerous pattern detected)"
+		}
+	}
+
+	// Default deny patterns can be exempted by custom allow patterns,
+	// so operators can selectively permit normally-blocked commands.
+	if !t.commandMatchesCustomAllowPattern(lower) {
+		for _, pattern := range t.denyPatterns {
+			if pattern.MatchString(lower) {
+				return "Command blocked by safety guard (dangerous pattern detected)"
+			}
 		}
 	}
 

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -670,8 +670,12 @@ func TestShellTool_CustomAllowPatterns(t *testing.T) {
 		t.Fatalf("unable to configure exec tool: %s", err)
 	}
 
+	ctx := WithToolContext(context.Background(), "cli", "test")
+
 	// "git push origin main" should be allowed by custom allow pattern.
-	result := tool.Execute(context.Background(), map[string]any{
+	// It may fail for other reasons (no git repo), but the error should not be a guard block.
+	result := tool.Execute(ctx, map[string]any{
+		"action":  "run",
 		"command": "git push origin main",
 	})
 	if result.IsError && strings.Contains(result.ForLLM, "blocked") {
@@ -679,11 +683,32 @@ func TestShellTool_CustomAllowPatterns(t *testing.T) {
 	}
 
 	// "git push upstream main" should still be blocked (does not match allow pattern).
-	result = tool.Execute(context.Background(), map[string]any{
+	result = tool.Execute(ctx, map[string]any{
+		"action":  "run",
 		"command": "git push upstream main",
 	})
-	if !result.IsError {
-		t.Errorf("'git push upstream main' should still be blocked by deny pattern")
+	if !result.IsError || !strings.Contains(result.ForLLM, "blocked") {
+		t.Errorf("'git push upstream main' should still be blocked by deny pattern, got: %s", result.ForLLM)
+	}
+
+	// Without any custom allow pattern, "git push origin main" should be blocked.
+	cfgNoAllow := &config.Config{
+		Tools: config.ToolsConfig{
+			Exec: config.ExecConfig{
+				EnableDenyPatterns: true,
+			},
+		},
+	}
+	toolNoAllow, err := NewExecToolWithConfig("", false, cfgNoAllow)
+	if err != nil {
+		t.Fatalf("unable to configure exec tool: %s", err)
+	}
+	result = toolNoAllow.Execute(ctx, map[string]any{
+		"action":  "run",
+		"command": "git push origin main",
+	})
+	if !result.IsError || !strings.Contains(result.ForLLM, "blocked") {
+		t.Errorf("'git push origin main' should be blocked without custom allow pattern, got: %s", result.ForLLM)
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

Bug: My agent was not able to execute 'git push' despite adding it to the exec allow list. According to the tests it should have worked.

Fixed `customAllowPatterns` not working: default deny patterns always took precedence in `guardCommand`, so a command like `git push` could never be permitted via a custom allow pattern. Separated user-specified `CustomDenyPatterns` from the built-in defaults so security-critical custom deny rules (e.g. jq env-access checks) still always apply, while built-in deny patterns can be exempted by a matching custom allow pattern.

Also fixed `TestShellTool_CustomAllowPatterns`, which previously passed vacuously: it never set an internal channel context, so the channel-restriction check blocked the command before the guard ran. The test now reaches `guardCommand` and genuinely asserts the allow/deny behavior (allowed with pattern, blocked without, blocked for non-matching remote).
## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)
## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)
## 🔗 Related Issue
N/A
## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** `guardCommand` checked all deny patterns (built-in + user `CustomDenyPatterns`) before any allow logic, and `customAllowPatterns` were only consulted by `commandMatchesAllowPattern`, which is gated on `allowPatterns` being non-empty (never populated in practice) — making custom allow rules dead code. The fix splits deny patterns into built-in (`denyPatterns`) and user-specified (`customDenyPatterns`) lists. Built-in deny patterns (e.g. `\bgit\s+push\b`) can now be exempted by a matching custom allow pattern, but custom deny patterns always apply so operators can't weaken explicit security rules (see #3079). The existing test appeared to pass but never exercised the guard due to the channel check firing first on an empty channel context.
## 🧪 Test Environment
- **Hardware:** PC (Apple Silicon Mac)
- **OS:** macOS
- **Model/Provider:** DeepSeek-V3
- **Channels:** CLI
## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>
Without the fix (shell.go reverted), `TestShellTool_CustomAllowPatterns` fails:
```
=== RUN   TestShellTool_CustomAllowPatterns
    shell_test.go:682: custom allow pattern should exempt 'git push origin main', got: Command blocked by safety guard (dangerous pattern detected)
--- FAIL: TestShellTool_CustomAllowPatterns (0.00s)
```
With the fix:
```
=== RUN   TestShellTool_CustomAllowPatterns
--- PASS: TestShellTool_CustomAllowPatterns (1.33s)
=== RUN   TestShellTool_CustomAllowDoesNotBypassDenyPatterns
--- PASS: TestShellTool_CustomAllowDoesNotBypassDenyPatterns (0.00s)
=== RUN   TestShellTool_CustomAllowStillPermitsSafeMatch
--- PASS: TestShellTool_CustomAllowStillPermitsSafeMatch (0.00s)
=== RUN   TestShellTool_CustomAllowDoesNotBecomeStrictAllowlist
--- PASS: TestShellTool_CustomAllowDoesNotBecomeStrictAllowlist (0.00s)
```
</details>


## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.