### PR TITLE
fix(agent): thread responses to the originating question message

### DIFF
--- a/pkg/agent/agent_outbound.go
+++ b/pkg/agent/agent_outbound.go
@@ -26,6 +26,7 @@ func (al *AgentLoop) maybePublishError(ctx context.Context, channel, chatID, ses
 
 func (al *AgentLoop) publishResponseOrError(
 	ctx context.Context,
+	inbound *bus.InboundContext,
 	channel, chatID, sessionKey string,
 	response string,
 	err error,
@@ -36,10 +37,18 @@ func (al *AgentLoop) publishResponseOrError(
 		}
 		response = ""
 	}
-	al.PublishResponseIfNeeded(ctx, channel, chatID, sessionKey, response)
+	al.PublishResponseForInbound(ctx, inbound, channel, chatID, sessionKey, response)
 }
 
+// PublishResponseIfNeeded publishes the response for turns that have no
+// inbound message context (cron, CLI). The reply target is lost for those.
 func (al *AgentLoop) PublishResponseIfNeeded(ctx context.Context, channel, chatID, sessionKey, response string) {
+	al.PublishResponseForInbound(ctx, nil, channel, chatID, sessionKey, response)
+}
+
+// PublishResponseForInbound publishes the turn response, threading it to the
+// originating message when the inbound context provides one.
+func (al *AgentLoop) PublishResponseForInbound(ctx context.Context, inbound *bus.InboundContext, channel, chatID, sessionKey, response string) {
 	if response == "" {
 		return
 	}
@@ -74,7 +83,7 @@ func (al *AgentLoop) PublishResponseIfNeeded(ctx context.Context, channel, chatI
 	}
 
 	msg := bus.OutboundMessage{
-		Context:    bus.NewOutboundContext(channel, chatID, ""),
+		Context:    outboundContextFromInbound(inbound, channel, chatID, ""),
 		SessionKey: sessionKey,
 		Content:    response,
 	}

--- a/pkg/agent/agent_steering.go
+++ b/pkg/agent/agent_steering.go
@@ -15,7 +15,7 @@ func (al *AgentLoop) processMessageSync(ctx context.Context, msg bus.InboundMess
 	}
 
 	response, err := al.processMessage(ctx, msg)
-	al.publishResponseOrError(ctx, msg.Channel, msg.ChatID, msg.SessionKey, response, err)
+	al.publishResponseOrError(ctx, &msg.Context, msg.Channel, msg.ChatID, msg.SessionKey, response, err)
 }
 
 func (al *AgentLoop) runTurnWithSteering(ctx context.Context, initialMsg bus.InboundMessage) {
@@ -56,9 +56,9 @@ func (al *AgentLoop) runTurnWithSteering(ctx context.Context, initialMsg bus.Inb
 		finalResponse = continued
 	}
 
-	// Publish final response
+	// Publish final response, threaded to the originating message
 	if finalResponse != "" {
-		al.PublishResponseIfNeeded(ctx, target.Channel, target.ChatID, target.SessionKey, finalResponse)
+		al.PublishResponseForInbound(ctx, &initialMsg.Context, target.Channel, target.ChatID, target.SessionKey, finalResponse)
 	}
 }
 

--- a/pkg/agent/agent_stop.go
+++ b/pkg/agent/agent_stop.go
@@ -45,7 +45,7 @@ func (al *AgentLoop) tryHandleStopCommand(
 		al.channelManager.InvokeTypingStop(msg.Channel, msg.ChatID)
 	}
 	al.resetMessageToolRound(sessionKey)
-	al.PublishResponseIfNeeded(ctx, msg.Channel, msg.ChatID, sessionKey, reply)
+	al.PublishResponseForInbound(ctx, &msg.Context, msg.Channel, msg.ChatID, sessionKey, reply)
 	return true
 }
 

--- a/pkg/agent/agent_utils.go
+++ b/pkg/agent/agent_utils.go
@@ -37,6 +37,11 @@ func outboundContextFromInbound(
 	if outboundCtx.ReplyToMessageID == "" {
 		outboundCtx.ReplyToMessageID = replyToMessageID
 	}
+	if outboundCtx.ReplyToMessageID == "" && outboundCtx.MessageID != "" {
+		// Thread the response to the message that triggered the turn so the
+		// answer stays attached to the originating question in the chat.
+		outboundCtx.ReplyToMessageID = outboundCtx.MessageID
+	}
 	return outboundCtx
 }
 

