### PR TITLE
fix(tools): honor exec timeout and boolean run options

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -216,7 +216,7 @@ func (t *ExecTool) Name() string {
 }
 
 func (t *ExecTool) Description() string {
-	return `Execute shell commands. Use background=true for long-running commands (returns sessionId). Use pty=true for interactive commands (can combine with background=true). Use poll/read/write/send-keys/kill with sessionId to manage background sessions. Sessions auto-cleanup 30 minutes after process exits; use kill to terminate early. Output buffer limit: 1MB.`
+	return `Execute shell commands. Use background=true for commands that may outlast the default timeout; it returns a sessionId immediately. Check background work with poll/read instead of running sleep in a synchronous command. Use pty=true for interactive commands (can combine with background=true). Use poll/read/write/send-keys/kill with sessionId to manage background sessions. The timeout argument overrides the configured timeout for one synchronous run. Sessions auto-cleanup 30 minutes after process exits; use kill to terminate early. Output buffer limit: 1MB.`
 }
 
 //nolint:dupl // Tool parameter schemas intentionally use similar JSON-schema map literals.
@@ -246,11 +246,11 @@ func (t *ExecTool) Parameters() map[string]any {
 				"description": "Data to write to stdin (required for write)",
 			},
 			"background": map[string]any{
-				"type":        "string",
+				"type":        "boolean",
 				"description": "Run in background immediately",
 			},
 			"pty": map[string]any{
-				"type":        "string",
+				"type":        "boolean",
 				"description": "Run in a pseudo-terminal (PTY) when available",
 			},
 			"cwd": map[string]any{
@@ -380,15 +380,38 @@ func (t *ExecTool) executeRun(ctx context.Context, args map[string]any) *ToolRes
 		return t.runBackground(ctx, command, cwd, isPty)
 	}
 
-	return t.runSync(ctx, command, cwd)
+	timeout := t.timeout
+	if rawTimeout, ok := args["timeout"]; ok {
+		var seconds int64
+		switch value := rawTimeout.(type) {
+		case int:
+			seconds = int64(value)
+		case int64:
+			seconds = value
+		case float64:
+			seconds = int64(value)
+		default:
+			return ErrorResult("timeout must be an integer number of seconds")
+		}
+		if seconds < 0 {
+			return ErrorResult("timeout must be greater than or equal to 0")
+		}
+		const maxTimeoutSeconds = int64((1<<63 - 1) / int64(time.Second))
+		if seconds > maxTimeoutSeconds {
+			return ErrorResult("timeout is too large")
+		}
+		timeout = time.Duration(seconds) * time.Second
+	}
+
+	return t.runSync(ctx, command, cwd, timeout)
 }
 
