### PR TITLE
fix(telegram): re-attach quoted documents when replying to a file message

### DIFF
--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -1398,6 +1398,15 @@ func quotedTelegramMediaRefs(
 			refs = append(refs, ref)
 		}
 	}
+	if message.Document != nil {
+		filename := strings.TrimSpace(message.Document.FileName)
+		if filename == "" {
+			filename = indexedMediaFilename("document", "", 0, 1)
+		}
+		if ref := resolve(message.Document.FileID, "", filename); ref != "" {
+			refs = append(refs, ref)
+		}
+	}
 	return refs
 }
 

--- a/pkg/channels/telegram/telegram_test.go
+++ b/pkg/channels/telegram/telegram_test.go
@@ -1495,6 +1495,36 @@ func TestQuotedTelegramMediaRefs_ResolvesQuotedAudioInOrder(t *testing.T) {
 	assert.Equal(t, []string{"ref://voice.ogg", "ref://audio.mp3"}, refs)
 }
 
+func TestQuotedTelegramMediaRefs_ResolvesQuotedDocument(t *testing.T) {
+	msg := &telego.Message{
+		Document: &telego.Document{
+			FileID:   "doc-file",
+			FileName: "log.txt",
+		},
+	}
+
+	var calls []string
+	refs := quotedTelegramMediaRefs(msg, func(fileID, ext, filename string) string {
+		calls = append(calls, fileID+"|"+ext+"|"+filename)
+		return "ref://" + filename
+	})
+
+	assert.Equal(t, []string{"doc-file||log.txt"}, calls)
+	assert.Equal(t, []string{"ref://log.txt"}, refs)
+}
+
+func TestQuotedTelegramMediaRefs_QuotedDocumentWithoutFilename(t *testing.T) {
+	msg := &telego.Message{
+		Document: &telego.Document{FileID: "doc-file"},
+	}
+
+	refs := quotedTelegramMediaRefs(msg, func(fileID, ext, filename string) string {
+		return "ref://" + filename
+	})
+
+	assert.Equal(t, []string{"ref://document"}, refs)
+}
+
 func TestHandleMessage_EmptyContent_Ignored(t *testing.T) {
 	messageBus := bus.NewMessageBus()
 	ch := &TelegramChannel{


### PR DESCRIPTION
## 📝 Description

When a user **replies to / quotes a document message** in the chat, the quoted reply only carried the literal `[file]` placeholder: `quotedTelegramMediaRefs()` re-attached voice and audio media from the quoted message but **ignored documents entirely**.

The agent therefore received an unresolvable `[file]` tag with no path, could not read the content, and answered something like *"I can't view the content of the cited file"* — even though quoting any other media type works.

This PR adds `message.Document` handling to `quotedTelegramMediaRefs()`, so quoting a file re-downloads it (honoring the original file name, with the existing `indexedMediaFilename` fallback when empty) and exposes it to the agent as a resolvable `[file:/path]` tag — matching the behavior of a direct document send.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

No open issue found for this; reproduced and diagnosed from production logs.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** `pkg/channels/telegram/telegram.go` (`quotedTelegramMediaRefs`, used by `handleMessage` when `message.ReplyToMessage != nil`)
- **Reasoning:** `telegramQuotedContent()` already emits a `[file]` marker for quoted documents, but the media refs resolver only covered `Voice` and `Audio`. Adding `Document` keeps content and media paths consistent (quoted refs are prepended before the current message's refs, so the first `[file]` placeholder is replaced by the quoted file's path tag, preserving ordering when both quoted and current messages contain documents).

## 🧪 Test Environment
- **Hardware:** PC (x86_64)
- **OS:** Linux (deployed on Ubuntu-based K3s nodes, container image)
- **Model/Provider:** OpenAI-compatible endpoint
- **Channels:** Telegram (supergroup, `mention_only`)

## 🧪 Tests

Added two unit tests:
- `TestQuotedTelegramMediaRefs_ResolvesQuotedDocument` — quoted document with a file name resolves with `ext=""` and the original `FileName`.
- `TestQuotedTelegramMediaRefs_QuotedDocumentWithoutFilename` — missing `FileName` falls back to `"document"`.

```
go test -tags "goolm,stdjson" ./pkg/channels/telegram/
ok  github.com/sipeed/picoclaw/pkg/channels/telegram
```

Validated in production (Telegram supergroup): a text file quoted with a bot mention now reaches the agent as `[file:/tmp/picoclaw_media/...]` and the agent reads it via `read_file` instead of claiming it cannot see the file.