--- a/pkg/agent/agent_utils_test.go
+++ b/pkg/agent/agent_utils_test.go
@@ -1,6 +1,10 @@
 package agent
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+)
 
 func TestInferMediaType(t *testing.T) {
 	tests := []struct {
@@ -72,5 +76,40 @@ func TestInferMediaType(t *testing.T) {
 				t.Fatalf("inferMediaType(%q, %q) = %q, want %q", tt.filename, tt.contentType, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestOutboundContextFromInbound_FallsBackToOriginatingMessage(t *testing.T) {
+	msgID := "4428"
+	inbound := &bus.InboundContext{
+		Channel:   "telegram",
+		ChatID:    "-1001725217387",
+		MessageID: msgID,
+	}
+
+	ctx := outboundContextFromInbound(inbound, "telegram", "-1001725217387", "")
+	if ctx.ReplyToMessageID != msgID {
+		t.Fatalf("ReplyToMessageID = %q, want originating message %q", ctx.ReplyToMessageID, msgID)
+	}
+}
+
+func TestOutboundContextFromInbound_KeepsExplicitReplyTarget(t *testing.T) {
+	inbound := &bus.InboundContext{
+		Channel:          "telegram",
+		ChatID:           "-1001725217387",
+		MessageID:        "4428",
+		ReplyToMessageID: "4422",
+	}
+
+	ctx := outboundContextFromInbound(inbound, "telegram", "-1001725217387", "")
+	if ctx.ReplyToMessageID != "4422" {
+		t.Fatalf("ReplyToMessageID = %q, want explicit target 4422", ctx.ReplyToMessageID)
+	}
+}
+
+func TestOutboundContextFromInbound_NilInboundUnchanged(t *testing.T) {
+	ctx := outboundContextFromInbound(nil, "telegram", "-1001725217387", "")
+	if ctx.ReplyToMessageID != "" {
+		t.Fatalf("ReplyToMessageID = %q, want empty", ctx.ReplyToMessageID)
 	}
 }


### PR DESCRIPTION
## 📝 Description

When a user's message triggered a turn **without being a reply** (e.g. a plain @mention in a group), the outbound response carried no `ReplyToMessageID` — the answer appeared in the chat disconnected from the question that prompted it. In busy groups this makes bot answers hard to follow.

`outboundContextFromInbound` now falls back to the inbound `MessageID` when no explicit reply target exists, so responses reference the **originating question**:

- Plain mention → the answer replies to the mention message.
- User replying to a previous message → unchanged (the explicit reply target is kept).
- Turns without a triggering message (cron, CLI) → unchanged (no `MessageID`, no synthetic reference).

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

No open issue found; observed in production (Telegram supergroup: bot answers floated without any reference to the questions that triggered them).

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** `pkg/agent/agent_utils.go` (`outboundContextFromInbound`)
- **Reasoning:** The bus already carries `ReplyToMessageID` end to end (`OutboundMessage` → `NormalizeOutboundMessage` mirrors it → channels like Telegram consume it for `reply_to_message_id`), but the fallback chain never considered the triggering message itself. Adding the fallback in the shared helper covers all four call sites uniformly: the final response, media delivery, and artifact messages — all become threaded to the originating question. Explicit reply targets take precedence, so existing quoting behavior is untouched.

## 🧪 Test Environment
- **Hardware:** PC (x86_64)
- **OS:** Linux (deployed on Ubuntu-based K3s nodes, container image)
- **Model/Provider:** OpenAI-compatible endpoint
- **Channels:** Telegram (supergroup, `mention_only`)

## 🧪 Tests

Added three unit tests in `pkg/agent/agent_utils_test.go`:
- `TestOutboundContextFromInbound_FallsBackToOriginatingMessage` — no explicit target → falls back to the inbound `MessageID`.
- `TestOutboundContextFromInbound_KeepsExplicitReplyTarget` — explicit `ReplyToMessageID` wins over the fallback.
- `TestOutboundContextFromInbound_NilInboundUnchanged` — nil inbound keeps legacy behavior.

```
go test -tags "goolm,stdjson" ./pkg/agent/
ok  github.com/sipeed/picoclaw/pkg/agent
```