### PR TITLE
fix(slack): set FileSize on media upload params

### DIFF
--- a/pkg/channels/slack/slack.go
+++ b/pkg/channels/slack/slack.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"os"
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
@@ -210,10 +211,20 @@ func (c *SlackChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaMessa
 			title = filename
 		}
 
+		info, err := os.Stat(localPath)
+		if err != nil {
+			logger.ErrorCF("slack", "Failed to stat media file", map[string]any{
+				"path":  localPath,
+				"error": err.Error(),
+			})
+			continue
+		}
+
 		err = c.uploadFileFn(ctx, slack.UploadFileParameters{
 			Channel:         channelID,
 			ThreadTimestamp: threadTS,
 			File:            localPath,
+			FileSize:        int(info.Size()),
 			Filename:        filename,
 			Title:           title,
 		})


### PR DESCRIPTION
## 📝 Description

SendMedia built slack.UploadFileParameters without FileSize, leaving it at zero-value. slack-go v0.23.1 rejects this before any network call because the files.upload.v2 flow requires the length upfront in files.getUploadURLExternal, and the SDK does not derive it from the File path. Every Slack media upload failed with
"file.upload.v2: file size cannot be 0".

Stat the resolved media file and pass its size. Also classify file.upload.v2 validation errors as ErrSendFailed instead of ErrTemporary, since they are deterministic and the previous mapping triggered three pointless retries per attempt.

Regression from the slack-go 0.17.3 -> 0.23.0 bump (#2802): the legacy files.upload endpoint did not require a size. slack_test.go did not catch it because it mocks uploadFileFn, bypassing SDK validation.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)


## 🔗 Related Issue

Fixes #3338

## 📚 Technical Context (Skip for Docs)
- **Reference URL:**
  - slack-go v0.23.1 validation guard: https://github.com/slack-go/slack/blob/v0.23.1/files.go#L547
  - Slack files.getUploadURLExternal (requires `length`): https://api.slack.com/methods/files.getUploadURLExternal
  - Originating dependency bump: #2802
- **Reasoning:** The v2 upload flow is three-step — getUploadURLExternal, PUT to the returned URL, completeUploadExternal. The first step needs the byte length before the file is read, so the SDK cannot infer it from the `File` path and fails fast instead. Passing `os.Stat().Size()` is the minimal fix at the call site; no SDK change or version pin is needed. The error-classification change is included because the two bugs compound: a permanent validation failure mapped to `ErrTemporary` caused the manager to retry three times and reported "temporary failure" to the agent, which then burned several LLM iterations attempting workarounds (base64 encoding, renaming the extension) for a condition that could never resolve on retry.

## 🧪 Test Environment
- **Hardware:** PC (x86_64)
- **OS:** WSL Ubuntu 22.04
- **Model/Provider:** GLM-5.2:cloud via Ollama
- **Channels:** Slack (Socket Mode)


## 📸 Evidence (Optional)
<img width="506" height="380" alt="image" src="https://github.com/user-attachments/assets/53eb6616-b1ce-46f8-a043-4daf07ed0066" />
