### PR TITLE
docs: add Parallel Search MCP setup example

### DIFF
--- a/docs/reference/mcp-cli.md
+++ b/docs/reference/mcp-cli.md
@@ -91,6 +91,25 @@ Open the raw config for advanced editing:
 picoclaw mcp edit
 ```
 
+## Example: Parallel Search
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides public web search and page extraction without a Parallel account or API key. Free access is rate limited.
+
+```bash
+picoclaw mcp add parallel --transport http https://search.parallel.ai/mcp
+picoclaw mcp show parallel
+```
+
+The `http` transport uses Streamable HTTP. The server exposes `web_search` and `web_fetch`; no auth headers are needed for this anonymous connection.
+
+Adding the server enables MCP. Start a new agent session or restart the gateway to load the updated configuration. Once loaded, the agent can invoke these tools during its work, sending queries, requested URLs, and any supplied objectives or context to Parallel. This adds MCP tools alongside the built-in web tools; it does not change the built-in search provider.
+
+To remove the connection, run the following command and start a new agent session or restart the gateway:
+
+```bash
+picoclaw mcp remove parallel
+```
+
 ## Command Summary
 
 | Command | Purpose |


### PR DESCRIPTION
## 📝 Description

This adds a copy-paste setup for Parallel Search MCP to the existing CLI guide. It gives PicoClaw web search and page extraction without a Parallel account or API key, with instructions for removing it and a clear explanation of what gets sent to Parallel.

PicoClaw [enables Sogou by default](https://github.com/sipeed/picoclaw/blob/bbf6893ca7afad27f1d00a0f5a45982a549c6ed6/pkg/config/defaults.go#L327-L355) for its built-in search, though [provider-native search takes precedence when available](https://github.com/sipeed/picoclaw/blob/bbf6893ca7afad27f1d00a0f5a45982a549c6ed6/pkg/agent/pipeline_llm.go#L42-L59). That's the default I'd like to evaluate Parallel against.

One reason to try it: [Artificial Analysis's August 31 leaderboard](https://artificialanalysis.ai/agents/search-api#search-api-public-leaderboard) gives Parallel Search (fast) **80/100 on DeepSearchQA F1** and **73/100 on its overall Search Index**. Fast is also the mode used by the [anonymous MCP connection](https://docs.parallel.ai/integrations/mcp/search-mcp#configure-search-behavior) in this example. These are Search API benchmark results, not a PicoClaw evaluation, and Artificial Analysis doesn't include Sogou, so they don't establish a win over the current default.

If better default search results are the goal, I'd suggest testing Parallel against Sogou on PicoClaw's own tasks and considering it as the default if it wins. This PR makes it easy to try; it only changes the docs and leaves the current default in place.

I work at Parallel, which operates this service.

## 🗣️ Type of Change
- [x] 📖 Documentation update

## 🤖 AI Code Generation
- [x] 🤖 Fully AI-generated (100% AI, 0% Human)

## 🔗 Related Issue

None. This adds an example to the existing setup guide.

## 📚 Technical Context (Skip for Docs)

[Parallel Search MCP setup](https://docs.parallel.ai/integrations/mcp/search-mcp)

## 🧪 Test Environment
- **Hardware:** Apple Silicon
- **OS:** macOS
- **Model/Provider:** Local test fixture
- **Channels:** CLI

## 📸 Evidence

- `make lint-docs` and `git diff --check` passed.
- Verified the documented add, show, and remove commands using the official, checksum-verified PicoClaw v0.3.1 macOS arm64 binary (`2cf030d2`) with an isolated config and no Parallel credentials.
- Verified native tool discovery and live anonymous search/fetch calls through `picoclaw agent`, using a local test fixture. Search returned ten results and fetch returned the setup page. The larger search output was verified in PicoClaw's saved artifact.
- The repository was not built locally and `make check` was not run. Runtime validation used the prebuilt release, with current source inspected for the documented configuration and transport behavior.

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
