### PR TITLE
fix(wecom): use CreateSafeHTTPClient for media downloads

### DIFF
--- a/pkg/channels/wecom/media.go
+++ b/pkg/channels/wecom/media.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/media"
+	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
 const (
@@ -281,6 +282,9 @@ func (c *WeComChannel) storeRemoteMedia(
 		return "", fmt.Errorf("no media store available")
 	}
 
+	if err := utils.ValidateSafeHTTPURL(resourceURL, nil, nil); err != nil {
+		return "", fmt.Errorf("download media: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resourceURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
@@ -418,6 +422,9 @@ func (c *WeComChannel) downloadRemoteMediaToTemp(
 	ctx context.Context,
 	resourceURL, fallbackName string,
 ) (string, string, string, error) {
+	if err := utils.ValidateSafeHTTPURL(resourceURL, nil, nil); err != nil {
+		return "", "", "", fmt.Errorf("download media: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resourceURL, nil)
 	if err != nil {
 		return "", "", "", fmt.Errorf("create request: %w", err)

--- a/pkg/channels/wecom/media_test.go
+++ b/pkg/channels/wecom/media_test.go
@@ -6,11 +6,14 @@ import (
 	"encoding/base64"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	basechannels "github.com/sipeed/picoclaw/pkg/channels"
 	"github.com/sipeed/picoclaw/pkg/media"
+	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
 func TestStoreRemoteMedia_DetectsJPEGContentTypeFromBody(t *testing.T) {
@@ -160,6 +163,48 @@ func TestStoreRemoteMedia_PreservesSuffixFromContentDisposition(t *testing.T) {
 	}
 	if !strings.HasSuffix(strings.ToLower(localPath), ".pptx") {
 		t.Fatalf("expected pptx temp path, got %q", localPath)
+	}
+}
+
+func TestStoreRemoteMedia_BlocksPrivateRedirect(t *testing.T) {
+	t.Parallel()
+
+	privateHit := false
+	private := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		privateHit = true
+		_, _ = w.Write([]byte("SECRET"))
+	}))
+	t.Cleanup(private.Close)
+
+	public := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, private.URL+"/secret", http.StatusFound)
+	}))
+	t.Cleanup(public.Close)
+
+	client, err := utils.CreateSafeHTTPClient(utils.SafeHTTPClientOptions{
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("CreateSafeHTTPClient: %v", err)
+	}
+
+	store := media.NewFileMediaStore()
+	ch := &WeComChannel{
+		BaseChannel: basechannels.NewBaseChannel("wecom", nil, nil, nil),
+		mediaClient: client,
+	}
+	ch.SetMediaStore(store)
+
+	_, err = ch.storeRemoteMedia(context.Background(), "test-scope", "msg-ssrf", public.URL, "", "")
+	if err == nil {
+		t.Fatal("expected storeRemoteMedia to reject redirect to private host")
+	}
+	if privateHit {
+		t.Fatal("private target was reached via redirect")
+	}
+	if !strings.Contains(err.Error(), "private or local") &&
+		!strings.Contains(err.Error(), "blocked private") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/pkg/channels/wecom/wecom.go
+++ b/pkg/channels/wecom/wecom.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/config"
 	"github.com/sipeed/picoclaw/pkg/identity"
 	"github.com/sipeed/picoclaw/pkg/logger"
+	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
 const (
@@ -124,6 +125,13 @@ func NewChannel(bc *config.Channel, cfg *config.WeComSettings, messageBus *bus.M
 		channels.WithReasoningChannelID(bc.ReasoningChannelID),
 	)
 
+	mediaClient, err := utils.CreateSafeHTTPClient(utils.SafeHTTPClientOptions{
+		Timeout: wecomMediaTimeout,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create wecom media http client: %w", err)
+	}
+
 	ch := &WeComChannel{
 		BaseChannel: base,
 		config:      cfg,
@@ -131,7 +139,7 @@ func NewChannel(bc *config.Channel, cfg *config.WeComSettings, messageBus *bus.M
 		turns:       make(map[string][]wecomTurn),
 		recent:      newRecentMessageSet(wecomRecentMessageMax),
 		routes:      newReqIDStore(""),
-		mediaClient: &http.Client{Timeout: wecomMediaTimeout},
+		mediaClient: mediaClient,
 	}
 	ch.SetOwner(ch)
 	return ch, nil


### PR DESCRIPTION
## Summary
- WeCom built `mediaClient` as a plain `http.Client`, so inbound `storeRemoteMedia` and outbound `downloadRemoteMediaToTemp` followed redirects onto loopback / private hosts.
- Construct the client with `utils.CreateSafeHTTPClient` and `ValidateSafeHTTPURL` before fetch.
- Sibling of #3322 (QQ/Telegram/Discord/LINE/Slack `DownloadFile` private block); WeCom uses a separate media client path.

## Test plan
- [x] `go test ./pkg/channels/wecom/ -count=1` (includes new redirect-to-private reject)
- [ ] CI


Made with [Cursor](https://cursor.com)