### PR TITLE
feat(telegram): render tables with native rich messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/minio/selfupdate v0.6.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/muesli/termenv v0.16.0
-	github.com/mymmrac/telego v1.10.0
+	github.com/mymmrac/telego v1.11.1
 	github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1
 	github.com/openai/openai-go/v3 v3.22.0
 	github.com/pion/rtp v1.10.2
@@ -144,12 +144,12 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.71.0 // indirect
+	github.com/valyala/fasthttp v1.72.0 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/arch v0.24.0 // indirect
 	golang.org/x/crypto v0.53.0
-	golang.org/x/net v0.55.0
+	golang.org/x/net v0.56.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 )

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/u
 github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
-github.com/mymmrac/telego v1.10.0 h1:Upe0TqYyiK+yE5RFXXuQWVHGfLZnqvUfj4KZVjTcgWE=
-github.com/mymmrac/telego v1.10.0/go.mod h1:LsQKDA6EwssPP9XkORPXwwOFUGIRf/Wf2Wb8y3YyJdE=
+github.com/mymmrac/telego v1.11.1 h1:CpJX1xwQfd9G5mbXbGBWIIqNYrNbUwzNGLd8JlO//6A=
+github.com/mymmrac/telego v1.11.1/go.mod h1:SV926cvGXAAk4vPHAX+JjeTtU7gY8PVEiHUzMS3+fX8=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -313,8 +313,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
-github.com/valyala/fasthttp v1.71.0 h1:tepR7H+Guh9VUqxxcPggYi8R3lGUu2Rsdh+z7/FCY3k=
-github.com/valyala/fasthttp v1.71.0/go.mod h1:z1sDUvOShhXq/C9mwH/fSm1Vb71tUJwmQdgkBrBNwnA=
+github.com/valyala/fasthttp v1.72.0 h1:R7kYdoWhn1ye1fVpP+cDHDJwYm3NkwLliwgzJ/Abg7M=
+github.com/valyala/fasthttp v1.72.0/go.mod h1:zsbLTYqcpIktdQytlVBwIjY9La5d6bs990nBxWg8efk=
 github.com/valyala/fastjson v1.6.10 h1:/yjJg8jaVQdYR3arGxPE2X5z89xrlhS0eGXdv+ADTh4=
 github.com/valyala/fastjson v1.6.10/go.mod h1:e6FubmQouUNP73jtMLmcbxS6ydWIpOfhz34TSfO3JaE=
 github.com/vektah/gqlparser/v2 v2.5.27 h1:RHPD3JOplpk5mP5JGX8RKZkt2/Vwj/PZv0HxTdwFp0s=
@@ -386,8 +386,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -151,6 +151,11 @@ func NewPromptRegistry() *PromptRegistry {
 			})
 		}
 	}
+	if err := r.RegisterContributor(telegramOutputPromptContributor{}); err != nil {
+		logger.WarnCF("agent", "Failed to register Telegram output prompt", map[string]any{
+			"error": err.Error(),
+		})
+	}
 	return r
 }
 

--- a/pkg/agent/prompt_contributors.go
+++ b/pkg/agent/prompt_contributors.go
@@ -8,6 +8,47 @@ import (
 	"github.com/sipeed/picoclaw/pkg/tools"
 )
 
