### PR TITLE
feat(irc): assemble IRCv3 multiline messages

### DIFF
--- a/pkg/channels/irc/handler.go
+++ b/pkg/channels/irc/handler.go
@@ -14,6 +14,11 @@ import (
 	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
+const (
+	multilineBatchType = "draft/multiline"
+	multilineConcatTag = "draft/multiline-concat"
+)
+
 // onConnect is called after a successful connection (and on reconnect).
 func (c *IRCChannel) onConnect(conn *ircevent.Connection) {
 	// NickServ auth (only if SASL is not configured)
@@ -28,6 +33,113 @@ func (c *IRCChannel) onConnect(conn *ircevent.Connection) {
 			"channel": ch,
 		})
 	}
+}
+
+// onMultilineBatch combines a completed IRCv3 multiline batch and sends it
+// through the normal message path exactly once. If an outer batch contains a
+// multiline child, it is flattened here so nested multiline batches still pass
+// through this callback instead of being naively reduced to individual lines.
+func (c *IRCChannel) onMultilineBatch(conn *ircevent.Connection, batch *ircevent.Batch) bool {
+	msg, ok := assembleMultilineBatch(batch)
+	if ok {
+		conn.HandleMessage(msg)
+		return true
+	}
+	if !containsMultilineBatch(batch) {
+		return false
+	}
+	handleBatchItems(conn, batch.Items)
+	return true
+}
+
+func containsMultilineBatch(batch *ircevent.Batch) bool {
+	if batch == nil {
+		return false
+	}
+	stack := append([]*ircevent.Batch(nil), batch.Items...)
+	for len(stack) > 0 {
+		item := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if item == nil {
+			continue
+		}
+		if item.Command == "BATCH" && len(item.Params) >= 2 && item.Params[1] == multilineBatchType {
+			return true
+		}
+		stack = append(stack, item.Items...)
+	}
+	return false
+}
+
+func handleBatchItems(conn *ircevent.Connection, items []*ircevent.Batch) {
+	stack := make([]*ircevent.Batch, 0, len(items))
+	for i := len(items) - 1; i >= 0; i-- {
+		stack = append(stack, items[i])
+	}
+	for len(stack) > 0 {
+		item := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if item == nil {
+			continue
+		}
+		if item.Command != "BATCH" {
+			conn.HandleMessage(item.Message)
+			continue
+		}
+		if msg, ok := assembleMultilineBatch(item); ok {
+			conn.HandleMessage(msg)
+			continue
+		}
+		for i := len(item.Items) - 1; i >= 0; i-- {
+			stack = append(stack, item.Items[i])
+		}
+	}
+}
+
+func assembleMultilineBatch(batch *ircevent.Batch) (ircmsg.Message, bool) {
+	if batch == nil || batch.Command != "BATCH" || len(batch.Params) < 3 {
+		return ircmsg.Message{}, false
+	}
+	if batch.Params[1] != multilineBatchType {
+		return ircmsg.Message{}, false
+	}
+
+	target := batch.Params[2]
+	if target == "" || len(batch.Items) == 0 {
+		return ircmsg.Message{}, false
+	}
+
+	var combined strings.Builder
+	result := batch.Message
+	source := batch.Source
+	for i, item := range batch.Items {
+		if item == nil || item.Command != "PRIVMSG" || len(item.Params) < 2 || item.Params[0] != target {
+			return ircmsg.Message{}, false
+		}
+		if i == 0 {
+			if source == "" {
+				source = item.Source
+			}
+			for name, value := range item.AllTags() {
+				if name != "batch" && name != multilineConcatTag && !result.HasTag(name) {
+					result.SetTag(name, value)
+				}
+			}
+		} else if !item.HasTag(multilineConcatTag) {
+			combined.WriteByte('\n')
+		}
+		if source != "" && item.Source != "" && item.Source != source {
+			return ircmsg.Message{}, false
+		}
+		combined.WriteString(item.Params[1])
+	}
+
+	result.Source = source
+	result.Command = "PRIVMSG"
+	result.Params = []string{target, combined.String()}
+	result.DeleteTag("batch")
+	result.DeleteTag(multilineConcatTag)
+	return result, true
 }
 
 // onPrivmsg handles incoming PRIVMSG events.

