### PR TITLE
fix(web): repair unparseable pnpm-lock.yaml

### DIFF
--- a/web/frontend/pnpm-lock.yaml
+++ b/web/frontend/pnpm-lock.yaml
@@ -3574,11 +3574,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.5:
-    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -7734,8 +7729,6 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
-
-  semver@7.8.5: {}
 
   semver@7.8.5: {}
 


### PR DESCRIPTION
`web/frontend/pnpm-lock.yaml` lists `semver@7.8.5` twice — once under `packages:`, once under `snapshots:`. YAML forbids duplicate mapping keys, so pnpm refuses the file:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "web/frontend/pnpm-lock.yaml" is broken:
duplicated mapping key (3577:3)
```

Reproducible on `main` (`49183d7e`) with the pinned pnpm:

```bash
cd web/frontend && pnpm install --lockfile-only --frozen-lockfile
```

## Scope

This is build tooling, not runtime — the web UI builds and behaves identically either way. What it blocks:

- **Frozen installs**, so builds of the embedded web assets aren't reproducible.
- **`pnpm audit`**, which can't run at all, leaving the npm dependency tree unauditable.
- **Dependabot npm updates** for `web/frontend`, which can't apply to an unparseable lockfile.

## The fix

Both duplicate blocks are byte-identical to the entries they repeat — same version, same integrity hash — so removing the second occurrence of each is lossless.

```diff
-  semver@7.8.5:
-    resolution: {integrity: sha512-Y7/KDsb8Ljoo...}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@1.2.1:
```

**7 deletions, 0 insertions.** No package version changes.

## Why not regenerate the lockfile

`pnpm install --lockfile-only` also fixes it, but pulls in roughly **80 unrelated package upgrades** — `vite 8.0.16→8.2.0`, `eslint 10.4.1→10.8.0`, `radix-ui 1.4.3→1.6.7`, `chokidar 3.6.0→5.0.0` (major), plus a new `lightningcss` tree. That's a dependency upgrade rather than a corruption fix, and it seemed better left to your own judgement. Happy to send that version instead if you'd prefer it.

## Verification

Using `pnpm@10.33.0`, the version pinned in `package.json`:

- Package set **identical** before and after — every `name@version` key diffed; the only difference is the removed duplicate.
- The file parses.
- `pnpm install --lockfile-only --frozen-lockfile` succeeds and leaves the file **unchanged**, confirming consistency with `package.json`.
- Line endings unchanged (LF).