+const telegramOutputPromptSourceID PromptSourceID = "channel:telegram:output"
+
+const telegramOutputFormattingPrompt = "# Telegram response formatting\n\n" +
+	"This response will be delivered through Telegram's rich-message renderer.\n\n" +
+	"- Use standard GitHub-Flavored Markdown for headings, emphasis, links, lists, and code.\n" +
+	"- Prefer a compact Markdown table for comparisons, data lists with repeated fields, status or metric summaries, and other genuinely tabular structured output.\n" +
+	"- Every table must have a header row and delimiter row, for example `| Name | Value |` followed by `|---|---|`.\n" +
+	"- Do not wrap an actual table in a code fence and do not simulate tables with ASCII art. Keep tables compact and use no more than 20 columns.\n" +
+	"- Use fenced code blocks only for source code or literal preformatted text."
+
+type telegramOutputPromptContributor struct{}
+
+func (telegramOutputPromptContributor) PromptSource() PromptSourceDescriptor {
+	return PromptSourceDescriptor{
+		ID:              telegramOutputPromptSourceID,
+		Owner:           "agent",
+		Description:     "Telegram rich-message output formatting policy",
+		Allowed:         []PromptPlacement{{Layer: PromptLayerContext, Slot: PromptSlotOutput}},
+		StableByDefault: false,
+	}
+}
+
+func (telegramOutputPromptContributor) ContributePrompt(
+	_ context.Context,
+	req PromptBuildRequest,
+) ([]PromptPart, error) {
+	if !strings.EqualFold(strings.TrimSpace(req.Channel), "telegram") {
+		return nil, nil
+	}
+	return []PromptPart{{
+		ID:      "context.output_policy.telegram_rich_messages",
+		Layer:   PromptLayerContext,
+		Slot:    PromptSlotOutput,
+		Source:  PromptSource{ID: telegramOutputPromptSourceID, Name: "telegram_rich_messages"},
+		Title:   "Telegram rich-message output policy",
+		Content: telegramOutputFormattingPrompt,
+		Stable:  false,
+		Cache:   PromptCacheNone,
+	}}, nil
+}
+
 type toolDiscoveryPromptContributor struct {
 	useBM25  bool
 	useRegex bool

--- a/pkg/agent/telegram_output_prompt_test.go
+++ b/pkg/agent/telegram_output_prompt_test.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTelegramOutputPromptContributor(t *testing.T) {
+	t.Parallel()
+
+	registry := NewPromptRegistry()
+	parts, err := registry.Collect(t.Context(), PromptBuildRequest{Channel: " Telegram "})
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	assert.Contains(t, parts[0].Content, "Prefer a compact Markdown table")
+	assert.Contains(t, parts[0].Content, "|---|---|")
+
+	parts, err = registry.Collect(t.Context(), PromptBuildRequest{Channel: "discord"})
+	require.NoError(t, err)
+	assert.Empty(t, parts)
+}
+
+func TestBuildMessagesAddsFormattingRulesOnlyForTelegram(t *testing.T) {
+	t.Parallel()
+
+	cb := NewContextBuilder(t.TempDir())
+	telegramMessages := cb.BuildMessagesFromPrompt(PromptBuildRequest{
+		CurrentMessage: "show metrics",
+		Channel:        "telegram",
+		ChatID:         "12345",
+	})
+	require.NotEmpty(t, telegramMessages)
+	require.Equal(t, "system", telegramMessages[0].Role)
+	assert.Contains(t, telegramMessages[0].Content, "# Telegram response formatting")
+
+	discordMessages := cb.BuildMessagesFromPrompt(PromptBuildRequest{
+		CurrentMessage: "show metrics",
+		Channel:        "discord",
+		ChatID:         "12345",
+	})
+	require.NotEmpty(t, discordMessages)
+	require.Equal(t, "system", discordMessages[0].Role)
+	assert.False(t, strings.Contains(discordMessages[0].Content, "# Telegram response formatting"))
+}

--- a/pkg/channels/telegram/rich_tables.go
+++ b/pkg/channels/telegram/rich_tables.go
@@ -1,0 +1,467 @@
+package telegram
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/net/html"
+)
+
+var (
+	richHTMLTablePattern = regexp.MustCompile(`(?is)<table\b[^>]*>.*?</table\s*>`)
+	tableSeparatorCell   = regexp.MustCompile(`^:?-{3,}:?$`)
+)
+
+// markdownTextSegment is a section of Markdown that is either normal text or a
+// fenced code block. Tables shown as examples inside code fences must never
+// trigger rich-message delivery or be rewritten by the fallback renderer.
+type markdownTextSegment struct {
+	text   string
+	fenced bool
+}
+
+type parsedMarkdownTable struct {
+	rows [][]string
+	end  int // exclusive line index
+}
+
+// hasTelegramRichTable reports whether content contains a Markdown or HTML
+// table that Telegram's rich-message parser can render natively.
+func hasTelegramRichTable(content string) bool {
+	for _, segment := range splitMarkdownFencedSegments(content) {
+		if segment.fenced {
+			continue
+		}
+
+		protected := extractInlineCodes(segment.text)
+		if richHTMLTablePattern.MatchString(protected.text) {
+			return true
+		}
+
+		lines := strings.Split(protected.text, "\n")
+		for i := 0; i+1 < len(lines); i++ {
+			if _, ok := parseMarkdownTableAt(lines, i); ok {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// telegramTableFallbackMarkdown converts native-table input into fenced code
+// blocks. The existing HTML/MarkdownV2 formatter then maps those fences to a
+// Telegram "pre" entity, providing a readable monospaced fallback.
+func telegramTableFallbackMarkdown(content string) string {
+	return renderTelegramTableFallback(content, true)
+}
+
+// telegramTableFallbackPlainText produces the final no-parse-mode fallback.
+// It keeps the aligned table but omits the generated Markdown fences when
+// Telegram rejects both formatted attempts.
+func telegramTableFallbackPlainText(content string) string {
+	return renderTelegramTableFallback(content, false)
+}
+
+func renderTelegramTableFallback(content string, fenced bool) string {
+	segments := splitMarkdownFencedSegments(content)
+	var result strings.Builder
+
+	for _, segment := range segments {
+		if segment.fenced {
+			result.WriteString(segment.text)
+			continue
+		}
+
+		inlineCodes := extractInlineCodes(segment.text)
+		var htmlFallbacks []string
+		text := richHTMLTablePattern.ReplaceAllStringFunc(inlineCodes.text, func(tableHTML string) string {
+			rows, ok := parseHTMLTableRows(tableHTML)
+			if !ok {
+				return tableHTML
+			}
+			placeholder := fmt.Sprintf("\x00HT%d\x00", len(htmlFallbacks))
+			htmlFallbacks = append(htmlFallbacks, surroundTableFallback(renderMonospacedTable(rows), fenced))
+			return placeholder
+		})
+		text = replaceMarkdownTables(text, fenced)
+		for i, fallback := range htmlFallbacks {
+			text = strings.ReplaceAll(text, fmt.Sprintf("\x00HT%d\x00", i), fallback)
+		}
+
+		for i, code := range inlineCodes.codes {
+			text = strings.ReplaceAll(text, fmt.Sprintf("\x00IC%d\x00", i), "`"+code+"`")
+		}
+		result.WriteString(text)
+	}
+
+	return result.String()
+}
+
+func replaceMarkdownTables(content string, fenced bool) string {
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+
+	for i := 0; i < len(lines); {
+		if table, ok := parseMarkdownTableAt(lines, i); ok {
+			out = append(out, surroundTableFallback(renderMonospacedTable(table.rows), fenced))
+			i = table.end
+			continue
+		}
+		out = append(out, lines[i])
+		i++
+	}
+
+	return strings.Join(out, "\n")
+}
+
+func parseMarkdownTableAt(lines []string, start int) (parsedMarkdownTable, bool) {
+	if start < 0 || start+1 >= len(lines) {
+		return parsedMarkdownTable{}, false
+	}
+
+	header, hasHeaderPipes := splitMarkdownTableRow(lines[start])
+	separator, hasSeparatorPipes := splitMarkdownTableRow(lines[start+1])
+	if !hasHeaderPipes || !hasSeparatorPipes || len(header) == 0 || len(separator) != len(header) {
+		return parsedMarkdownTable{}, false
+	}
+	for _, cell := range separator {
+		cell = strings.Join(strings.Fields(cell), "")
+		if !tableSeparatorCell.MatchString(cell) {
+			return parsedMarkdownTable{}, false
+		}
+	}
+
+	rows := [][]string{normalizeTableRow(header, len(header))}
+	end := start + 2
+	for end < len(lines) {
+		if strings.TrimSpace(lines[end]) == "" {
+			break
+		}
+		row, hasPipes := splitMarkdownTableRow(lines[end])
+		if !hasPipes {
+			break
+		}
+		rows = append(rows, normalizeTableRow(row, len(header)))
+		end++
+	}
+
+	return parsedMarkdownTable{rows: rows, end: end}, true
+}
+
+// splitMarkdownTableRow handles escaped pipes and pipes inside inline code. It
+// intentionally accepts optional leading/trailing pipes, matching GFM tables.
+func splitMarkdownTableRow(line string) ([]string, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return nil, false
+	}
+
+	var (
+		cells        []string
+		cell         strings.Builder
+		hasPipe      bool
+		codeTicks    int
+		leadingPipe  bool
+		trailingPipe bool
+	)
+
+	for i := 0; i < len(line); {
+		switch line[i] {
+		case '\\':
+			if i+1 < len(line) && line[i+1] == '|' {
+				cell.WriteByte('|')
+				i += 2
+				continue
+			}
+			cell.WriteByte(line[i])
+			i++
+		case '`':
+			run := 1
+			for i+run < len(line) && line[i+run] == '`' {
+				run++
+			}
+			cell.WriteString(line[i : i+run])
+			if codeTicks == 0 {
+				codeTicks = run
+			} else if codeTicks == run {
+				codeTicks = 0
+			}
+			i += run
+		case '|':
+			if codeTicks != 0 {
+				cell.WriteByte('|')
+				i++
+				continue
+			}
+			hasPipe = true
+			if len(cells) == 0 && strings.TrimSpace(cell.String()) == "" {
+				leadingPipe = true
+			}
+			cells = append(cells, strings.TrimSpace(cell.String()))
+			cell.Reset()
+			i++
+			trailingPipe = strings.TrimSpace(line[i:]) == ""
+		default:
+			cell.WriteByte(line[i])
+			i++
+		}
+	}
+	cells = append(cells, strings.TrimSpace(cell.String()))
+
+	if leadingPipe && len(cells) > 0 {
+		cells = cells[1:]
+	}
+	if trailingPipe && len(cells) > 0 {
+		cells = cells[:len(cells)-1]
+	}
+	return cells, hasPipe
+}
+
+func normalizeTableRow(row []string, columns int) []string {
+	normalized := make([]string, columns)
+	for i := 0; i < columns && i < len(row); i++ {
+		normalized[i] = collapseTableCellWhitespace(row[i])
+	}
+	return normalized
+}
+
+func collapseTableCellWhitespace(value string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+}
+
+func parseHTMLTableRows(tableHTML string) ([][]string, bool) {
+	doc, err := html.Parse(strings.NewReader(tableHTML))
+	if err != nil {
+		return nil, false
+	}
+
+	table := findHTMLElement(doc, "table")
+	if table == nil {
+		return nil, false
+	}
+
+	var rows [][]string
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.ElementNode && node.Data == "table" && node != table {
+			return
+		}
+		if node.Type == html.ElementNode && node.Data == "tr" && nearestHTMLAncestor(node, "table") == table {
+			var cells []string
+			for child := node.FirstChild; child != nil; child = child.NextSibling {
+				collectHTMLRowCells(child, node, &cells)
+			}
+			if len(cells) > 0 {
+				rows = append(rows, cells)
+			}
+			return
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(table)
+
+	if len(rows) == 0 {
+		return nil, false
+	}
+	columns := 0
+	for _, row := range rows {
+		if len(row) > columns {
+			columns = len(row)
+		}
+	}
+	for i := range rows {
+		rows[i] = normalizeTableRow(rows[i], columns)
+	}
+	return rows, true
+}
+
+func findHTMLElement(node *html.Node, name string) *html.Node {
+	if node.Type == html.ElementNode && node.Data == name {
+		return node
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		if found := findHTMLElement(child, name); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func nearestHTMLAncestor(node *html.Node, name string) *html.Node {
+	for parent := node.Parent; parent != nil; parent = parent.Parent {
+		if parent.Type == html.ElementNode && parent.Data == name {
+			return parent
+		}
+	}
+	return nil
+}
+
+func collectHTMLRowCells(node, row *html.Node, cells *[]string) {
+	if node.Type == html.ElementNode && (node.Data == "td" || node.Data == "th") &&
+		nearestHTMLAncestor(node, "tr") == row {
+		*cells = append(*cells, collapseTableCellWhitespace(htmlNodeText(node)))
+		return
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		collectHTMLRowCells(child, row, cells)
+	}
+}
+
+func htmlNodeText(node *html.Node) string {
+	var result strings.Builder
+	var walk func(*html.Node)
+	walk = func(current *html.Node) {
+		if current.Type == html.TextNode {
+			result.WriteString(current.Data)
+			return
+		}
+		if current.Type == html.ElementNode && current.Data == "br" {
+			result.WriteByte(' ')
+			return
+		}
+		for child := current.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(node)
+	return result.String()
+}
+
+func renderMonospacedTable(rows [][]string) string {
+	if len(rows) == 0 {
+		return ""
+	}
+
+	columns := 0
+	for _, row := range rows {
+		if len(row) > columns {
+			columns = len(row)
+		}
+	}
+	if columns == 0 {
+		return ""
+	}
+
+	widths := make([]int, columns)
+	for _, row := range rows {
+		for column := 0; column < columns; column++ {
+			value := ""
+			if column < len(row) {
+				value = collapseTableCellWhitespace(row[column])
+			}
+			if width := utf8.RuneCountInString(value); width > widths[column] {
+				widths[column] = width
+			}
+		}
+	}
+
+	var result strings.Builder
+	writeRow := func(row []string) {
+		result.WriteString("| ")
+		for column := 0; column < columns; column++ {
+			if column > 0 {
+				result.WriteString(" | ")
+			}
+			value := ""
+			if column < len(row) {
+				value = collapseTableCellWhitespace(row[column])
+			}
+			result.WriteString(value)
+			result.WriteString(strings.Repeat(" ", widths[column]-utf8.RuneCountInString(value)))
+		}
+		result.WriteString(" |\n")
+	}
+
+	writeRow(rows[0])
+	result.WriteString("|-")
+	for column, width := range widths {
+		if column > 0 {
+			result.WriteString("-|-")
+		}
+		if width < 3 {
+			width = 3
+		}
+		result.WriteString(strings.Repeat("-", width))
+	}
+	result.WriteString("-|\n")
+	for _, row := range rows[1:] {
+		writeRow(row)
+	}
+
+	return strings.TrimSuffix(result.String(), "\n")
+}
+
+func surroundTableFallback(table string, fenced bool) string {
+	if !fenced {
+		return table
+	}
+	// Avoid accidentally terminating the generated code block when a cell
+	// contains a literal fence.
+	table = strings.ReplaceAll(table, "```", "`` `")
+	return "```\n" + table + "\n```"
+}
+
+func splitMarkdownFencedSegments(content string) []markdownTextSegment {
+	lines := strings.SplitAfter(content, "\n")
+	segments := make([]markdownTextSegment, 0, 3)
+	var current strings.Builder
+	var fence byte
+	var fenceLength int
+	currentFenced := false
+
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		segments = append(segments, markdownTextSegment{text: current.String(), fenced: currentFenced})
+		current.Reset()
+	}
+
+	for _, line := range lines {
+		marker, length, ok := markdownFenceMarker(line)
+		if fence == 0 && ok {
+			flush()
+			currentFenced = true
+			fence = marker
+			fenceLength = length
+			current.WriteString(line)
+			continue
+		}
+
+		current.WriteString(line)
+		if fence != 0 && ok && marker == fence && length >= fenceLength {
+			flush()
+			currentFenced = false
+			fence = 0
+			fenceLength = 0
+		}
+	}
+	flush()
+
+	return segments
+}
+
+func markdownFenceMarker(line string) (byte, int, bool) {
+	line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+	indent := 0
+	for indent < len(line) && indent < 4 && line[indent] == ' ' {
+		indent++
+	}
+	if indent > 3 || indent >= len(line) {
+		return 0, 0, false
+	}
+	marker := line[indent]
+	if marker != '`' && marker != '~' {
+		return 0, 0, false
+	}
+	length := 1
+	for indent+length < len(line) && line[indent+length] == marker {
+		length++
+	}
+	return marker, length, length >= 3
+}

--- a/pkg/channels/telegram/rich_tables_delivery_test.go
+++ b/pkg/channels/telegram/rich_tables_delivery_test.go
@@ -1,0 +1,262 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mymmrac/telego"
+	ta "github.com/mymmrac/telego/telegoapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/config"
+)
+
+const testMarkdownTable = "**Metrics**\n\n" +
+	"- Scope: system\n" +
+	"- Source: `picoclaw status`\n\n" +
+	"| Name | Value |\n" +
+	"|------|------:|\n" +
+	"| CPU  | 42%   |"
+
+func TestSendMarkdownTableUsesNativeRichMessage(t *testing.T) {
+	caller := &stubCaller{
+		callFn: func(_ context.Context, url string, _ *ta.RequestData) (*ta.Response, error) {
+			require.Contains(t, url, "sendRichMessage")
+			return successResponseWithMessageID(t, 91), nil
+		},
+	}
+	ch := newTestChannel(t, caller)
+
+	ids, err := ch.Send(context.Background(), bus.OutboundMessage{
+		ChatID:           "-1001234567890/42",
+		ReplyToMessageID: "77",
+		Content:          testMarkdownTable,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"91"}, ids)
+	require.Len(t, caller.calls, 1)
+
+	var payload struct {
+		ChatID          int64 `json:"chat_id"`
+		MessageThreadID int   `json:"message_thread_id"`
+		RichMessage     struct {
+			Markdown string `json:"markdown"`
+		} `json:"rich_message"`
+		ReplyParameters struct {
+			MessageID int `json:"message_id"`
+		} `json:"reply_parameters"`
+	}
+	require.NoError(t, json.Unmarshal(caller.calls[0].Data.BodyRaw, &payload))
+	assert.Equal(t, int64(-1001234567890), payload.ChatID)
+	assert.Equal(t, 42, payload.MessageThreadID)
+	assert.Equal(t, testMarkdownTable, payload.RichMessage.Markdown)
+	assert.Equal(t, 77, payload.ReplyParameters.MessageID)
+	assert.NotContains(t, string(caller.calls[0].Data.BodyRaw), `"parse_mode"`)
+	assert.NotContains(t, string(caller.calls[0].Data.BodyRaw), `"entities"`)
+}
+
+func TestSendHTMLTableUsesNativeRichMessage(t *testing.T) {
+	content := `<h2>Metrics</h2><table><tr><th>Name</th><th>Value</th></tr><tr><td>CPU</td><td>42%</td></tr></table>`
+	caller := &stubCaller{
+		callFn: func(_ context.Context, url string, _ *ta.RequestData) (*ta.Response, error) {
+			require.Contains(t, url, "sendRichMessage")
+			return successResponse(t), nil
+		},
+	}
+	ch := newTestChannel(t, caller)
+	ch.tgCfg.UseMarkdownV2 = true
+
+	_, err := ch.Send(context.Background(), bus.OutboundMessage{ChatID: "12345", Content: content})
+	require.NoError(t, err)
+	require.Len(t, caller.calls, 1)
+
+	var payload struct {
+		RichMessage telego.InputRichMessage `json:"rich_message"`
+	}
+	require.NoError(t, json.Unmarshal(caller.calls[0].Data.BodyRaw, &payload))
+	assert.Equal(t, content, payload.RichMessage.Markdown)
+}
+
+func TestSendTableInsideCodeBlockUsesRegularMessage(t *testing.T) {
+	content := "```markdown\n| Name | Value |\n|---|---|\n| CPU | 42% |\n```"
+	caller := &stubCaller{
+		callFn: func(_ context.Context, url string, _ *ta.RequestData) (*ta.Response, error) {
+			assert.Contains(t, url, "sendMessage")
+			assert.NotContains(t, url, "sendRichMessage")
+			return successResponse(t), nil
+		},
+	}
+	ch := newTestChannel(t, caller)
+
+	_, err := ch.Send(context.Background(), bus.OutboundMessage{ChatID: "12345", Content: content})
+	require.NoError(t, err)
+	require.Len(t, caller.calls, 1)
+}
+
+func TestSendNativeTableFailureFallsBackToPreformattedMessage(t *testing.T) {
+	caller := &stubCaller{
+		callFn: func(_ context.Context, url string, _ *ta.RequestData) (*ta.Response, error) {
+			if strings.Contains(url, "sendRichMessage") {
+				return nil, errors.New("Bad Request: rich messages are unsupported")
+			}
+			return successResponse(t), nil
+		},
+	}
+	ch := newTestChannel(t, caller)
+
+	ids, err := ch.Send(context.Background(), bus.OutboundMessage{
+		ChatID:  "12345",
+		Content: testMarkdownTable,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"1"}, ids)
+	require.Len(t, caller.calls, 2)
+	assert.Contains(t, caller.calls[0].URL, "sendRichMessage")
+	assert.Contains(t, caller.calls[1].URL, "sendMessage")
+
+	var payload struct {
+		Text      string `json:"text"`
+		ParseMode string `json:"parse_mode"`
+	}
+	require.NoError(t, json.Unmarshal(caller.calls[1].Data.BodyRaw, &payload))
+	assert.Equal(t, telego.ModeHTML, payload.ParseMode)
+	assert.Contains(t, payload.Text, "<pre><code>")
+	assert.Contains(t, payload.Text, "| Name")
+	assert.NotContains(t, payload.Text, "|------|------:|")
+}
+
+func TestSendTableFallbackEndsWithAlignedPlainText(t *testing.T) {
+	call := 0
+	caller := &stubCaller{
+		callFn: func(_ context.Context, _ string, _ *ta.RequestData) (*ta.Response, error) {
+			call++
+			if call < 3 {
+				return nil, errors.New("Bad Request: rejected")
+			}
+			return successResponse(t), nil
+		},
+	}
+	ch := newTestChannel(t, caller)
+
+	_, err := ch.Send(context.Background(), bus.OutboundMessage{
+		ChatID:  "12345",
+		Content: testMarkdownTable,
+	})
+	require.NoError(t, err)
+	require.Len(t, caller.calls, 3)
+
+	var payload struct {
+		Text      string `json:"text"`
+		ParseMode string `json:"parse_mode"`
+	}
+	require.NoError(t, json.Unmarshal(caller.calls[2].Data.BodyRaw, &payload))
+	assert.Empty(t, payload.ParseMode)
+	assert.NotContains(t, payload.Text, "```")
+	assert.Contains(t, payload.Text, "| Name")
+	assert.NotContains(t, payload.Text, "|------|------:|")
+}
+
+func TestSendTableFallbackHonorsMarkdownV2Mode(t *testing.T) {
+	caller := &stubCaller{
+		callFn: func(_ context.Context, url string, _ *ta.RequestData) (*ta.Response, error) {
+			if strings.Contains(url, "sendRichMessage") {
+				return nil, errors.New("Bad Request: rich messages are unsupported")
+			}
+			return successResponse(t), nil
+		},
+	}
+	ch := newTestChannel(t, caller)
+	ch.tgCfg.UseMarkdownV2 = true
+
+	_, err := ch.Send(context.Background(), bus.OutboundMessage{
+		ChatID:  "12345",
+		Content: testMarkdownTable,
+	})
+	require.NoError(t, err)
+	require.Len(t, caller.calls, 2)
+
+	var payload struct {
+		Text      string `json:"text"`
+		ParseMode string `json:"parse_mode"`
+	}
+	require.NoError(t, json.Unmarshal(caller.calls[1].Data.BodyRaw, &payload))
+	assert.Equal(t, telego.ModeMarkdownV2, payload.ParseMode)
+	assert.Contains(t, payload.Text, "```")
+	assert.Contains(t, payload.Text, "| Name")
+}
+
+func TestEditMessageTableUsesNativeRichMessage(t *testing.T) {
+	caller := &stubCaller{
+		callFn: func(_ context.Context, url string, _ *ta.RequestData) (*ta.Response, error) {
+			require.Contains(t, url, "editMessageText")
+			return successResponse(t), nil
+		},
+	}
+	ch := newTestChannel(t, caller)
+
+	require.NoError(t, ch.EditMessage(context.Background(), "12345", "88", testMarkdownTable))
+	require.Len(t, caller.calls, 1)
+
+	var payload struct {
+		Text        string                   `json:"text"`
+		RichMessage *telego.InputRichMessage `json:"rich_message"`
+	}
+	require.NoError(t, json.Unmarshal(caller.calls[0].Data.BodyRaw, &payload))
+	assert.Empty(t, payload.Text)
+	require.NotNil(t, payload.RichMessage)
+	assert.Equal(t, testMarkdownTable, payload.RichMessage.Markdown)
+}
+
+func TestEditMessageNativeTableFailureFallsBackToPreformatted(t *testing.T) {
+	call := 0
+	caller := &stubCaller{
+		callFn: func(_ context.Context, _ string, _ *ta.RequestData) (*ta.Response, error) {
+			call++
+			if call == 1 {
+				return nil, errors.New("Bad Request: rich messages are unsupported")
+			}
+			return successResponse(t), nil
+		},
+	}
+	ch := newTestChannel(t, caller)
+
+	require.NoError(t, ch.EditMessage(context.Background(), "12345", "88", testMarkdownTable))
+	require.Len(t, caller.calls, 2)
+
+	var payload struct {
+		Text        string                   `json:"text"`
+		ParseMode   string                   `json:"parse_mode"`
+		RichMessage *telego.InputRichMessage `json:"rich_message"`
+	}
+	require.NoError(t, json.Unmarshal(caller.calls[1].Data.BodyRaw, &payload))
+	assert.Nil(t, payload.RichMessage)
+	assert.Equal(t, telego.ModeHTML, payload.ParseMode)
+	assert.Contains(t, payload.Text, "<pre><code>")
+}
+
+func TestStreamFinalizeTableUsesNativeRichMessage(t *testing.T) {
+	caller := &stubCaller{
+		callFn: func(_ context.Context, url string, _ *ta.RequestData) (*ta.Response, error) {
+			require.Contains(t, url, "sendRichMessage")
+			return successResponse(t), nil
+		},
+	}
+	ch := newTestChannel(t, caller)
+	ch.tgCfg.Streaming = config.StreamingConfig{Enabled: true}
+
+	streamer, err := ch.BeginStream(context.Background(), "12345")
+	require.NoError(t, err)
+	require.NoError(t, streamer.Finalize(context.Background(), testMarkdownTable))
+	require.Len(t, caller.calls, 1)
+
+	var payload struct {
+		RichMessage telego.InputRichMessage `json:"rich_message"`
+	}
+	require.NoError(t, json.Unmarshal(caller.calls[0].Data.BodyRaw, &payload))
+	assert.Equal(t, testMarkdownTable, payload.RichMessage.Markdown)
+}

--- a/pkg/channels/telegram/rich_tables_test.go
+++ b/pkg/channels/telegram/rich_tables_test.go
@@ -1,0 +1,137 @@
+package telegram
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasTelegramRichTable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name: "markdown table",
+			content: `| Name | Value |
+|------|------:|
+| CPU  | 42%   |`,
+			want: true,
+		},
+		{
+			name: "markdown table without outer pipes",
+			content: `Name | Value
+--- | ---
+CPU | 42%`,
+			want: true,
+		},
+		{
+			name:    "html table",
+			content: `Before <TABLE striped><TR><TH>Name</TH></TR><TR><TD>CPU</TD></TR></TABLE> after`,
+			want:    true,
+		},
+		{
+			name: "table with inline code pipe",
+			content: "| Expression | Result |\n" +
+				"|------------|--------|\n" +
+				"| `a|b`      | true   |",
+			want: true,
+		},
+		{
+			name:    "ordinary text with pipes",
+			content: `Use a | b when choosing one value.`,
+			want:    false,
+		},
+		{
+			name: "missing delimiter",
+			content: `| Name | Value |
+| CPU  | 42%   |`,
+			want: false,
+		},
+		{
+			name:    "markdown table in fenced code",
+			content: "```markdown\n| Name | Value |\n|---|---|\n| CPU | 42% |\n```",
+			want:    false,
+		},
+		{
+			name:    "html table in inline code",
+			content: "Use `<table><tr><td>x</td></tr></table>` as an example.",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, hasTelegramRichTable(tt.content))
+		})
+	}
+}
+
+func TestTelegramTableFallbackMarkdown(t *testing.T) {
+	t.Parallel()
+
+	input := `Summary:
+
+| Name | Value |
+|------|------:|
+| CPU  | 42%   |
+
+- healthy`
+
+	fallback := telegramTableFallbackMarkdown(input)
+	assert.Contains(t, fallback, "```\n| Name | Value |")
+	assert.Contains(t, fallback, "| CPU")
+	assert.NotContains(t, fallback, "|------|------:|")
+	assert.Contains(t, fallback, "\n```\n\n- healthy")
+
+	htmlFormatted := markdownToTelegramHTML(fallback)
+	assert.Contains(t, htmlFormatted, "<pre><code>")
+	assert.Contains(t, htmlFormatted, "| Name | Value |")
+	assert.Contains(t, htmlFormatted, "</code></pre>")
+}
+
+func TestTelegramHTMLTableFallback(t *testing.T) {
+	t.Parallel()
+
+	input := `<p>Metrics</p>
+<table bordered>
+  <tr><th>Name</th><th>Value</th></tr>
+  <tr><td>Latency</td><td><b>12 &amp; 13 ms</b></td></tr>
+</table>`
+
+	fallback := telegramTableFallbackMarkdown(input)
+	assert.Contains(t, fallback, "```")
+	assert.Contains(t, fallback, "| Name")
+	assert.Contains(t, fallback, "| Latency")
+	assert.Contains(t, fallback, "12 & 13 ms")
+	assert.NotContains(t, fallback, "<table")
+}
+
+func TestTelegramTableFallbackPreservesExistingCodeBlocks(t *testing.T) {
+	t.Parallel()
+
+	codeBlock := "```markdown\n| Example | Only |\n|---|---|\n| a | b |\n```"
+	input := codeBlock + "\n\n| Real | Table |\n|---|---|\n| c | d |"
+
+	fallback := telegramTableFallbackMarkdown(input)
+	assert.Contains(t, fallback, codeBlock)
+	assert.Equal(t, 4, strings.Count(fallback, "```"))
+}
+
+func TestTelegramTableFallbackPlainTextHasNoAddedFence(t *testing.T) {
+	t.Parallel()
+
+	input := "| Name | Value |\n|---|---|\n| CPU | 42% |"
+	fallback := telegramTableFallbackPlainText(input)
+
+	assert.NotContains(t, fallback, "```")
+	assert.Contains(t, fallback, "| Name")
+	assert.Contains(t, fallback, "| CPU")
+	assert.NotContains(t, fallback, "|---|---|")
+}

