### PR TITLE
Fix/mcp failure hangs agent loop

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -146,10 +146,12 @@ func (al *AgentLoop) Run(ctx context.Context) error {
 	al.running.Store(true)
 
 	if err := al.ensureHooksInitialized(ctx); err != nil {
-		return err
+		logger.WarnCF("agent", "Hooks failed to initialize, continuing without hooks",
+			map[string]any{"error": err.Error()})
 	}
 	if err := al.ensureMCPInitialized(ctx); err != nil {
-		return err
+		logger.WarnCF("agent", "MCP initialization failed, continuing without MCP tools",
+			map[string]any{"error": err.Error()})
 	}
 
 	idleTicker := time.NewTicker(100 * time.Millisecond)

--- a/pkg/agent/agent_mcp_test.go
+++ b/pkg/agent/agent_mcp_test.go
@@ -11,7 +11,9 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
 	"github.com/sipeed/picoclaw/pkg/mcp"
 	agenttools "github.com/sipeed/picoclaw/pkg/tools"
@@ -311,5 +313,76 @@ func TestEnsureMCPInitialized_LoadFailureSetsInitErr(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to load MCP servers") {
 		t.Fatalf("second ensureMCPInitialized() error = %q, want wrapped load failure", err.Error())
+	}
+}
+
+func TestAgentLoopRun_DoesNotExitOnMCPInitFailure(t *testing.T) {
+	al, cfg, msgBus, _, cleanup := newTestAgentLoop(t)
+	defer cleanup()
+	defer al.Close()
+
+	cfg.Tools = config.ToolsConfig{
+		MCP: config.MCPConfig{
+			ToolConfig: config.ToolConfig{Enabled: true},
+			Servers: map[string]config.MCPServerConfig{
+				"broken": {
+					Enabled: true,
+					Command: "picoclaw-command-that-does-not-exist-for-mcp-tests",
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- al.Run(ctx)
+	}()
+
+	// MCP initialization fails (broken server), but the loop must keep running
+	// instead of returning the error and hanging the chat.
+	select {
+	case err := <-runErr:
+		t.Fatalf("Run() returned before context cancel: %v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	// The loop must still reply to messages even though MCP is unavailable.
+	msg := bus.InboundMessage{
+		Context: bus.InboundContext{
+			Channel:  "telegram",
+			ChatID:   "chat1",
+			ChatType: "direct",
+			SenderID: "user1",
+		},
+		Channel:  "telegram",
+		ChatID:   "chat1",
+		SenderID: "user1",
+		Content:  "hello",
+	}
+	if err := msgBus.PublishInbound(context.Background(), msg); err != nil {
+		t.Fatalf("PublishInbound failed: %v", err)
+	}
+
+	select {
+	case outbound := <-msgBus.OutboundChan():
+		if outbound.Content == "" {
+			t.Fatal("empty response published after MCP init failure")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for agent reply after MCP init failure")
+	}
+
+	// Cancelling the context must stop the loop cleanly.
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run() error after cancel = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Run() to return after cancel")
 	}
 }

--- a/pkg/agent/agent_message.go
+++ b/pkg/agent/agent_message.go
@@ -48,7 +48,8 @@ func (al *AgentLoop) ProcessDirectWithChannel(
 		return "", err
 	}
 	if err := al.ensureMCPInitialized(ctx); err != nil {
-		return "", err
+		logger.WarnCF("agent", "MCP initialization failed, continuing without MCP tools",
+			map[string]any{"error": err.Error()})
 	}
 
 	msg := bus.InboundMessage{
@@ -73,7 +74,8 @@ func (al *AgentLoop) ProcessHeartbeat(
 		return "", err
 	}
 	if err := al.ensureMCPInitialized(ctx); err != nil {
-		return "", err
+		logger.WarnCF("agent", "MCP initialization failed, continuing without MCP tools",
+			map[string]any{"error": err.Error()})
 	}
 
 	agent := al.GetRegistry().GetDefaultAgent()

--- a/pkg/agent/steering.go
+++ b/pkg/agent/steering.go
@@ -386,12 +386,12 @@ func (al *AgentLoop) Continue(ctx context.Context, sessionKey, channel, chatID s
 	}
 
 	if err := al.ensureHooksInitialized(ctx); err != nil {
-		al.activeTurnStates.Delete(sessionKey)
-		return "", err
+		logger.WarnCF("agent", "Hooks failed to initialize, continuing without hooks",
+			map[string]any{"error": err.Error()})
 	}
 	if err := al.ensureMCPInitialized(ctx); err != nil {
-		al.activeTurnStates.Delete(sessionKey)
-		return "", err
+		logger.WarnCF("agent", "MCP initialization failed, continuing without MCP tools",
+			map[string]any{"error": err.Error()})
 	}
 
 	steeringMsgs := al.dequeueSteeringMessagesForScopeWithFallback(sessionKey)


### PR DESCRIPTION
## 📝 Description

Fixes a hang in the agent loop when an MCP server connection fails. Previously, if `ensureMCPInitialized` returned an error (e.g. an unreachable/broken MCP server), `AgentLoop.Run` propagated the error and exited, so the chat interface stopped replying to users entirely until a restart.

This PR makes MCP initialization failure **non-fatal**: the error is logged as a warning and the agent keeps running without MCP tools. The change is applied to every entry point that treated MCP failure as fatal:

- `Run` — keeps the agent loop alive and still processes inbound messages (`pkg/agent/agent.go`).
- `Continue` — no longer drops the claimed session, so queued steering messages are still processed (`pkg/agent/steering.go`).
- `ProcessDirectWithChannel` / `ProcessHeartbeat` — direct and cron/heartbeat calls continue without MCP tools (`pkg/agent/agent_message.go`).

Hooks initialization remains fatal in the direct/heartbeat paths (unchanged behavior), but is also downgraded to a warning inside `Run`/`Continue`, since killing the whole loop there would cause the same hang class.

A regression test (`TestAgentLoopRun_DoesNotExitOnMCPInitFailure`) verifies that with a broken MCP server the loop stays alive, replies to inbound messages, and exits cleanly on context cancel.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)

## 🔗 Related Issue

Fixes #3269

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/issues/3269
- **Reasoning:** The buggy code returned the MCP init error from `Run`, exiting the agent loop and hanging the chat. `mcpRuntime` already caches the init error (`initOnce`), so a failure does not need to be fatal — the same "log and continue" pattern is already used in `ReloadProviderAndConfig` and the `/mcp` command handlers. A config reload (`mcp.reset()`) already retries initialization after the server is fixed.

## 🧪 Test Environment
- **Hardware:** PC (x86_64)
- **OS:** Linux
- **Model/Provider:** N/A — unit tests with mock provider
- **Channels:** N/A — agent loop (inbound/outbound bus) tested directly

## 📸 Evidence (Optional)

<details>
<summary>Click to view Logs</summary>

Regression test output — MCP failure is logged as a warning, the loop keeps replying:

```
WRN agent agent.go:153 > MCP initialization failed, continuing without MCP tools error="failed to load MCP servers: failed to connect to server broken: ..."
INF agent agent_message.go:137 > Processing message from telegram:user1: hello
INF agent agent_outbound.go:86 > Published outbound response channel=telegram chat_id=chat1 content_len=13
--- PASS: TestAgentLoopRun_DoesNotExitOnMCPInitFailure (0.30s)
```

Full package run: `go test ./pkg/agent/` → `ok`; `make vet` and `gofmt` pass.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.