### PR TITLE
docs: add Pilot MCP setup example

### DIFF
--- a/docs/reference/mcp-cli.md
+++ b/docs/reference/mcp-cli.md
@@ -36,6 +36,16 @@ Add a stdio server via `npx`:
 picoclaw mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /tmp
 ```
 
+Add Pilot Protocol for specialist discovery and agent-to-agent messaging:
+
+```bash
+npx -y pilotprotocol-mcp setup --picoclaw
+picoclaw mcp test pilot
+```
+
+The setup command preserves the existing PicoClaw configuration and adds an
+enabled `pilot` stdio server. Pilot runs locally and does not require an API key.
+
 Add a stdio server with environment variables saved in config:
 
 ```bash


### PR DESCRIPTION
## Summary

- add the Pilot Protocol setup command to the native MCP CLI quick start
- include the PicoClaw health-check command
- clarify that setup preserves existing configuration and needs no API key

## Validation

- `make lint-docs`
- `git diff --check`

## 🤖 AI Code Generation

AI-assisted; reviewed and validated by the contributor.

Disclosure: I contribute to Pilot Protocol.