--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -265,7 +265,10 @@ func (c *TelegramChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]
 		chunk := queue[0]
 		queue = queue[1:]
 
-		content := parseContent(chunk, useMarkdownV2)
+		content := chunk
+		if !hasTelegramRichTable(chunk) {
+			content = parseContent(chunk, useMarkdownV2)
+		}
 
 		if len([]rune(content)) > 4096 {
 			if isToolFeedback {
@@ -359,12 +362,42 @@ type sendChunkParams struct {
 	useMarkdownV2 bool
 }
 
-// sendChunk sends a single HTML/MarkdownV2 message, falling back to the original
-// markdown as plain text on parse failure so users never see raw HTML/MarkdownV2 tags.
+// sendChunk sends a native rich message when the chunk contains a table.
+// Unsupported rich-message servers fall back to a monospaced table sent through
+// the existing HTML/MarkdownV2 path, then finally to aligned plain text.
 func (c *TelegramChannel) sendChunk(
 	ctx context.Context,
 	params sendChunkParams,
 ) (string, error) {
+	var replyParameters *telego.ReplyParameters
+	if params.replyToID != "" {
+		if mid, parseErr := strconv.Atoi(params.replyToID); parseErr == nil {
+			replyParameters = &telego.ReplyParameters{MessageID: mid}
+		}
+	}
+
+	if hasTelegramRichTable(params.mdFallback) {
+		pMsg, richErr := c.bot.SendRichMessage(ctx, &telego.SendRichMessageParams{
+			ChatID:          tu.ID(params.chatID),
+			MessageThreadID: params.threadID,
+			RichMessage: telego.InputRichMessage{
+				Markdown: params.mdFallback,
+			},
+			ReplyParameters: replyParameters,
+		})
+		if richErr == nil {
+			return strconv.Itoa(pMsg.MessageID), nil
+		}
+
+		logger.WarnCF("telegram", "Native rich table send failed, using preformatted fallback", map[string]any{
+			"chat_id": params.chatID,
+			"error":   richErr.Error(),
+		})
+		fallbackMarkdown := telegramTableFallbackMarkdown(params.mdFallback)
+		params.content = parseContent(fallbackMarkdown, params.useMarkdownV2)
+		params.mdFallback = telegramTableFallbackPlainText(params.mdFallback)
+	}
+
 	tgMsg := tu.Message(tu.ID(params.chatID), params.content)
 	tgMsg.MessageThreadID = params.threadID
 	if params.useMarkdownV2 {
@@ -373,13 +406,7 @@ func (c *TelegramChannel) sendChunk(
 		tgMsg.WithParseMode(telego.ModeHTML)
 	}
 
-	if params.replyToID != "" {
-		if mid, parseErr := strconv.Atoi(params.replyToID); parseErr == nil {
-			tgMsg.ReplyParameters = &telego.ReplyParameters{
-				MessageID: mid,
-			}
-		}
-	}
+	tgMsg.ReplyParameters = replyParameters
 
 	pMsg, err := c.bot.SendMessage(ctx, tgMsg)
 	if err != nil {
@@ -452,6 +479,35 @@ func (c *TelegramChannel) EditMessage(ctx context.Context, chatID string, messag
 	if err != nil {
 		return err
 	}
+	plainFallback := content
+	if hasTelegramRichTable(content) {
+		_, err = c.bot.EditMessageText(ctx, &telego.EditMessageTextParams{
+			ChatID:    tu.ID(cid),
+			MessageID: mid,
+			RichMessage: &telego.InputRichMessage{
+				Markdown: content,
+			},
+		})
+		if err == nil || strings.Contains(err.Error(), "message is not modified") {
+			return nil
+		}
+		if isPostConnectError(err) {
+			logUnknownTelegramEditResult(chatID, mid, err)
+			return nil
+		}
+		if !isTelegramFormattingRejection(err) {
+			return err
+		}
+
+		logger.WarnCF("telegram", "Native rich table edit failed, using preformatted fallback", map[string]any{
+			"chat_id": chatID,
+			"mid":     mid,
+			"error":   err.Error(),
+		})
+		content = telegramTableFallbackMarkdown(content)
+		plainFallback = telegramTableFallbackPlainText(plainFallback)
+	}
+
 	parsedContent := parseContent(content, useMarkdownV2)
 	editMsg := tu.EditMessageText(tu.ID(cid), mid, parsedContent)
 	if useMarkdownV2 {
@@ -472,7 +528,7 @@ func (c *TelegramChannel) EditMessage(ctx context.Context, chatID string, messag
 		// Network errors or timeouts should NOT trigger a retry with different content.
 		if strings.Contains(err.Error(), "Bad Request") {
 			logParseFailed(err, useMarkdownV2)
-			_, err = c.bot.EditMessageText(ctx, tu.EditMessageText(tu.ID(cid), mid, content))
+			_, err = c.bot.EditMessageText(ctx, tu.EditMessageText(tu.ID(cid), mid, plainFallback))
 		}
 	}
 
@@ -482,20 +538,24 @@ func (c *TelegramChannel) EditMessage(ctx context.Context, chatID string, messag
 		}
 
 		if isPostConnectError(err) {
-			logger.WarnCF(
-				"telegram",
-				"EditMessage likely landed but result is unknown; swallowing error to prevent duplicate",
-				map[string]any{
-					"chat_id": chatID,
-					"mid":     mid,
-					"error":   err.Error(),
-				},
-			)
+			logUnknownTelegramEditResult(chatID, mid, err)
 			return nil // Swallow to prevent Manager fallback to a new SendMessage
 		}
 	}
 
 	return err
+}
+
+func logUnknownTelegramEditResult(chatID string, messageID int, err error) {
+	logger.WarnCF(
+		"telegram",
+		"EditMessage likely landed but result is unknown; swallowing error to prevent duplicate",
+		map[string]any{
+			"chat_id": chatID,
+			"mid":     messageID,
+			"error":   err.Error(),
+		},
+	)
 }
 
 // DeleteMessage implements channels.MessageDeleter.
@@ -1557,6 +1617,18 @@ func logParseFailed(err error, useMarkdownV2 bool) {
 	)
 }
 
+func isTelegramFormattingRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "bad request") ||
+		strings.Contains(message, "not found") ||
+		strings.Contains(message, "unsupported") ||
+		strings.Contains(message, "can't parse") ||
+		strings.Contains(message, "cannot parse")
+}
+
 // isBotMentioned checks if the bot is mentioned in the message via entities.
 func (c *TelegramChannel) isBotMentioned(message *telego.Message) bool {
 	text, entities := telegramEntityTextAndList(message)
@@ -1724,6 +1796,27 @@ func (s *telegramStreamer) Update(ctx context.Context, content string) error {
 }
 
 func (s *telegramStreamer) Finalize(ctx context.Context, content string) error {
+	plainFallback := content
+	if hasTelegramRichTable(content) {
+		if _, err := s.bot.SendRichMessage(ctx, &telego.SendRichMessageParams{
+			ChatID:          tu.ID(s.chatID),
+			MessageThreadID: s.threadID,
+			RichMessage: telego.InputRichMessage{
+				Markdown: content,
+			},
+		}); err == nil {
+			s.Cancel(ctx)
+			return nil
+		} else {
+			logger.WarnCF("telegram", "Native rich table finalize failed, using preformatted fallback", map[string]any{
+				"chat_id": s.chatID,
+				"error":   err.Error(),
+			})
+		}
+		content = telegramTableFallbackMarkdown(content)
+		plainFallback = telegramTableFallbackPlainText(plainFallback)
+	}
+
 	htmlContent := markdownToTelegramHTML(content)
 	tgMsg := tu.Message(tu.ID(s.chatID), htmlContent)
 	tgMsg.MessageThreadID = s.threadID
@@ -1731,6 +1824,7 @@ func (s *telegramStreamer) Finalize(ctx context.Context, content string) error {
 
 	if _, err := s.bot.SendMessage(ctx, tgMsg); err != nil {
 		// Fallback to plain text
+		tgMsg.Text = plainFallback
 		tgMsg.ParseMode = ""
 		if _, err = s.bot.SendMessage(ctx, tgMsg); err != nil {
 			logger.ErrorCF("telegram", "Finalize failed after HTML and plain-text attempts", map[string]any{


### PR DESCRIPTION
## 📝 Description

Render genuinely tabular Telegram replies with Bot API rich messages instead of reducing every table to a monospaced code block.

This change:

- detects GFM tables and supported HTML `<table>` blocks outside inline/fenced code examples;
- delivers matching send, reply/topic, edit, and streaming-finalization paths through `sendRichMessage` / `InputRichMessage.Markdown`;
- falls back to a readable preformatted table and then aligned plain text when rich formatting is rejected;
- adds Telegram-only output guidance so model responses use compact GFM tables for comparisons and repeated-field data;
- upgrades `telego` to v1.11.1 for Bot API 10.2 rich-message support; and
- adds parser, payload, fallback, edit, streaming, and prompt-scoping tests.

Normal non-table Telegram messages keep the existing HTML/MarkdownV2 delivery path. The unrelated broken-lockfile cleanup discovered during the Android build is already covered by #3318 and is not included here.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

The implementation and tests were AI-generated, followed by an AI-assisted line-by-line review of the parser, delivery paths, fallbacks, dependency diff, and external-input handling. The contributor then verified the resulting module on a live Telegram chat.

## 🔗 Related Issue

Closes #3325

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://core.telegram.org/bots/api#rich-messages and https://core.telegram.org/bots/api#sendrichmessage
- **Reasoning:** Bot API 10.1/10.2 tables are rich-message blocks, not classic `MessageEntity` values. Telegram's rich Markdown parser is GFM-compatible, accepts supported rich HTML, and enforces the documented 20-column table limit. Passing the original Markdown/HTML through `InputRichMessage` preserves inline formatting without implementing a second rich-text AST. Capability failures retain readable output through the existing classic message path.

## 🧪 Test Environment
- **Hardware:** Android ARM64 device with KSU Next; GitHub-hosted x86_64 build runner
- **OS:** Android with the Nekogram Telegram client; Ubuntu 24.04 GitHub Actions runner
- **Model/Provider:** Configured PicoClaw provider (delivery behavior is provider-independent)
- **Channels:** Live Telegram bot plus mocked `telego` Bot API delivery tests

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- Live smoke test on 2026-08-09 with PicoClaw Android module `v0.3.1-r4`: a four-column, five-row GFM table rendered as Telegram's native bordered table UI in Nekogram.
- The same live rich message preserved syntax-highlighted fenced code and a styled blockquote alongside the table.
- The source commit completed frontend compilation, Go/CGO Android ARM64 compilation, ELF validation, and module packaging in GitHub Actions: https://github.com/As-tsaqib/picoclaw-module/actions/runs/31315293747
- Added tests assert native rich payloads, replies and forum topics, HTML/GFM detection, code-block exclusion, edit and streaming paths, plus both formatted and plain-text fallbacks.
- Upstream PR CI is the authoritative lint, security, unit, and integration validation for this contribution.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have reviewed the documentation impact; there is no new user-facing configuration to document.
