### PR TITLE
fix(line): warn on inert webhook_host / webhook_port instead of seeding them

### DIFF
--- a/pkg/channels/line/line.go
+++ b/pkg/channels/line/line.go
@@ -61,6 +61,14 @@ func NewLINEChannel(
 		return nil, fmt.Errorf("line channel_secret and channel_access_token are required")
 	}
 
+	if keys := inertBindKeys(cfg); len(keys) > 0 {
+		logger.WarnCF("line", "Ignoring LINE webhook bind settings: the webhook is served by the shared gateway HTTP server", map[string]any{
+			"ignored":      strings.Join(keys, ", "),
+			"use_instead":  "gateway.host / gateway.port",
+			"webhook_path": webhookPath(cfg),
+		})
+	}
+
 	client, err := messaging_api.NewMessagingApiAPI(
 		cfg.ChannelAccessToken.String(),
 		messaging_api.WithHTTPClient(&http.Client{Timeout: 30 * time.Second}),
@@ -126,10 +134,29 @@ func (c *LINEChannel) Stop(ctx context.Context) error {
 
 // WebhookPath returns the path for registering on the shared HTTP server.
 func (c *LINEChannel) WebhookPath() string {
-	if c.config.WebhookPath != "" {
-		return c.config.WebhookPath
+	return webhookPath(c.config)
+}
+
+func webhookPath(cfg *config.LINESettings) string {
+	if cfg.WebhookPath != "" {
+		return cfg.WebhookPath
 	}
 	return "/webhook/line"
+}
+
+// inertBindKeys reports which webhook bind settings are set but unused. The
+// LINE channel is mounted as a handler on the shared gateway HTTP server and
+// has no listener of its own, so webhook_host and webhook_port never bind
+// anything. They are still parsed so that existing config files keep loading.
+func inertBindKeys(cfg *config.LINESettings) []string {
+	var keys []string
+	if cfg.WebhookHost != "" {
+		keys = append(keys, "webhook_host")
+	}
+	if cfg.WebhookPort != 0 {
+		keys = append(keys, "webhook_port")
+	}
+	return keys
 }
 
 // ServeHTTP implements http.Handler for the shared HTTP server.

--- a/pkg/channels/line/line.go
+++ b/pkg/channels/line/line.go
@@ -62,11 +62,15 @@ func NewLINEChannel(
 	}
 
 	if keys := inertBindKeys(cfg); len(keys) > 0 {
-		logger.WarnCF("line", "Ignoring LINE webhook bind settings: the webhook is served by the shared gateway HTTP server", map[string]any{
-			"ignored":      strings.Join(keys, ", "),
-			"use_instead":  "gateway.host / gateway.port",
-			"webhook_path": webhookPath(cfg),
-		})
+		logger.WarnCF(
+			"line",
+			"Ignoring LINE webhook bind settings: the webhook is served by the shared gateway server",
+			map[string]any{
+				"ignored":      strings.Join(keys, ", "),
+				"use_instead":  "gateway.host / gateway.port",
+				"webhook_path": webhookPath(cfg),
+			},
+		)
 	}
 
 	client, err := messaging_api.NewMessagingApiAPI(

--- a/pkg/channels/line/line.go
+++ b/pkg/channels/line/line.go
@@ -147,7 +147,8 @@ func webhookPath(cfg *config.LINESettings) string {
 // inertBindKeys reports which webhook bind settings are set but unused. The
 // LINE channel is mounted as a handler on the shared gateway HTTP server and
 // has no listener of its own, so webhook_host and webhook_port never bind
-// anything. They are still parsed so that existing config files keep loading.
+// anything. They remain in the settings struct so a config still carrying
+// them can be warned about instead of silently ignored.
 func inertBindKeys(cfg *config.LINESettings) []string {
 	var keys []string
 	if cfg.WebhookHost != "" {

--- a/pkg/channels/line/line_test.go
+++ b/pkg/channels/line/line_test.go
@@ -83,3 +83,48 @@ func TestWebhookRejectsInvalidSignature(t *testing.T) {
 		t.Errorf("expected status %d, got %d", http.StatusForbidden, rec.Code)
 	}
 }
+
+func TestInertBindKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.LINESettings
+		want []string
+	}{
+		{name: "unset", cfg: config.LINESettings{}},
+		{
+			name: "host only",
+			cfg:  config.LINESettings{WebhookHost: "0.0.0.0"},
+			want: []string{"webhook_host"},
+		},
+		{
+			name: "port only",
+			cfg:  config.LINESettings{WebhookPort: 18791},
+			want: []string{"webhook_port"},
+		},
+		{
+			name: "both",
+			cfg:  config.LINESettings{WebhookHost: "0.0.0.0", WebhookPort: 18791},
+			want: []string{"webhook_host", "webhook_port"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inertBindKeys(&tt.cfg)
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("inertBindKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWebhookPathIgnoresBindSettings(t *testing.T) {
+	ch := &LINEChannel{config: &config.LINESettings{
+		WebhookHost: "127.0.0.1",
+		WebhookPort: 9999,
+	}}
+
+	if got := ch.WebhookPath(); got != "/webhook/line" {
+		t.Errorf("WebhookPath() = %q, want %q", got, "/webhook/line")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -631,9 +631,9 @@ type LINESettings struct {
 
 	// Deprecated: the LINE webhook is served by the shared gateway HTTP server,
 	// so the channel has no listener of its own and these bind nothing. Use
-	// gateway.host / gateway.port instead. They are still parsed so that config
-	// files carrying them keep loading (unknown JSON fields are a hard error);
-	// setting them logs a warning at channel startup.
+	// gateway.host / gateway.port instead. They are kept as fields so that a
+	// config still carrying them can be detected and warned about at channel
+	// startup; omitempty keeps them out of configs that do not set them.
 	WebhookHost string `json:"webhook_host,omitempty" yaml:"-" env:"PICOCLAW_CHANNELS_LINE_WEBHOOK_HOST"`
 	WebhookPort int    `json:"webhook_port,omitempty" yaml:"-" env:"PICOCLAW_CHANNELS_LINE_WEBHOOK_PORT"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -627,9 +627,15 @@ type DeltaChatSettings struct {
 type LINESettings struct {
 	ChannelSecret      SecureString `json:"channel_secret,omitzero"       yaml:"channel_secret,omitempty"       env:"PICOCLAW_CHANNELS_LINE_CHANNEL_SECRET"`
 	ChannelAccessToken SecureString `json:"channel_access_token,omitzero" yaml:"channel_access_token,omitempty" env:"PICOCLAW_CHANNELS_LINE_CHANNEL_ACCESS_TOKEN"`
-	WebhookHost        string       `json:"webhook_host"                  yaml:"-"                              env:"PICOCLAW_CHANNELS_LINE_WEBHOOK_HOST"`
-	WebhookPort        int          `json:"webhook_port"                  yaml:"-"                              env:"PICOCLAW_CHANNELS_LINE_WEBHOOK_PORT"`
 	WebhookPath        string       `json:"webhook_path"                  yaml:"-"                              env:"PICOCLAW_CHANNELS_LINE_WEBHOOK_PATH"`
+
+	// Deprecated: the LINE webhook is served by the shared gateway HTTP server,
+	// so the channel has no listener of its own and these bind nothing. Use
+	// gateway.host / gateway.port instead. They are still parsed so that config
+	// files carrying them keep loading (unknown JSON fields are a hard error);
+	// setting them logs a warning at channel startup.
+	WebhookHost string `json:"webhook_host,omitempty" yaml:"-" env:"PICOCLAW_CHANNELS_LINE_WEBHOOK_HOST"`
+	WebhookPort int    `json:"webhook_port,omitempty" yaml:"-" env:"PICOCLAW_CHANNELS_LINE_WEBHOOK_PORT"`
 }
 
 type OneBotSettings struct {

--- a/pkg/config/config_channel_test.go
+++ b/pkg/config/config_channel_test.go
@@ -1104,3 +1104,50 @@ func TestChannel_EncryptedToken_NoPassphrase(t *testing.T) {
 func mustParseRawNode(s string) RawNode {
 	return RawNode(s)
 }
+
+// The LINE webhook is served by the shared gateway HTTP server, so
+// webhook_host / webhook_port bind nothing. They must stay parseable — a config
+// file carrying them would otherwise fail to load as an unknown field — but
+// they must not be seeded into fresh configs, where an inert 18791 next to the
+// real gateway port 18790 reads as the port the webhook is served on.
+func TestDefaultChannels_LINEOmitsInertWebhookBindKeys(t *testing.T) {
+	line, ok := defaultChannels()[ChannelLINE]
+	require.True(t, ok, "line channel missing from defaults")
+
+	var settings map[string]any
+	require.NoError(t, line.Settings.Decode(&settings))
+
+	assert.NotContains(t, settings, "webhook_host")
+	assert.NotContains(t, settings, "webhook_port")
+	assert.Equal(t, "/webhook/line", settings["webhook_path"])
+}
+
+func TestLINESettings_InertWebhookBindKeysRemainLoadable(t *testing.T) {
+	ch := &Channel{Type: ChannelLINE}
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"enabled": true,
+		"settings": {
+			"webhook_host": "0.0.0.0",
+			"webhook_port": 18791,
+			"webhook_path": "/webhook/line"
+		}
+	}`), ch))
+
+	var settings LINESettings
+	require.NoError(t, ch.Decode(&settings))
+
+	assert.Equal(t, "0.0.0.0", settings.WebhookHost)
+	assert.Equal(t, 18791, settings.WebhookPort)
+	assert.Equal(t, "/webhook/line", settings.WebhookPath)
+}
+
+func TestLINESettings_InertWebhookBindKeysNotSerializedWhenUnset(t *testing.T) {
+	data, err := json.Marshal(LINESettings{WebhookPath: "/webhook/line"})
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.NotContains(t, raw, "webhook_host")
+	assert.NotContains(t, raw, "webhook_port")
+}

--- a/pkg/config/config_channel_test.go
+++ b/pkg/config/config_channel_test.go
@@ -1106,10 +1106,10 @@ func mustParseRawNode(s string) RawNode {
 }
 
 // The LINE webhook is served by the shared gateway HTTP server, so
-// webhook_host / webhook_port bind nothing. They must stay parseable — a config
-// file carrying them would otherwise fail to load as an unknown field — but
-// they must not be seeded into fresh configs, where an inert 18791 next to the
-// real gateway port 18790 reads as the port the webhook is served on.
+// webhook_host / webhook_port bind nothing. They must stay parseable so a
+// config carrying them can be warned about, but they must not be seeded into
+// fresh configs, where an inert 18791 next to the real gateway port 18790
+// reads as the port the webhook is served on.
 func TestDefaultChannels_LINEOmitsInertWebhookBindKeys(t *testing.T) {
 	line, ok := defaultChannels()[ChannelLINE]
 	require.True(t, ok, "line channel missing from defaults")

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -558,9 +558,9 @@ func defaultChannels() ChannelsConfig {
 		},
 		"line": map[string]any{
 			"group_trigger": map[string]any{"mention_only": true},
+			// The webhook is served by the shared gateway HTTP server, so the
+			// channel has no listener of its own: only the path is configurable.
 			"settings": map[string]any{
-				"webhook_host": "0.0.0.0",
-				"webhook_port": 18791,
 				"webhook_path": "/webhook/line",
 			},
 		},

--- a/pkg/migrate/sources/openclaw/openclaw_config.go
+++ b/pkg/migrate/sources/openclaw/openclaw_config.go
@@ -1122,9 +1122,18 @@ func (c ChannelsConfig) ToStandardChannels() config.ChannelsConfig {
 	setChannel(channels, "line", func() map[string]any {
 		m := map[string]any{
 			"enabled":      c.LINE.Enabled,
-			"webhook_host": c.LINE.WebhookHost,
-			"webhook_port": c.LINE.WebhookPort,
 			"webhook_path": c.LINE.WebhookPath,
+		}
+		// webhook_host / webhook_port bind nothing: the LINE webhook is served
+		// by the shared gateway HTTP server. Carry them over only when the
+		// source config actually set them, so the channel can warn about them
+		// at startup, rather than writing an inert "": 0 pair into every
+		// migrated config.
+		if c.LINE.WebhookHost != "" {
+			m["webhook_host"] = c.LINE.WebhookHost
+		}
+		if c.LINE.WebhookPort != 0 {
+			m["webhook_port"] = c.LINE.WebhookPort
 		}
 		if c.LINE.ChannelSecret != "" {
 			m["channel_secret"] = config.NewSecureString(c.LINE.ChannelSecret)

--- a/pkg/migrate/sources/openclaw/openclaw_config_test.go
+++ b/pkg/migrate/sources/openclaw/openclaw_config_test.go
@@ -827,3 +827,64 @@ func strPtr(s string) *string {
 func boolPtr(b bool) *bool {
 	return &b
 }
+
+// The LINE webhook is served by PicoClaw's shared gateway HTTP server, so
+// webhook_host / webhook_port bind nothing. Migrating them unconditionally
+// wrote an inert `"webhook_host": "", "webhook_port": 0` pair into every
+// migrated config; they should survive migration only when actually set, so
+// the channel can warn about them at startup.
+func TestToStandardConfig_LINEOmitsUnsetWebhookBindKeys(t *testing.T) {
+	picoCfg := &PicoClawConfig{}
+	picoCfg.Channels.LINE = LINEConfig{
+		Enabled:            true,
+		ChannelSecret:      "sec",
+		ChannelAccessToken: "tok",
+	}
+
+	settings := marshalLINESettings(t, picoCfg)
+
+	if _, ok := settings["webhook_host"]; ok {
+		t.Errorf("webhook_host should not be migrated when unset: %#v", settings)
+	}
+	if _, ok := settings["webhook_port"]; ok {
+		t.Errorf("webhook_port should not be migrated when unset: %#v", settings)
+	}
+}
+
+func TestToStandardConfig_LINEKeepsSetWebhookBindKeys(t *testing.T) {
+	picoCfg := &PicoClawConfig{}
+	picoCfg.Channels.LINE = LINEConfig{
+		Enabled:     true,
+		WebhookHost: "127.0.0.1",
+		WebhookPort: 18791,
+	}
+
+	settings := marshalLINESettings(t, picoCfg)
+
+	if got := settings["webhook_host"]; got != "127.0.0.1" {
+		t.Errorf("webhook_host = %v, want %q", got, "127.0.0.1")
+	}
+	if got := settings["webhook_port"]; got != float64(18791) {
+		t.Errorf("webhook_port = %v, want %d", got, 18791)
+	}
+}
+
+// marshalLINESettings round-trips the migrated LINE channel through JSON, which
+// is what actually lands in config.json.
+func marshalLINESettings(t *testing.T, picoCfg *PicoClawConfig) map[string]any {
+	t.Helper()
+
+	stdCfg := picoCfg.ToStandardConfig()
+	data, err := json.Marshal(stdCfg.Channels["line"])
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	var out struct {
+		Settings map[string]any `json:"settings"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+	return out.Settings
+}


### PR DESCRIPTION
Fixes #3328.

## Problem

`line.settings.webhook_host` / `webhook_port` are declared, defaulted, and env-bound, but nothing reads them. The LINE channel implements `WebhookPath()` and is mounted as a handler on the **shared** gateway HTTP server (`pkg/channels/manager.go`, `m.mux.Handle(wh.WebhookPath(), wh)`) — it has no listener of its own, so there is no port for it to bind. The only other references are the openclaw importer, a test fixture, and a Web UI label.

The webhook is actually served on `gateway.port` (default **18790**), while every fresh config was seeded with `webhook_port: 18791`. Both numbers are plausible and adjacent, and nothing distinguishes them. Anyone putting a reverse proxy or tunnel in front of PicoClaw reads the config, points at 18791, and gets a listener that never answers — while channel-enabled, process-healthy, tunnel-connected, and credentials-valid all report fine. The failure surfaces only as webhooks silently 404ing.

## Change

Option (1) from the issue — stop advertising them — plus the warning the issue suggests for configs that already set them.

- **Defaults** (`pkg/config/defaults.go`): drop both keys from the LINE channel, so new configs no longer advertise a port that is never bound. Only `webhook_path` remains, which is genuinely honoured.
- **Migration** (`pkg/migrate/sources/openclaw/openclaw_config.go`): the importer copied both keys unconditionally, so every migrated `config.json` got an inert `"webhook_host": "", "webhook_port": 0` even when the source never set them. Now carried over only when actually set.
- **Struct** (`pkg/config/config.go`): both fields kept, marked `Deprecated:`, with `omitempty` added. They are what makes a stale config *detectable* — that is the only reason to keep them, and they are no longer written back out.
- **Warning** (`pkg/channels/line/line.go`): when either is set, log one warning at channel startup naming `gateway.host` / `gateway.port` as the real setting, and echo the effective `webhook_path`.

Net effect: fresh and migrated configs are clean, and a config that still sets these says so out loud instead of failing silently.

## Behaviour

Startup with a legacy config carrying both keys:

```
WARN [line] Ignoring LINE webhook bind settings: the webhook is served by the shared gateway HTTP server
  ignored=webhook_host, webhook_port  use_instead=gateway.host / gateway.port  webhook_path=/webhook/line
```

Nothing else changes — the fields were inert before this PR and are inert after it. Deleting the fields outright would also have been load-compatible (unknown keys inside a channel `settings` block are silently ignored, since `Settings` is a `RawNode` decoded with a plain `json.Unmarshal`; only *top-level* unknown fields are a hard error) — but then a config still setting them would go on being ignored in silence, which is the actual complaint in #3328.

## Tests

- `TestInertBindKeys` — table test over unset / host-only / port-only / both
- `TestWebhookPathIgnoresBindSettings` — path resolution unaffected by the bind keys
- `TestDefaultChannels_LINEOmitsInertWebhookBindKeys` — defaults no longer seed them
- `TestLINESettings_InertWebhookBindKeysRemainLoadable` — a config setting them still decodes
- `TestLINESettings_InertWebhookBindKeysNotSerializedWhenUnset` — `omitempty` keeps them out of saved configs
- `TestToStandardConfig_LINEOmitsUnsetWebhookBindKeys` / `TestToStandardConfig_LINEKeepsSetWebhookBindKeys` — migration output, both directions

`go vet` and `go test ./pkg/config/... ./pkg/channels/line/... ./pkg/migrate/...` pass. (`pkg/channels/matrix` fails to build in my container for an unrelated pre-existing reason — missing libolm C headers.)

## Notes for reviewers

**Web UI left alone** — `web/frontend/src/components/channels/channel-forms/generic-form.tsx` still maps `webhook_host` / `webhook_port` to "Webhook listening host/port" descriptions. With the keys gone from defaults and migration, the field only renders for configs that already carry it; removing the entries would also orphan the string in ~20 locale files. Happy to fold that in if you'd prefer.

**Docs need no change** — the issue states these are documented in `docs/channels/line/README.md`, but no LINE README (en/ja/zh/fr/pt-br/vi) mentions `webhook_host`, `webhook_port`, or 18791. The en README already correctly says the shared gateway serves the webhook on 18790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
