### PR TITLE
Support topics in private bot chats

### DIFF
--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -1153,13 +1153,10 @@ func (c *TelegramChannel) handleMessages(ctx context.Context, messages []*telego
 		content = c.prependTelegramQuotedReply(content, message.ReplyToMessage)
 	}
 
-	// For forum topics, embed the thread ID as "chatID/threadID" so replies
-	// route to the correct topic and each topic gets its own session.
-	// Only forum groups (IsForum) are handled; regular group reply threads
-	// must share one session per group.
 	compositeChatID := fmt.Sprintf("%d", chatID)
 	threadID := message.MessageThreadID
-	if message.Chat.IsForum && threadID != 0 {
+	isTopic := threadID != 0 && (message.Chat.IsForum || message.IsTopicMessage)
+	if isTopic {
 		compositeChatID = fmt.Sprintf("%d/%d", chatID, threadID)
 	}
 
@@ -1192,7 +1189,7 @@ func (c *TelegramChannel) handleMessages(ctx context.Context, messages []*telego
 		Mentioned: isMentioned,
 		Raw:       metadata,
 	}
-	if message.Chat.IsForum && threadID != 0 {
+	if isTopic {
 		inboundCtx.TopicID = fmt.Sprintf("%d", threadID)
 	}
 	if message.ReplyToMessage != nil {

--- a/pkg/channels/telegram/telegram_test.go
+++ b/pkg/channels/telegram/telegram_test.go
@@ -1014,6 +1014,33 @@ func TestSend_WithForumThreadID(t *testing.T) {
 	assert.Len(t, caller.calls, 1)
 }
 
+func TestSend_WithPrivateTopicThreadID(t *testing.T) {
+	caller := &stubCaller{
+		callFn: func(ctx context.Context, url string, data *ta.RequestData) (*ta.Response, error) {
+			return successResponse(t), nil
+		},
+	}
+	ch := newTestChannel(t, caller)
+
+	_, err := ch.Send(context.Background(), bus.OutboundMessage{
+		ChatID:  "123456789/42",
+		Content: "Hello from private topic",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, caller.calls, 1)
+
+	var params struct {
+		ChatID          int64  `json:"chat_id"`
+		MessageThreadID int    `json:"message_thread_id"`
+		Text            string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(caller.calls[0].Data.BodyRaw, &params))
+	assert.Equal(t, int64(123456789), params.ChatID)
+	assert.Equal(t, 42, params.MessageThreadID)
+	assert.Equal(t, "Hello from private topic", params.Text)
+}
+
 func TestSend_UsesContextTopicIDWhenChatIDDoesNotIncludeThread(t *testing.T) {
 	caller := &stubCaller{
 		callFn: func(ctx context.Context, url string, data *ta.RequestData) (*ta.Response, error) {
@@ -1246,6 +1273,70 @@ func TestHandleMessage_ForumTopic_SetsMetadata(t *testing.T) {
 	assert.Equal(t, "-1001234567890/42", inbound.ChatID)
 	assert.Equal(t, "group", inbound.Context.ChatType)
 	assert.Equal(t, "42", inbound.Context.TopicID)
+}
+
+func TestHandleMessage_PrivateTopic_SetsMetadata(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	ch := &TelegramChannel{
+		BaseChannel: channels.NewBaseChannel("telegram", nil, messageBus, nil),
+		chatIDs:     make(map[string]int64),
+		ctx:         context.Background(),
+	}
+
+	msg := &telego.Message{
+		Text:            "hello from private topic",
+		MessageID:       12,
+		MessageThreadID: 42,
+		IsTopicMessage:  true,
+		Chat: telego.Chat{
+			ID:   123456789,
+			Type: "private",
+		},
+		From: &telego.User{
+			ID:        7,
+			FirstName: "Alice",
+		},
+	}
+
+	err := ch.handleMessage(context.Background(), msg)
+	require.NoError(t, err)
+
+	inbound, ok := <-messageBus.InboundChan()
+	require.True(t, ok)
+	assert.Equal(t, "123456789/42", inbound.ChatID)
+	assert.Equal(t, "direct", inbound.Context.ChatType)
+	assert.Equal(t, "42", inbound.Context.TopicID)
+}
+
+func TestHandleMessage_PrivateChat_NoTopicMetadata(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	ch := &TelegramChannel{
+		BaseChannel: channels.NewBaseChannel("telegram", nil, messageBus, nil),
+		chatIDs:     make(map[string]int64),
+		ctx:         context.Background(),
+	}
+
+	msg := &telego.Message{
+		Text:      "hello from private chat",
+		MessageID: 13,
+		Chat: telego.Chat{
+			ID:   123456789,
+			Type: "private",
+		},
+		From: &telego.User{
+			ID:        7,
+			FirstName: "Alice",
+		},
+	}
+
+	err := ch.handleMessage(context.Background(), msg)
+	require.NoError(t, err)
+
+	inbound, ok := <-messageBus.InboundChan()
+	require.True(t, ok)
+	assert.Equal(t, "123456789", inbound.ChatID)
+	assert.Equal(t, "direct", inbound.Context.ChatType)
+	assert.Empty(t, inbound.Context.TopicID)
 }
 
 func TestHandleMessage_NoForum_NoThreadMetadata(t *testing.T) {

--- a/pkg/session/allocator_test.go
+++ b/pkg/session/allocator_test.go
@@ -119,6 +119,39 @@ func TestAllocateRouteSession_TelegramForumTopicsRemainIsolatedByDefault(t *test
 	}
 }
 
+func TestAllocateRouteSession_TelegramPrivateTopicsRemainIsolatedByDefault(t *testing.T) {
+	first := AllocateRouteSession(AllocationInput{
+		AgentID: "main",
+		Context: bus.InboundContext{
+			Channel:  "telegram",
+			ChatID:   "123456789/42",
+			ChatType: "direct",
+			TopicID:  "42",
+			SenderID: "7",
+		},
+		SessionPolicy: routing.SessionPolicy{
+			Dimensions: []string{"chat"},
+		},
+	})
+	second := AllocateRouteSession(AllocationInput{
+		AgentID: "main",
+		Context: bus.InboundContext{
+			Channel:  "telegram",
+			ChatID:   "123456789/99",
+			ChatType: "direct",
+			TopicID:  "99",
+			SenderID: "7",
+		},
+		SessionPolicy: routing.SessionPolicy{
+			Dimensions: []string{"chat"},
+		},
+	})
+
+	if first.SessionKey == second.SessionKey {
+		t.Fatalf("private topics should not share default session key: %q", first.SessionKey)
+	}
+}
+
 func TestAllocateRouteSession_PicoDirectAliasesIncludeLegacyChatKey(t *testing.T) {
 	allocation := AllocateRouteSession(AllocationInput{
 		AgentID: "main",


### PR DESCRIPTION
## 📝 Description

Fix Telegram topic handling for private chats with bots that have forum topic mode enabled.

PicoClaw previously recognized topics only when `Chat.IsForum` was true. That works for forum supergroups but not private bot chats, where Telegram instead provides `IsTopicMessage` and `MessageThreadID`.

This change:

- recognizes both forum-supergroup and private-chat topics
- preserves the thread ID in the composite chat ID and `InboundContext.TopicID`
- routes replies to the originating private topic
- isolates conversation history between private topics
- preserves existing behavior for non-forum group reply threads
- adds regression tests for inbound metadata, outbound routing, and session isolation

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Follow-up to #3110. The original fix covered Telegram forum supergroups, while this PR covers forum topic mode in private bot chats.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://core.telegram.org/bots/api#message
- **Reasoning:** Telegram sets `Chat.IsForum` for forum supergroups, but private chats with topic-enabled bots use `Message.IsTopicMessage` together with a nonzero `MessageThreadID`. PicoClaw checked only `Chat.IsForum`, causing private-topic messages to lose their thread routing and session context. The fix treats a message as topic-aware when it has a thread ID and either `Chat.IsForum` or `IsTopicMessage` is true.

## 🧪 Test Environment
- **Hardware:** Apple Silicon arm64
- **OS:** macOS 15.7.7
- **Model/Provider:** N/A — unit tests do not invoke an LLM
- **Channels:** Telegram

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly. No documentation changes are required because this is an internal Telegram routing fix with no configuration or API changes.
```