-func (t *ExecTool) runSync(ctx context.Context, command, cwd string) *ToolResult {
+func (t *ExecTool) runSync(ctx context.Context, command, cwd string, timeout time.Duration) *ToolResult {
 	// timeout == 0 means no timeout
 	var cmdCtx context.Context
 	var cancel context.CancelFunc
-	if t.timeout > 0 {
-		cmdCtx, cancel = context.WithTimeout(ctx, t.timeout)
+	if timeout > 0 {
+		cmdCtx, cancel = context.WithTimeout(ctx, timeout)
 	} else {
 		cmdCtx, cancel = context.WithCancel(ctx)
 	}
@@ -453,7 +476,7 @@ func (t *ExecTool) runSync(ctx context.Context, command, cwd string) *ToolResult
 
 	if err != nil {
 		if errors.Is(cmdCtx.Err(), context.DeadlineExceeded) {
-			msg := fmt.Sprintf("Command timed out after %v", t.timeout)
+			msg := fmt.Sprintf("Command timed out after %v. For long-running work, rerun it with background=true and use poll/read with the returned sessionId instead of sleeping in a synchronous command.", timeout)
 			if output != "" {
 				msg += "\n\nPartial output before timeout:\n" + output
 			}

--- a/pkg/tools/shell_test.go
+++ b/pkg/tools/shell_test.go
@@ -105,6 +105,49 @@ func TestShellTool_Timeout(t *testing.T) {
 	}
 }
 
+func TestShellTool_ParametersUseBooleanBackgroundFlags(t *testing.T) {
+	tool, err := NewExecTool("", false)
+	require.NoError(t, err)
+
+	properties := tool.Parameters()["properties"].(map[string]any)
+	require.Equal(t, "boolean", properties["background"].(map[string]any)["type"])
+	require.Equal(t, "boolean", properties["pty"].(map[string]any)["type"])
+}
+
+func TestShellTool_PerCallTimeoutOverridesConfiguredTimeout(t *testing.T) {
+	tool, err := NewExecTool("", false)
+	require.NoError(t, err)
+	tool.SetTimeout(10 * time.Second)
+
+	start := time.Now()
+	result := tool.Execute(context.Background(), map[string]any{
+		"action":  "run",
+		"command": "sleep 5",
+		"timeout": 1,
+	})
+	elapsed := time.Since(start)
+
+	require.True(t, result.IsError)
+	require.Less(t, elapsed, 3*time.Second)
+	require.Contains(t, result.ForLLM, "timed out after 1s")
+	require.Contains(t, result.ForLLM, "background=true")
+}
+
+func TestShellTool_PerCallTimeoutCanExtendConfiguredTimeout(t *testing.T) {
+	tool, err := NewExecTool("", false)
+	require.NoError(t, err)
+	tool.SetTimeout(100 * time.Millisecond)
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"action":  "run",
+		"command": "sleep 0.2; printf done",
+		"timeout": 1,
+	})
+
+	require.False(t, result.IsError, result.ForLLM)
+	require.Contains(t, result.ForLLM, "done")
+}
+
 // TestShellTool_WorkingDir verifies custom working directory
 func TestShellTool_WorkingDir(t *testing.T) {
 	// Create temp directory


### PR DESCRIPTION
## 📝 Description

The `exec` tool advertises a per-run `timeout` argument, but synchronous execution always used the configured global timeout and silently ignored the supplied value. The tool schema also declared `background` and `pty` as strings even though they are boolean options and the executor accepts boolean values.

This PR:

- honors an explicitly supplied per-run timeout, including values longer or shorter than the configured default;
- rejects negative or overflowing timeout values;
- declares `background` and `pty` as JSON booleans;
- tells the model to use background sessions with `poll`/`read` instead of synchronous sleeps after a timeout;
- adds regression tests for the schema and both timeout override directions.

This is a focused follow-up to #2161, limited to the exec option contract. It also relates to the fixed global-timeout report in #1025.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

- Related to #1025
- Focused follow-up to #2161

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** #1752
- **Reasoning:** The JSON schema should describe boolean run flags as booleans, and every advertised timeout argument should affect the context deadline used by that run. The executor continues accepting legacy string booleans internally for compatibility.

## 🧪 Test Environment
- **Hardware:** x86_64 NAS / PC
- **OS:** Linux
- **Model/Provider:** DeepSeek V4 Flash through an OpenAI-compatible provider
- **Channels:** Weixin and CLI

Tests run:

- `go test ./pkg/tools -count=1`
- `go vet ./pkg/tools`
- deployed the patched binary and verified the gateway health endpoint

`make test` was also run. It reached an unrelated existing failure in `TestMCPAddRejectsNonExecutableLocalCommand` because the NAS temporary filesystem does not preserve the test's non-executable mode; this branch does not modify MCP code.

## 📸 Evidence (Optional)
<details>
<summary>Behavior verified</summary>

- A per-run timeout shorter than the configured default terminates at the supplied deadline.
- A per-run timeout longer than the configured default allows the command to complete.
- Boolean `background` and `pty` parameters pass schema validation.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the tool description and regression tests accordingly.