--- a/pkg/channels/irc/irc.go
+++ b/pkg/channels/irc/irc.go
@@ -25,6 +25,34 @@ type IRCChannel struct {
 	cancel context.CancelFunc
 }
 
+func requestedCapabilities(configured []string) []string {
+	if len(configured) == 0 {
+		return []string{"server-time", "message-tags", "batch", multilineBatchType}
+	}
+
+	caps := make([]string, 0, len(configured)+2)
+	seen := make(map[string]struct{}, len(configured)+2)
+	for _, capability := range configured {
+		if _, exists := seen[capability]; exists {
+			continue
+		}
+		seen[capability] = struct{}{}
+		caps = append(caps, capability)
+	}
+	if _, enabled := seen[multilineBatchType]; !enabled {
+		return caps
+	}
+
+	for _, required := range []string{"message-tags", "batch"} {
+		if _, exists := seen[required]; exists {
+			continue
+		}
+		seen[required] = struct{}{}
+		caps = append(caps, required)
+	}
+	return caps
+}
+
 // NewIRCChannel creates a new IRC channel.
 func NewIRCChannel(bc *config.Channel, cfg *config.IRCSettings, messageBus *bus.MessageBus) (*IRCChannel, error) {
 	if cfg.Server == "" {
@@ -60,10 +88,7 @@ func (c *IRCChannel) Start(ctx context.Context) error {
 	if realName == "" {
 		realName = c.config.Nick
 	}
-	caps := []string(c.config.RequestCaps)
-	if len(caps) == 0 {
-		caps = []string{"server-time", "message-tags"}
-	}
+	caps := requestedCapabilities(c.config.RequestCaps)
 
 	conn := &ircevent.Connection{
 		Server:      c.config.Server,
@@ -96,6 +121,9 @@ func (c *IRCChannel) Start(ctx context.Context) error {
 	})
 	conn.AddCallback("PRIVMSG", func(e ircmsg.Message) {
 		c.onPrivmsg(conn, e)
+	})
+	conn.AddBatchCallback(func(batch *ircevent.Batch) bool {
+		return c.onMultilineBatch(conn, batch)
 	})
 
 	if err := conn.Connect(); err != nil {

--- a/pkg/channels/irc/irc_test.go
+++ b/pkg/channels/irc/irc_test.go
@@ -1,7 +1,11 @@
 package irc
 
 import (
+	"reflect"
 	"testing"
+
+	"github.com/ergochat/irc-go/ircevent"
+	"github.com/ergochat/irc-go/ircmsg"
 
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
@@ -64,6 +68,192 @@ func TestExtractHost(t *testing.T) {
 			got := extractHost(tt.server)
 			if got != tt.want {
 				t.Errorf("extractHost(%q) = %q, want %q", tt.server, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestedCapabilities(t *testing.T) {
+	configured := []string{"echo-message", "batch", "batch"}
+	got := requestedCapabilities(configured)
+	want := []string{"echo-message", "batch"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("requestedCapabilities() = %v, want %v", got, want)
+	}
+	if !reflect.DeepEqual(configured, []string{"echo-message", "batch", "batch"}) {
+		t.Fatalf("requestedCapabilities mutated its input: %v", configured)
+	}
+
+	defaults := requestedCapabilities(nil)
+	wantDefaults := []string{"server-time", "message-tags", "batch", multilineBatchType}
+	if !reflect.DeepEqual(defaults, wantDefaults) {
+		t.Fatalf("requestedCapabilities(nil) = %v, want %v", defaults, wantDefaults)
+	}
+
+	explicitMultiline := requestedCapabilities([]string{multilineBatchType})
+	wantExplicit := []string{multilineBatchType, "message-tags", "batch"}
+	if !reflect.DeepEqual(explicitMultiline, wantExplicit) {
+		t.Fatalf("requestedCapabilities(multiline) = %v, want %v", explicitMultiline, wantExplicit)
+	}
+}
+
+func multilineTestLine(content string, concat bool) *ircevent.Batch {
+	msg := ircmsg.Message{
+		Source:  "nick!user@host",
+		Command: "PRIVMSG",
+		Params:  []string{"#channel", content},
+	}
+	msg.SetTag("batch", "123")
+	if concat {
+		msg.SetTag(multilineConcatTag, "")
+	}
+	return &ircevent.Batch{Message: msg}
+}
+
+func multilineTestBatch(items ...*ircevent.Batch) *ircevent.Batch {
+	msg := ircmsg.Message{
+		Source:  "nick!user@host",
+		Command: "BATCH",
+		Params:  []string{"+123", multilineBatchType, "#channel"},
+	}
+	msg.SetTag("account", "alice")
+	msg.SetTag("msgid", "message-123")
+	return &ircevent.Batch{Message: msg, Items: items}
+}
+
+func TestAssembleMultilineBatch(t *testing.T) {
+	batch := multilineTestBatch(
+		multilineTestLine("hello", false),
+		multilineTestLine("", false),
+		multilineTestLine("how is ", false),
+		multilineTestLine("everyone?", true),
+	)
+	batch.Items[0].SetTag("time", "2026-08-31T00:00:00Z")
+
+	got, ok := assembleMultilineBatch(batch)
+	if !ok {
+		t.Fatal("assembleMultilineBatch rejected a valid multiline batch")
+	}
+	if got.Params[1] != "hello\n\nhow is everyone?" {
+		t.Fatalf("assembled content = %q", got.Params[1])
+	}
+	if got.Source != batch.Source {
+		t.Fatalf("assembled source = %q, want batch source %q", got.Source, batch.Source)
+	}
+	for tag, want := range map[string]string{
+		"account": "alice",
+		"msgid":   "message-123",
+		"time":    "2026-08-31T00:00:00Z",
+	} {
+		if present, gotValue := got.GetTag(tag); !present || gotValue != want {
+			t.Fatalf("assembled %s tag = (%v, %q), want (true, %q)", tag, present, gotValue, want)
+		}
+	}
+	if got.HasTag("batch") || got.HasTag(multilineConcatTag) {
+		t.Fatal("assembled message retained transport-only multiline tags")
+	}
+}
+
+func TestNestedMultilineBatchIsDeliveredOnce(t *testing.T) {
+	multiline := multilineTestBatch(
+		multilineTestLine("hello", false),
+		multilineTestLine("world", false),
+	)
+	outer := &ircevent.Batch{
+		Message: ircmsg.Message{
+			Command: "BATCH",
+			Params:  []string{"+history", "chathistory", "#channel"},
+		},
+		Items: []*ircevent.Batch{
+			{Message: ircmsg.Message{
+				Source:  "other!user@host",
+				Command: "PRIVMSG",
+				Params:  []string{"#channel", "before"},
+			}},
+			multiline,
+		},
+	}
+
+	conn := &ircevent.Connection{}
+	var received []string
+	conn.AddCallback("PRIVMSG", func(msg ircmsg.Message) {
+		received = append(received, msg.Params[1])
+	})
+	channel := &IRCChannel{}
+	conn.AddBatchCallback(func(batch *ircevent.Batch) bool {
+		return channel.onMultilineBatch(conn, batch)
+	})
+
+	conn.HandleBatch(outer)
+
+	want := []string{"before", "hello\nworld"}
+	if !reflect.DeepEqual(received, want) {
+		t.Fatalf("nested batch deliveries = %q, want %q", received, want)
+	}
+}
+
+func TestDeeplyNestedMultilineBatchDoesNotRecurse(t *testing.T) {
+	batch := multilineTestBatch(multilineTestLine("hello", false))
+	for i := 0; i < 10_000; i++ {
+		batch = &ircevent.Batch{
+			Message: ircmsg.Message{
+				Command: "BATCH",
+				Params:  []string{"+outer", "example/outer"},
+			},
+			Items: []*ircevent.Batch{batch},
+		}
+	}
+
+	conn := &ircevent.Connection{}
+	var received []string
+	conn.AddCallback("PRIVMSG", func(msg ircmsg.Message) {
+		received = append(received, msg.Params[1])
+	})
+	channel := &IRCChannel{}
+	conn.AddBatchCallback(func(batch *ircevent.Batch) bool {
+		return channel.onMultilineBatch(conn, batch)
+	})
+
+	conn.HandleBatch(batch)
+
+	if !reflect.DeepEqual(received, []string{"hello"}) {
+		t.Fatalf("deeply nested batch deliveries = %q, want [hello]", received)
+	}
+}
+
+func TestAssembleMultilineBatchRejectsMalformedBatches(t *testing.T) {
+	validBatch := func() *ircevent.Batch {
+		return multilineTestBatch(multilineTestLine("hello", false))
+	}
+
+	tests := map[string]func(*ircevent.Batch){
+		"unknown batch type": func(batch *ircevent.Batch) {
+			batch.Params[1] = "chathistory"
+		},
+		"empty batch": func(batch *ircevent.Batch) {
+			batch.Items = nil
+		},
+		"mismatched target": func(batch *ircevent.Batch) {
+			batch.Items[0].Params[0] = "#other"
+		},
+		"mixed command": func(batch *ircevent.Batch) {
+			batch.Items[0].Command = "NOTICE"
+		},
+		"nested batch": func(batch *ircevent.Batch) {
+			batch.Items[0].Command = "BATCH"
+		},
+		"mismatched source": func(batch *ircevent.Batch) {
+			batch.Items[0].Source = "mallory!user@host"
+		},
+	}
+
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			batch := validBatch()
+			mutate(batch)
+			if _, ok := assembleMultilineBatch(batch); ok {
+				t.Fatal("assembleMultilineBatch accepted a malformed batch")
 			}
 		})
 	}


### PR DESCRIPTION
## 📝 Description

Add IRCv3 `draft/multiline` receive support so a long or multi-line IRC message reaches PicoClaw as one cohesive inbound message.

- Request `batch`, `message-tags`, and `draft/multiline` by default. Explicit `request_caps` remain authoritative; dependencies are added only when that list explicitly enables multiline.
- Use `irc-go`'s completed-batch callback instead of maintaining a second concurrent batch registry.
- Validate multiline type, target, command, source, and shape before combining fragments.
- Implement the specified newline versus `draft/multiline-concat` behavior.
- Preserve opening-batch metadata such as `msgid` and `account`, merge non-structural first-line tags, and remove closed transport tags.
- Handle multiline nested inside history/playback batches exactly once with an iterative O(n) traversal, including adversarial deep nesting.
- Return unknown or malformed top-level batches to `irc-go`'s existing flattening behavior.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)
- [ ] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Closes #3287

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://ircv3.net/specs/extensions/multiline and https://ircv3.net/specs/extensions/batch
- **Reasoning:** The existing `irc-go v0.6.0` dependency already owns capability-aware batch lifecycle, nesting, and disconnect cleanup. PicoClaw only needs to register a completed-batch callback, assemble valid multiline content, and re-enter the normal message callback path. This avoids a duplicate state machine and prevents one multiline message from triggering the agent once per protocol fragment.

## 🧪 Test Environment
- **Hardware:** Apple Silicon Mac
- **OS:** macOS
- **Model/Provider:** N/A
- **Channels:** IRC; full channels package regression

## 📸 Evidence (Optional)
<details>
<summary>Click to view test evidence</summary>

```text
$ go test -race ./pkg/channels/irc -count=100
ok github.com/sipeed/picoclaw/pkg/channels/irc

$ go test -race -tags goolm,stdjson ./pkg/channels/...
ok github.com/sipeed/picoclaw/pkg/channels/irc
ok all tested channel packages

$ GOFLAGS="-tags=goolm,stdjson" go vet ./pkg/channels/...
# exit 0

$ golangci-lint run --build-tags=goolm,stdjson
0 issues.
```

The focused tests cover the official multiline example, blank-line and concat semantics, capability dependency/deduplication, opening metadata preservation, transport-tag removal, malformed target/command/source fallback, nested chathistory delivery exactly once, and 10,000 nested batches without recursive stack growth.

`go test -tags goolm,stdjson ./...` passed all packages except three pre-existing macOS path-sandbox tests in `pkg/tools`:

- `TestShellTool_RelativePathWithSlashAllowed`
- `TestShellTool_DevNullAllowed`
- `TestShellTool_FileURISandboxing`

All three reject macOS `/var/folders/...` temporary paths as outside the working directory and do not exercise IRC code.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] Documentation is not required; configuration shape and user-facing commands are unchanged.