### PR TITLE
fix(telegram): treat replies to the bot's own messages as implicit mentions

### DIFF
--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -1126,6 +1126,12 @@ func (c *TelegramChannel) handleMessages(ctx context.Context, messages []*telego
 	isMentioned := false
 	if message.Chat.Type != "private" {
 		isMentioned = c.isBotMentioned(message)
+		// Replying directly to one of the bot's own messages is an implicit
+		// mention: users expect the conversation to continue without having
+		// to @mention the bot on every follow-up.
+		if !isMentioned && c.isReplyToSelf(message) {
+			isMentioned = true
+		}
 		if isMentioned {
 			content = c.stripBotMention(content)
 		}
@@ -1558,6 +1564,15 @@ func logParseFailed(err error, useMarkdownV2 bool) {
 }
 
 // isBotMentioned checks if the bot is mentioned in the message via entities.
+// isReplyToSelf reports whether the message is a direct reply to one of the
+// bot's own messages, which users treat as talking to the bot.
+func (c *TelegramChannel) isReplyToSelf(message *telego.Message) bool {
+	if message == nil || message.ReplyToMessage == nil {
+		return false
+	}
+	return c.isOwnBotUser(message.ReplyToMessage.From)
+}
+
 func (c *TelegramChannel) isBotMentioned(message *telego.Message) bool {
 	text, entities := telegramEntityTextAndList(message)
 	if text == "" || len(entities) == 0 {

--- a/pkg/channels/telegram/telegram_test.go
+++ b/pkg/channels/telegram/telegram_test.go
@@ -1495,6 +1495,79 @@ func TestQuotedTelegramMediaRefs_ResolvesQuotedAudioInOrder(t *testing.T) {
 	assert.Equal(t, []string{"ref://voice.ogg", "ref://audio.mp3"}, refs)
 }
 
+func TestHandleMessage_GroupMentionOnly_ReplyToOwnBotMessageTriggers(t *testing.T) {
+	ch, messageBus := newGroupMentionOnlyChannel(t, "testbot")
+
+	msg := &telego.Message{
+		Text:      "é exatamente isso que está acontecendo, e agora?",
+		MessageID: 44,
+		Chat: telego.Chat{
+			ID:   123,
+			Type: "group",
+		},
+		From: &telego.User{
+			ID:        7,
+			FirstName: "Alice",
+		},
+		ReplyToMessage: &telego.Message{
+			MessageID: 43,
+			Text:      "resposta anterior do bot",
+			From: &telego.User{
+				ID:        555,
+				IsBot:     true,
+				FirstName: "Test",
+				Username:  "testbot",
+			},
+		},
+	}
+
+	if err := ch.handleMessage(context.Background(), msg); err != nil {
+		t.Fatalf("handleMessage error: %v", err)
+	}
+
+	inbound, ok := <-messageBus.InboundChan()
+	require.True(t, ok)
+	assert.Equal(t, "43", inbound.Context.ReplyToMessageID)
+	assert.True(t, inbound.Context.Mentioned)
+	assert.Contains(t, inbound.Content, "[quoted assistant message from testbot]: resposta anterior do bot")
+	assert.Contains(t, inbound.Content, "é exatamente isso que está acontecendo, e agora?")
+}
+
+func TestHandleMessage_GroupMentionOnly_ReplyToOtherUserDoesNotTrigger(t *testing.T) {
+	ch, messageBus := newGroupMentionOnlyChannel(t, "testbot")
+
+	msg := &telego.Message{
+		Text:      "mensagem comum para outro membro",
+		MessageID: 45,
+		Chat: telego.Chat{
+			ID:   123,
+			Type: "group",
+		},
+		From: &telego.User{
+			ID:        7,
+			FirstName: "Alice",
+		},
+		ReplyToMessage: &telego.Message{
+			MessageID: 44,
+			Text:      "mensagem de outro usuário",
+			From: &telego.User{
+				ID:        8,
+				FirstName: "Bob",
+			},
+		},
+	}
+
+	if err := ch.handleMessage(context.Background(), msg); err != nil {
+		t.Fatalf("handleMessage error: %v", err)
+	}
+
+	select {
+	case inbound := <-messageBus.InboundChan():
+		t.Fatalf("message should have been ignored, got: %+v", inbound.Content)
+	default:
+	}
+}
+
 func TestHandleMessage_EmptyContent_Ignored(t *testing.T) {
 	messageBus := bus.NewMessageBus()
 	ch := &TelegramChannel{


### PR DESCRIPTION
## 📝 Description

In groups with `mention_only: true`, a user **replying directly to one of the bot's messages** was silently ignored unless the reply also contained an @mention. This breaks conversation continuity: users naturally hit "reply" on the bot's answer to ask a follow-up, and the bot never responds (the message reaches `getUpdates` but is dropped by the group gate before any turn starts).

This PR treats a reply whose `ReplyToMessage` came from the bot itself as an **implicit mention**, reusing the existing `isOwnBotUser()` identity check (matches by bot user ID or username). Plain replies to other members keep requiring a mention, so busy groups are unaffected.

Independent of and complementary to #3356 (also open against this file).

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

No open issue found; reproduced from production logs (supergroup with `mention_only: true` — a follow-up question replying to the bot's answer arrived via `getUpdates` but produced zero turns).

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** `pkg/channels/telegram/telegram.go` (`handleMessage` group trigger section, new `isReplyToSelf` helper)
- **Reasoning:** `ShouldRespondInGroup` gates on `isMentioned`, which only inspected mention/bot-command entities in the text/caption. A reply to the bot's own message is a platform-level "talking to you" signal that Telegram users universally expect to trigger a response. The check runs before `stripBotMention` (a no-op when there is no mention entity) and composes correctly with the quoted-reply content that is already prepended to the turn.

## 🧪 Test Environment
- **Hardware:** PC (x86_64)
- **OS:** Linux (deployed on Ubuntu-based K3s nodes, container image)
- **Model/Provider:** OpenAI-compatible endpoint
- **Channels:** Telegram (supergroup, `mention_only`)

## 🧪 Tests

Added two unit tests (mirroring `newGroupMentionOnlyChannel`):
- `TestHandleMessage_GroupMentionOnly_ReplyToOwnBotMessageTriggers` — a reply to the bot's message is forwarded, marked `Mentioned`, and carries the quoted assistant message.
- `TestHandleMessage_GroupMentionOnly_ReplyToOtherUserDoesNotTrigger` — a reply to another member is still ignored.

```
go test -tags "goolm,stdjson" ./pkg/channels/telegram/
ok  github.com/sipeed/picoclaw/pkg/channels/telegram
```