### PR TITLE
fix(channels): bound tool feedback animations

### DIFF
--- a/pkg/channels/tool_feedback_animator.go
+++ b/pkg/channels/tool_feedback_animator.go
@@ -5,9 +5,15 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
-const toolFeedbackAnimationInterval = 3 * time.Second
+const (
+	toolFeedbackAnimationInterval    = 3 * time.Second
+	toolFeedbackAnimationMaxDuration = 5 * time.Minute
+	toolFeedbackEditTimeout          = 5 * time.Second
+)
 
 const initialToolFeedbackAnimationFrame = ""
 
@@ -33,17 +39,23 @@ type toolFeedbackAnimationState struct {
 }
 
 type ToolFeedbackAnimator struct {
-	mu      sync.Mutex
-	editFn  func(ctx context.Context, chatID, messageID, content string) error
-	entries map[string]*toolFeedbackAnimationState
+	mu                sync.Mutex
+	editFn            func(ctx context.Context, chatID, messageID, content string) error
+	entries           map[string]*toolFeedbackAnimationState
+	animationInterval time.Duration
+	maxDuration       time.Duration
+	editTimeout       time.Duration
 }
 
 func NewToolFeedbackAnimator(
 	editFn func(ctx context.Context, chatID, messageID, content string) error,
 ) *ToolFeedbackAnimator {
 	return &ToolFeedbackAnimator{
-		editFn:  editFn,
-		entries: make(map[string]*toolFeedbackAnimationState),
+		editFn:            editFn,
+		entries:           make(map[string]*toolFeedbackAnimationState),
+		animationInterval: toolFeedbackAnimationInterval,
+		maxDuration:       toolFeedbackAnimationMaxDuration,
+		editTimeout:       toolFeedbackEditTimeout,
 	}
 }
 
