### PR TITLE
fix(channels): block private targets on inbound media downloads

### DIFF
--- a/pkg/channels/discord/discord.go
+++ b/pkg/channels/discord/discord.go
@@ -739,8 +739,9 @@ func (c *DiscordChannel) StartTyping(ctx context.Context, chatID string) (func()
 
 func (c *DiscordChannel) downloadAttachment(url, filename string) string {
 	return utils.DownloadFile(url, filename, utils.DownloadOptions{
-		LoggerPrefix: "discord",
-		ProxyURL:     c.config.Proxy,
+		LoggerPrefix:        "discord",
+		ProxyURL:            c.config.Proxy,
+		BlockPrivateTargets: true,
 	})
 }
 

--- a/pkg/channels/line/line.go
+++ b/pkg/channels/line/line.go
@@ -618,6 +618,7 @@ func (c *LINEChannel) downloadContent(messageID, filename string) string {
 		ExtraHeaders: map[string]string{
 			"Authorization": "Bearer " + c.config.ChannelAccessToken.String(),
 		},
+		BlockPrivateTargets: true,
 	})
 }
 

--- a/pkg/channels/qq/qq.go
+++ b/pkg/channels/qq/qq.go
@@ -808,8 +808,9 @@ func (c *QQChannel) downloadAttachment(urlStr, filename string) string {
 	}
 
 	return utils.DownloadFile(urlStr, filename, utils.DownloadOptions{
-		LoggerPrefix: "qq",
-		ExtraHeaders: c.downloadHeaders(),
+		LoggerPrefix:        "qq",
+		ExtraHeaders:        c.downloadHeaders(),
+		BlockPrivateTargets: true,
 	})
 }
 

--- a/pkg/channels/slack/slack.go
+++ b/pkg/channels/slack/slack.go
@@ -584,6 +584,7 @@ func (c *SlackChannel) downloadSlackFile(file slack.File) string {
 		ExtraHeaders: map[string]string{
 			"Authorization": "Bearer " + c.config.BotToken.String(),
 		},
+		BlockPrivateTargets: true,
 	})
 }
 

--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -1424,7 +1424,8 @@ func (c *TelegramChannel) downloadFileWithInfo(file *telego.File, ext string) st
 	// Use FilePath as filename for better identification
 	filename := file.FilePath + ext
 	return utils.DownloadFile(url, filename, utils.DownloadOptions{
-		LoggerPrefix: "telegram",
+		LoggerPrefix:        "telegram",
+		BlockPrivateTargets: true,
 	})
 }
 

--- a/pkg/utils/media.go
+++ b/pkg/utils/media.go
@@ -67,7 +67,10 @@ type DownloadOptions struct {
 	Timeout             time.Duration
 	ExtraHeaders        map[string]string
 	LoggerPrefix        string
-	ProxyURL            string
+	ProxyURL string
+	// BlockPrivateTargets enables SSRF hardening (scheme/host checks + safe dial
+	// + redirect re-check). Inbound channel attachment downloads should set this
+	// so a crafted media URL cannot reach loopback/link-local/RFC1918.
 	BlockPrivateTargets bool
 }
 


### PR DESCRIPTION
## Summary

`utils.DownloadFile` already supports SSRF hardening via `BlockPrivateTargets` (safe dial + redirect re-check). OneBot used it; QQ / Telegram / Discord / LINE / Slack inbound attachment downloads did not, so a crafted media URL could still reach loopback, link-local, or RFC1918 (including cloud metadata) through redirects.

This PR enables `BlockPrivateTargets: true` on those channel download paths (parity with OneBot).

## Test plan

- [x] `go test ./pkg/utils/ -count=1` (existing `TestDownloadFile_BlockPrivateTargetsBlocksRedirectToLoopback`)
- [ ] CI green

Tip: `49183d7`


Made with [Cursor](https://cursor.com)