@@ -163,8 +175,10 @@ func (a *ToolFeedbackAnimator) detach(chatID string) *toolFeedbackAnimationState
 func (a *ToolFeedbackAnimator) run(chatID string, entry *toolFeedbackAnimationState) {
 	defer close(entry.done)
 
-	ticker := time.NewTicker(toolFeedbackAnimationInterval)
+	ticker := time.NewTicker(a.animationInterval)
 	defer ticker.Stop()
+	lifetime := time.NewTimer(a.maxDuration)
+	defer lifetime.Stop()
 
 	frameIdx := 1
 
@@ -172,15 +186,26 @@ func (a *ToolFeedbackAnimator) run(chatID string, entry *toolFeedbackAnimationSt
 		select {
 		case <-entry.stop:
 			return
+		case <-lifetime.C:
+			logger.WarnCF("channels", "Tool feedback animation reached its maximum duration", map[string]any{
+				"max_duration": a.maxDuration.String(),
+			})
+			return
 		case <-ticker.C:
 			if a.editFn == nil {
 				continue
 			}
 			frame := toolFeedbackAnimationFrames[frameIdx%len(toolFeedbackAnimationFrames)]
 			content := formatAnimatedToolFeedbackContent(entry.baseContent, frame)
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			_ = a.editFn(ctx, chatID, entry.messageID, content)
+			ctx, cancel := context.WithTimeout(context.Background(), a.editTimeout)
+			err := a.editFn(ctx, chatID, entry.messageID, content)
 			cancel()
+			if err != nil {
+				logger.WarnCF("channels", "Tool feedback animation stopped after edit failure", map[string]any{
+					"error": err.Error(),
+				})
+				return
+			}
 			frameIdx++
 		}
 	}

--- a/pkg/channels/tool_feedback_animator_test.go
+++ b/pkg/channels/tool_feedback_animator_test.go
@@ -3,7 +3,9 @@ package channels
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestFormatAnimatedToolFeedbackContent(t *testing.T) {
@@ -117,5 +119,68 @@ func TestToolFeedbackAnimator_UpdateFailureRestoresTracking(t *testing.T) {
 	}
 	if currentID, ok := animator.Current("chat-1"); !ok || currentID != "msg-1" {
 		t.Fatalf("Current() after failed Update = (%q, %v), want (msg-1, true)", currentID, ok)
+	}
+}
+
+func TestToolFeedbackAnimator_StopsAfterMaximumDuration(t *testing.T) {
+	var edits atomic.Int32
+	animator := NewToolFeedbackAnimator(func(context.Context, string, string, string) error {
+		edits.Add(1)
+		return nil
+	})
+	animator.animationInterval = 5 * time.Millisecond
+	animator.maxDuration = 30 * time.Millisecond
+	defer animator.StopAll()
+
+	animator.Record("chat-1", "msg-1", "🔧 `read_file`\nChecking config")
+	waitForToolFeedbackAnimation(t, animator, "chat-1")
+
+	editsAtStop := edits.Load()
+	if editsAtStop == 0 {
+		t.Fatal("animation stopped before making any edits")
+	}
+	time.Sleep(2 * animator.animationInterval)
+	if got := edits.Load(); got != editsAtStop {
+		t.Fatalf("animation made %d edits after maximum duration, want 0", got-editsAtStop)
+	}
+	if currentID, ok := animator.Current("chat-1"); !ok || currentID != "msg-1" {
+		t.Fatalf("Current() after animation expiry = (%q, %v), want (msg-1, true)", currentID, ok)
+	}
+}
+
+func TestToolFeedbackAnimator_StopsAfterEditFailure(t *testing.T) {
+	var edits atomic.Int32
+	animator := NewToolFeedbackAnimator(func(context.Context, string, string, string) error {
+		edits.Add(1)
+		return errors.New("edit failed")
+	})
+	animator.animationInterval = 5 * time.Millisecond
+	animator.maxDuration = time.Second
+	defer animator.StopAll()
+
+	animator.Record("chat-1", "msg-1", "🔧 `read_file`\nChecking config")
+	waitForToolFeedbackAnimation(t, animator, "chat-1")
+
+	if got := edits.Load(); got != 1 {
+		t.Fatalf("edit attempts after first failure = %d, want 1", got)
+	}
+	if currentID, ok := animator.Current("chat-1"); !ok || currentID != "msg-1" {
+		t.Fatalf("Current() after edit failure = (%q, %v), want (msg-1, true)", currentID, ok)
+	}
+}
+
+func waitForToolFeedbackAnimation(t *testing.T, animator *ToolFeedbackAnimator, chatID string) {
+	t.Helper()
+	animator.mu.Lock()
+	entry := animator.entries[chatID]
+	animator.mu.Unlock()
+	if entry == nil {
+		t.Fatal("tool feedback animation was not recorded")
+	}
+
+	select {
+	case <-entry.done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for tool feedback animation to stop")
 	}
 }


### PR DESCRIPTION
## 📝 Description

Bound tool feedback animations so a missed lifecycle cleanup cannot keep editing a channel message indefinitely.

- Stop the animation after five minutes, matching Telegram typing feedback's existing lifetime cap.
- Stop immediately after the first edit error instead of repeatedly hitting a failed or rate-limited API.
- Keep the tracked message state available for a later final update or explicit cleanup.
- Log one warning when either safety boundary stops an animation.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Closes #3343

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** #3343; existing five-minute Telegram typing cap in `pkg/channels/telegram/telegram.go`.
- **Reasoning:** The animator is the final safety boundary shared by channel implementations. Terminating only its edit loop prevents unbounded requests while preserving the tracked message for normal `Update`, `Take`, and `Clear` flows.

## 🧪 Test Environment
- **Hardware:** Apple Silicon Mac
- **OS:** macOS
- **Model/Provider:** N/A
- **Channels:** Shared channel animator with deterministic edit callback; no live Telegram credentials required

## 📸 Evidence (Optional)
<details>
<summary>Click to view test evidence</summary>

```text
go test -race -tags=goolm,stdjson ./pkg/channels -run 'TestToolFeedbackAnimator' -count=100
ok github.com/sipeed/picoclaw/pkg/channels 6.590s

go test -race ./pkg/channels
ok github.com/sipeed/picoclaw/pkg/channels 15.280s

golangci-lint run --build-tags goolm,stdjson
0 issues.

make lint-docs
docs lint: OK
```

`make check` completed dependency verification, formatting, and full-workspace vet, then ran the repository test suite. Three pre-existing `pkg/tools` path-sandbox tests fail on this macOS environment: `TestShellTool_RelativePathWithSlashAllowed`, `TestShellTool_DevNullAllowed`, and `TestShellTool_FileURISandboxing`. The changed `pkg/channels` package is green under the race detector and CI build tags.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly (no user-facing documentation change required).
