### PR TITLE
feat(tools): add Keenable web search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ PicoClaw can search the web to provide up-to-date information. Configure in `too
 | [Tavily](https://tavily.com) | Required | 1000 queries/month | Optimized for AI Agents |
 | [Brave Search](https://brave.com/search/api) | Required | 2000 queries/month | Fast and private |
 | [Kagi Search](https://help.kagi.com/kagi/api/search.html) | Required | Paid/limited by API setup | Premium search results |
+| [Keenable](https://keenable.ai) | Optional | Keyless: 10 req/s, 1000/hour per IP | Works without a key; a key lifts the rate limits |
 | [Perplexity](https://www.perplexity.ai) | Required | Paid | AI-powered search |
 | [SearXNG](https://github.com/searxng/searxng) | Not needed | Self-hosted | Free metasearch engine |
 | [GLM Search](https://open.bigmodel.cn/) | Required | Varies | Zhipu web search |

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -341,6 +341,12 @@
         "base_url": "https://kagi.com/api/v1/search",
         "max_results": 5
       },
+      "keenable": {
+        "enabled": false,
+        "api_keys": [],
+        "base_url": "https://api.keenable.ai",
+        "max_results": 5
+      },
       "provider": "auto",
       "sogou": {
         "enabled": true,

--- a/docs/reference/tools_configuration.md
+++ b/docs/reference/tools_configuration.md
@@ -164,6 +164,42 @@ web:
 
 Kagi API usage may be billed or limited separately from a normal Kagi subscription, depending on your account and API setup.
 
+### Keenable
+
+Keenable works without an API key. With no key configured, requests go to the public endpoint (`POST /v1/search/public`), which is rate limited per IP (10 requests/second, 1000 per hour). Setting a key switches to `POST /v1/search` and lifts those limits; nothing else changes.
+
+| Config        | Type     | Default                   | Description                                                    |
+|---------------|----------|---------------------------|----------------------------------------------------------------|
+| `enabled`     | bool     | false                     | Enable Keenable search                                         |
+| `api_keys`    | string[] | -                         | Optional API keys; rotated like other providers                |
+| `base_url`    | string   | `https://api.keenable.ai` | Keenable API base URL                                          |
+| `max_results` | int      | 5                         | Maximum number of results                                      |
+
+```json
+{
+  "tools": {
+    "web": {
+      "provider": "keenable",
+      "keenable": {
+        "enabled": true,
+        "max_results": 5
+      }
+    }
+  }
+}
+```
+
+To lift the keyless rate limits, store a key in `.security.yml`:
+
+```yaml
+web:
+  keenable:
+    api_keys:
+      - "YOUR_KEENABLE_API_KEY"
+```
+
+The `range` parameter maps to `published_after` (`d`, `w`, `m`, `y` become a date 1 day, 7 days, 1 month, or 1 year before today).
+
 ### Tavily
 
 | Config        | Type   | Default | Description               |

--- a/docs/security/security_configuration.md
+++ b/docs/security/security_configuration.md
@@ -248,7 +248,7 @@ channel_list:
 
 ### Web Tools
 
-**Brave, Tavily, Perplexity, Kagi:**
+**Brave, Tavily, Perplexity, Kagi, Keenable:**
 ```yaml
 web:
   brave:
@@ -318,7 +318,7 @@ model_list:
 - **Rate limit management**: Distribute usage across multiple keys
 - **High availability**: Reduce downtime during API provider issues
 
-### Web Tools (Brave/Tavily/Perplexity/Kagi) - Single key
+### Web Tools (Brave/Tavily/Perplexity/Kagi/Keenable) - Single key
 
 ```yaml
 web:
@@ -330,7 +330,7 @@ web:
       - "your-kagi-api-key"
 ```
 
-### Web Tools (Brave/Tavily/Perplexity/Kagi) - Multiple keys
+### Web Tools (Brave/Tavily/Perplexity/Kagi/Keenable) - Multiple keys
 
 ```yaml
 web:
@@ -568,7 +568,7 @@ go test ./pkg/config -run TestSecurityConfig
 
 - Ensure you're using `api_keys` (plural) in `.security.yml` for models and web tools (except GLMSearch/BaiduSearch)
 - Check that the array format is correct in YAML (proper indentation with dashes)
-- Remember: Models, Brave, Tavily, Perplexity, Kagi MUST use `api_keys` (array format)
+- Remember: Models, Brave, Tavily, Perplexity, Kagi, Keenable MUST use `api_keys` (array format)
 - GLMSearch and BaiduSearch MUST use `api_key` (single string format)
 
 ### Load Balancing/Failover Issues

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -966,6 +966,34 @@ func (c *KagiConfig) SetAPIKeys(keys []string) {
 	c.APIKeys = SimpleSecureStrings(keys...)
 }
 
+// KeenableConfig configures the Keenable web search provider. An API key is
+// optional: without one, requests go to Keenable's public endpoint, which is
+// rate limited per IP. A key only lifts those limits.
+type KeenableConfig struct {
+	Enabled    bool          `json:"enabled"           yaml:"-"                  env:"PICOCLAW_TOOLS_WEB_KEENABLE_ENABLED"`
+	APIKeys    SecureStrings `json:"api_keys,omitzero" yaml:"api_keys,omitempty" env:"PICOCLAW_TOOLS_WEB_KEENABLE_API_KEYS"`
+	BaseURL    string        `json:"base_url"          yaml:"-"                  env:"PICOCLAW_TOOLS_WEB_KEENABLE_BASE_URL"`
+	MaxResults int           `json:"max_results"       yaml:"-"                  env:"PICOCLAW_TOOLS_WEB_KEENABLE_MAX_RESULTS"`
+}
+
+// APIKey returns the Keenable API key
+func (c *KeenableConfig) APIKey() string {
+	if len(c.APIKeys) == 0 {
+		return ""
+	}
+	return c.APIKeys[0].String()
+}
+
+// SetAPIKey sets the Keenable API key
+func (c *KeenableConfig) SetAPIKey(key string) {
+	c.APIKeys = SimpleSecureStrings(key)
+}
+
+// SetAPIKeys sets the Keenable API keys
+func (c *KeenableConfig) SetAPIKeys(keys []string) {
+	c.APIKeys = SimpleSecureStrings(keys...)
+}
+
 type DuckDuckGoConfig struct {
 	Enabled    bool `json:"enabled"     env:"PICOCLAW_TOOLS_WEB_DUCKDUCKGO_ENABLED"`
 	MaxResults int  `json:"max_results" env:"PICOCLAW_TOOLS_WEB_DUCKDUCKGO_MAX_RESULTS"`
@@ -1030,6 +1058,7 @@ type WebToolsConfig struct {
 	Brave       BraveConfig        `yaml:"brave,omitempty"                                        json:"brave"`
 	Tavily      TavilyConfig       `yaml:"tavily,omitempty"                                       json:"tavily"`
 	Kagi        KagiConfig         `yaml:"kagi,omitempty"                                         json:"kagi"`
+	Keenable    KeenableConfig     `yaml:"keenable,omitempty"                                     json:"keenable"`
 	Sogou       SogouConfig        `yaml:"-"                                                      json:"sogou"`
 	DuckDuckGo  DuckDuckGoConfig   `yaml:"-"                                                      json:"duckduckgo"`
 	Gemini      GeminiSearchConfig `yaml:"gemini,omitempty"                                       json:"gemini"`

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -346,6 +346,11 @@ func DefaultConfig() *Config {
 					BaseURL:    "https://kagi.com/api/v1/search",
 					MaxResults: 5,
 				},
+				Keenable: KeenableConfig{
+					Enabled:    false,
+					BaseURL:    "https://api.keenable.ai",
+					MaxResults: 5,
+				},
 				Sogou: SogouConfig{
 					Enabled:    true,
 					MaxResults: 5,

--- a/pkg/config/example_security_usage.go
+++ b/pkg/config/example_security_usage.go
@@ -51,7 +51,7 @@ channels:
 	  token: "your-discord-bot-token"
 
 # Web Tool Keys
-# Brave, Tavily, Perplexity, Kagi: Use 'api_keys' array
+# Brave, Tavily, Perplexity, Kagi, Keenable: Use 'api_keys' array
 # GLMSearch, BaiduSearch: Use 'api_key' single string
 web:
 
@@ -242,7 +242,7 @@ channels:
 
 ## Web Tool API Keys
 
-**Brave, Tavily, Perplexity, Kagi:**
+**Brave, Tavily, Perplexity, Kagi, Keenable:**
 ```yaml
 web:
 
@@ -449,7 +449,7 @@ web:
 
 ## Single Key Format
 
-**Models, Brave, Tavily, Perplexity, Kagi:**
+**Models, Brave, Tavily, Perplexity, Kagi, Keenable:**
 ```yaml
 model_list:
 
@@ -571,7 +571,7 @@ and .security.yml values.
 ## Multiple API Keys Not Working
 - Ensure you're using `api_keys` (plural) in .security.yml for models and web tools (except GLMSearch/BaiduSearch)
 - Check that the array format is correct in YAML (proper indentation with dashes)
-- Remember: Models, Brave, Tavily, Perplexity, Kagi MUST use `api_keys` (array format)
+- Remember: Models, Brave, Tavily, Perplexity, Kagi, Keenable MUST use `api_keys` (array format)
 - GLMSearch and BaiduSearch MUST use `api_key` (single string format)
 
 ## Keys Not Being Applied

--- a/pkg/config/security_integration_test.go
+++ b/pkg/config/security_integration_test.go
@@ -195,6 +195,10 @@ func TestAllSecurityKeysAccessible(t *testing.T) {
 		err = os.WriteFile(kagiAPIKeyFile, []byte("kagi-from-file-33333"), 0o600)
 		require.NoError(t, err)
 
+		keenableAPIKeyFile := filepath.Join(tmpDir, "keenable_api_key.txt")
+		err = os.WriteFile(keenableAPIKeyFile, []byte("keenable-from-file-44444"), 0o600)
+		require.NoError(t, err)
+
 		githubTokenFile := filepath.Join(tmpDir, "github_token.txt")
 		err = os.WriteFile(githubTokenFile, []byte("ghp-github-from-file-abc123"), 0o600)
 		require.NoError(t, err)
@@ -277,6 +281,9 @@ func TestAllSecurityKeysAccessible(t *testing.T) {
       "kagi": {
         "enabled": true
       },
+      "keenable": {
+        "enabled": true
+      },
       "glm_search": {
         "enabled": true
       }
@@ -341,6 +348,9 @@ web:
   kagi:
     api_keys:
       - "file://kagi_api_key.txt"
+  keenable:
+    api_keys:
+      - "file://keenable_api_key.txt"
   glm_search:
     api_key: "glm-test-glm-search-key"
 
@@ -468,6 +478,9 @@ skills:
 
 		assert.Equal(t, "kagi-from-file-33333", cfg.Tools.Web.Kagi.APIKey())
 		t.Logf("Kagi APIKey(): %s", cfg.Tools.Web.Kagi.APIKey())
+
+		assert.Equal(t, "keenable-from-file-44444", cfg.Tools.Web.Keenable.APIKey())
+		t.Logf("Keenable APIKey(): %s", cfg.Tools.Web.Keenable.APIKey())
 
 		// GLM Search - Note: GLM uses SetAPIKey (lowercase) internally
 		t.Logf("GLMSearch APIKey(): %s", cfg.Tools.Web.GLMSearch.APIKey.String())

--- a/pkg/tools/integration/web.go
+++ b/pkg/tools/integration/web.go
@@ -37,6 +37,14 @@ const (
 
 	defaultMaxChars = 50000
 	maxRedirects    = 5
+
+	keenableDefaultBaseURL = "https://api.keenable.ai"
+	// keenableAppTitle identifies PicoClaw to Keenable's public (keyless)
+	// endpoint, which rejects requests without an X-Keenable-Title header.
+	keenableAppTitle = "picoclaw"
+	// keenableSnippetMaxLength asks the API for snippets of roughly this many
+	// characters, in line with what the other providers return per result.
+	keenableSnippetMaxLength = 500
 )
 
 // Pre-compiled regexes for HTML text extraction
@@ -250,6 +258,23 @@ func mapBaiduRecencyFilter(rangeCode string) string {
 	default:
 		return ""
 	}
+}
+
+func mapKeenablePublishedAfter(rangeCode string, now time.Time) string {
+	var since time.Time
+	switch rangeCode {
+	case "d":
+		since = now.AddDate(0, 0, -1)
+	case "w":
+		since = now.AddDate(0, 0, -7)
+	case "m":
+		since = now.AddDate(0, -1, 0)
+	case "y":
+		since = now.AddDate(-1, 0, 0)
+	default:
+		return ""
+	}
+	return since.UTC().Format(time.DateOnly)
 }
 
 func mapKagiLensTimeFilter(rangeCode string, now time.Time) *kagiopenapi.SearchRequestLens {
@@ -574,6 +599,151 @@ func (p *KagiSearchProvider) Search(
 		return formatKagiSearchResults(query, results), nil
 	}
 
+	return "", fmt.Errorf("all api keys failed, last error: %w", lastErr)
+}
+
+// KeenableSearchProvider searches the web through the Keenable API.
+// It needs no API key: without one it calls the public endpoint, which is
+// rate limited per IP. Configured keys switch to the keyed endpoint and are
+// rotated like the other key-pool providers.
+type KeenableSearchProvider struct {
+	keyPool *APIKeyPool
+	baseURL string
+	proxy   string
+	client  *http.Client
+}
+
+func (p *KeenableSearchProvider) Search(
+	ctx context.Context,
+	query string,
+	count int,
+	rangeCode string,
+) (string, error) {
+	baseURL := strings.TrimSuffix(p.baseURL, "/")
+	if baseURL == "" {
+		baseURL = keenableDefaultBaseURL
+	}
+
+	payload := map[string]any{
+		"query":              query,
+		"max_results":        count,
+		"snippet_max_length": keenableSnippetMaxLength,
+	}
+	if publishedAfter := mapKeenablePublishedAfter(rangeCode, time.Now()); publishedAfter != "" {
+		payload["published_after"] = publishedAfter
+	}
+
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	// Collect the attempts up front: every configured key, or a single
+	// keyless request when none is configured.
+	var apiKeys []string
+	if p.keyPool != nil {
+		iter := p.keyPool.NewIterator()
+		for {
+			apiKey, ok := iter.Next()
+			if !ok {
+				break
+			}
+			apiKeys = append(apiKeys, apiKey)
+		}
+	}
+	keyless := len(apiKeys) == 0
+	if keyless {
+		apiKeys = []string{""}
+	}
+
+	var lastErr error
+	for _, apiKey := range apiKeys {
+		searchURL := baseURL + "/v1/search"
+		if apiKey == "" {
+			searchURL = baseURL + "/v1/search/public"
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, searchURL, bytes.NewReader(bodyBytes))
+		if err != nil {
+			return "", fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Keenable-Title", keenableAppTitle)
+		if apiKey != "" {
+			req.Header.Set("X-API-Key", apiKey)
+		}
+
+		resp, err := p.client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("request failed: %w", err)
+			continue
+		}
+
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		_ = resp.Body.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("failed to read response: %w", err)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("keenable api error (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+			if resp.StatusCode == http.StatusTooManyRequests && keyless {
+				lastErr = fmt.Errorf(
+					"keenable api error (status %d): public rate limit reached, retry later or configure an API key",
+					resp.StatusCode,
+				)
+			}
+			if resp.StatusCode == http.StatusTooManyRequests ||
+				resp.StatusCode == http.StatusUnauthorized ||
+				resp.StatusCode == http.StatusForbidden ||
+				resp.StatusCode >= 500 {
+				continue
+			}
+			return "", lastErr
+		}
+
+		var searchResp struct {
+			Results []struct {
+				Title       string `json:"title"`
+				URL         string `json:"url"`
+				Snippet     string `json:"snippet"`
+				Description string `json:"description"`
+			} `json:"results"`
+		}
+		if err := json.Unmarshal(body, &searchResp); err != nil {
+			return "", fmt.Errorf("failed to parse response: %w", err)
+		}
+
+		results := searchResp.Results
+		if len(results) == 0 {
+			return fmt.Sprintf("No results for: %s", query), nil
+		}
+
+		var lines []string
+		lines = append(lines, fmt.Sprintf("Results for: %s (via Keenable)", query))
+		for i, item := range results {
+			if i >= count {
+				break
+			}
+			lines = append(lines, fmt.Sprintf("%d. %s\n   %s", i+1, item.Title, item.URL))
+			content := item.Snippet
+			if content == "" {
+				content = item.Description
+			}
+			// Snippets can span several passages; keep one line per result.
+			content = strings.Join(strings.Fields(content), " ")
+			if content != "" {
+				lines = append(lines, fmt.Sprintf("   %s", content))
+			}
+		}
+
+		return strings.Join(lines, "\n"), nil
+	}
+
+	if keyless {
+		return "", lastErr
+	}
 	return "", fmt.Errorf("all api keys failed, last error: %w", lastErr)
 }
 
@@ -1476,6 +1646,10 @@ type WebSearchToolOptions struct {
 	KagiBaseURL           string
 	KagiMaxResults        int
 	KagiEnabled           bool
+	KeenableAPIKeys       []string
+	KeenableBaseURL       string
+	KeenableMaxResults    int
+	KeenableEnabled       bool
 	SogouMaxResults       int
 	SogouEnabled          bool
 	DuckDuckGoMaxResults  int
@@ -1516,6 +1690,10 @@ func WebSearchToolOptionsFromConfig(cfg *config.Config) WebSearchToolOptions {
 		KagiBaseURL:           cfg.Tools.Web.Kagi.BaseURL,
 		KagiMaxResults:        cfg.Tools.Web.Kagi.MaxResults,
 		KagiEnabled:           cfg.Tools.Web.Kagi.Enabled,
+		KeenableAPIKeys:       cfg.Tools.Web.Keenable.APIKeys.Values(),
+		KeenableBaseURL:       cfg.Tools.Web.Keenable.BaseURL,
+		KeenableMaxResults:    cfg.Tools.Web.Keenable.MaxResults,
+		KeenableEnabled:       cfg.Tools.Web.Keenable.Enabled,
 		SogouMaxResults:       cfg.Tools.Web.Sogou.MaxResults,
 		SogouEnabled:          cfg.Tools.Web.Sogou.Enabled,
 		DuckDuckGoMaxResults:  cfg.Tools.Web.DuckDuckGo.MaxResults,
@@ -1559,12 +1737,13 @@ var (
 		"brave",
 		"tavily",
 		"kagi",
+		"keenable",
 		"perplexity",
 		"searxng",
 		"glm_search",
 		"baidu_search",
 	}
-	autoPrimaryWebSearchProviders  = []string{"perplexity", "brave", "kagi", "searxng", "tavily", "gemini"}
+	autoPrimaryWebSearchProviders  = []string{"perplexity", "brave", "kagi", "searxng", "tavily", "gemini", "keenable"}
 	autoFallbackWebSearchProviders = []string{"baidu_search", "glm_search"}
 )
 
@@ -1592,6 +1771,9 @@ func (opts WebSearchToolOptions) providerReady(name string) bool {
 		return opts.TavilyEnabled && len(opts.TavilyAPIKeys) > 0
 	case "kagi":
 		return opts.KagiEnabled && len(opts.KagiAPIKeys) > 0
+	case "keenable":
+		// No key needed: the public endpoint is used when none is configured.
+		return opts.KeenableEnabled
 	case "perplexity":
 		return opts.PerplexityEnabled && len(opts.PerplexityAPIKeys) > 0
 	case "searxng":
@@ -1774,6 +1956,24 @@ func (opts WebSearchToolOptions) providerByName(name string) (SearchProvider, in
 		return &KagiSearchProvider{
 			keyPool: NewAPIKeyPool(opts.KagiAPIKeys),
 			baseURL: opts.KagiBaseURL,
+			proxy:   opts.Proxy,
+			client:  client,
+		}, maxResults, nil
+	case "keenable":
+		if !opts.providerReady("keenable") {
+			return nil, 0, nil
+		}
+		client, err := utils.CreateHTTPClient(opts.Proxy, searchTimeout)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to create HTTP client for Keenable: %w", err)
+		}
+		maxResults := 10
+		if opts.KeenableMaxResults > 0 {
+			maxResults = min(opts.KeenableMaxResults, 10)
+		}
+		return &KeenableSearchProvider{
+			keyPool: NewAPIKeyPool(opts.KeenableAPIKeys),
+			baseURL: opts.KeenableBaseURL,
 			proxy:   opts.Proxy,
 			client:  client,
 		}, maxResults, nil

--- a/pkg/tools/integration/web_test.go
+++ b/pkg/tools/integration/web_test.go
@@ -2415,3 +2415,331 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
 }
+
+func TestMapKeenablePublishedAfter(t *testing.T) {
+	now := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		rangeCode string
+		want      string
+	}{
+		{rangeCode: "", want: ""},
+		{rangeCode: "d", want: "2026-03-14"},
+		{rangeCode: "w", want: "2026-03-08"},
+		{rangeCode: "m", want: "2026-02-15"},
+		{rangeCode: "y", want: "2025-03-15"},
+	}
+	for _, tt := range tests {
+		if got := mapKeenablePublishedAfter(tt.rangeCode, now); got != tt.want {
+			t.Errorf("mapKeenablePublishedAfter(%q) = %q, want %q", tt.rangeCode, got, tt.want)
+		}
+	}
+}
+
+func TestWebTool_KeenableSearch_ReadyWithoutKey(t *testing.T) {
+	tool, err := NewWebSearchTool(WebSearchToolOptions{
+		KeenableEnabled:    true,
+		KeenableMaxResults: 3,
+		Proxy:              "http://127.0.0.1:7890",
+	})
+	if err != nil {
+		t.Fatalf("NewWebSearchTool() error: %v", err)
+	}
+	if tool == nil {
+		t.Fatal("expected a tool when Keenable is enabled without a key")
+	}
+	p, ok := tool.provider.(*KeenableSearchProvider)
+	if !ok {
+		t.Fatalf("provider type = %T, want *KeenableSearchProvider", tool.provider)
+	}
+	if p.proxy != "http://127.0.0.1:7890" {
+		t.Fatalf("provider proxy = %q, want %q", p.proxy, "http://127.0.0.1:7890")
+	}
+	if tool.maxResults != 3 {
+		t.Fatalf("maxResults = %d, want 3", tool.maxResults)
+	}
+}
+
+func TestWebTool_KeenableSearch_AutoOrder(t *testing.T) {
+	// Enabled without a key, Keenable is picked before the built-in scrapers.
+	name, err := ResolveWebSearchProviderName(WebSearchToolOptions{
+		KeenableEnabled:      true,
+		SogouEnabled:         true,
+		DuckDuckGoEnabled:    true,
+		DuckDuckGoMaxResults: 5,
+	}, "best robotics companies")
+	if err != nil {
+		t.Fatalf("ResolveWebSearchProviderName() error: %v", err)
+	}
+	if name != "keenable" {
+		t.Fatalf("provider = %q, want keenable", name)
+	}
+
+	// A configured keyed provider still wins over Keenable.
+	name, err = ResolveWebSearchProviderName(WebSearchToolOptions{
+		KeenableEnabled: true,
+		TavilyEnabled:   true,
+		TavilyAPIKeys:   []string{"tvly-key"},
+	}, "best robotics companies")
+	if err != nil {
+		t.Fatalf("ResolveWebSearchProviderName() error: %v", err)
+	}
+	if name != "tavily" {
+		t.Fatalf("provider = %q, want tavily", name)
+	}
+}
+
+func TestWebTool_KeenableSearch_Endpoints(t *testing.T) {
+	tests := []struct {
+		name      string
+		apiKeys   []string
+		wantPath  string
+		wantKey   string
+		wantTitle string
+	}{
+		{
+			name:      "keyless uses public endpoint and title header",
+			apiKeys:   nil,
+			wantPath:  "/v1/search/public",
+			wantKey:   "",
+			wantTitle: "picoclaw",
+		},
+		{
+			name:      "keyed uses X-API-Key on the keyed endpoint",
+			apiKeys:   []string{"kn-test-key"},
+			wantPath:  "/v1/search",
+			wantKey:   "kn-test-key",
+			wantTitle: "picoclaw",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %s, want POST", r.Method)
+				}
+				if r.URL.Path != tt.wantPath {
+					t.Errorf("path = %s, want %s", r.URL.Path, tt.wantPath)
+				}
+				if got := r.Header.Get("X-API-Key"); got != tt.wantKey {
+					t.Errorf("X-API-Key = %q, want %q", got, tt.wantKey)
+				}
+				if got := r.Header.Get("X-Keenable-Title"); got != tt.wantTitle {
+					t.Errorf("X-Keenable-Title = %q, want %q", got, tt.wantTitle)
+				}
+				if got := r.Header.Get("Content-Type"); got != "application/json" {
+					t.Errorf("Content-Type = %q, want application/json", got)
+				}
+
+				var payload map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Errorf("decode payload: %v", err)
+				}
+				if payload["query"] != "test query" {
+					t.Errorf("query = %v, want 'test query'", payload["query"])
+				}
+				if payload["max_results"] != float64(5) {
+					t.Errorf("max_results = %v, want 5", payload["max_results"])
+				}
+				if payload["snippet_max_length"] != float64(500) {
+					t.Errorf("snippet_max_length = %v, want 500", payload["snippet_max_length"])
+				}
+				if _, ok := payload["published_after"]; ok {
+					t.Errorf("published_after should be absent without a range")
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{
+					"results": []map[string]any{
+						{
+							"title":       "Test Result 1",
+							"url":         "https://example.com/1",
+							"snippet":     "Snippet for result 1",
+							"description": "",
+						},
+						{
+							"title":       "Test Result 2",
+							"url":         "https://example.com/2",
+							"snippet":     "",
+							"description": "Description for result 2",
+						},
+						{
+							"title":   "Test Result 3",
+							"url":     "https://example.com/3",
+							"snippet": "First passage.\n\nSecond   passage.",
+						},
+					},
+				})
+			}))
+			defer server.Close()
+
+			tool, err := NewWebSearchTool(WebSearchToolOptions{
+				KeenableEnabled:    true,
+				KeenableAPIKeys:    tt.apiKeys,
+				KeenableBaseURL:    server.URL,
+				KeenableMaxResults: 5,
+			})
+			if err != nil {
+				t.Fatalf("NewWebSearchTool() error: %v", err)
+			}
+
+			result := tool.Execute(context.Background(), map[string]any{"query": "test query"})
+			if result.IsError {
+				t.Fatalf("expected success, got error: %s", result.ForLLM)
+			}
+			for _, want := range []string{
+				"via Keenable",
+				"Test Result 1",
+				"https://example.com/1",
+				"Snippet for result 1",
+				"Test Result 2",
+				"Description for result 2",
+				"3. Test Result 3\n   https://example.com/3\n   First passage. Second passage.",
+			} {
+				if !strings.Contains(result.ForUser, want) {
+					t.Errorf("output missing %q:\n%s", want, result.ForUser)
+				}
+			}
+		})
+	}
+}
+
+func TestWebTool_KeenableSearch_RangeMapping(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode payload: %v", err)
+		}
+		got, _ := payload["published_after"].(string)
+		want := mapKeenablePublishedAfter("w", time.Now())
+		if got != want {
+			t.Errorf("published_after = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+	}))
+	defer server.Close()
+
+	tool, err := NewWebSearchTool(WebSearchToolOptions{
+		KeenableEnabled:    true,
+		KeenableBaseURL:    server.URL,
+		KeenableMaxResults: 5,
+	})
+	if err != nil {
+		t.Fatalf("NewWebSearchTool() error: %v", err)
+	}
+	result := tool.Execute(context.Background(), map[string]any{"query": "test query", "range": "w"})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.ForLLM)
+	}
+	if !strings.Contains(result.ForUser, "No results for: test query") {
+		t.Fatalf("unexpected output: %s", result.ForUser)
+	}
+}
+
+func TestWebTool_KeenableSearch_Errors(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiKeys    []string
+		statusCode int
+		body       string
+		wantErr    []string
+	}{
+		{
+			name:       "keyless rate limit surfaces as an error",
+			apiKeys:    nil,
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"error":"rate limit exceeded"}`,
+			wantErr:    []string{"status 429", "configure an API key"},
+		},
+		{
+			name:       "keyed rate limit reports the status",
+			apiKeys:    []string{"kn-test-key"},
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"error":"rate limit exceeded"}`,
+			wantErr:    []string{"all api keys failed", "status 429"},
+		},
+		{
+			name:       "bad request does not retry",
+			apiKeys:    nil,
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":"query is required"}`,
+			wantErr:    []string{"status 400", "query is required"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls++
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			tool, err := NewWebSearchTool(WebSearchToolOptions{
+				KeenableEnabled:    true,
+				KeenableAPIKeys:    tt.apiKeys,
+				KeenableBaseURL:    server.URL,
+				KeenableMaxResults: 5,
+			})
+			if err != nil {
+				t.Fatalf("NewWebSearchTool() error: %v", err)
+			}
+
+			result := tool.Execute(context.Background(), map[string]any{"query": "test query"})
+			if !result.IsError {
+				t.Fatalf("expected an error result, got: %s", result.ForUser)
+			}
+			for _, want := range tt.wantErr {
+				if !strings.Contains(result.ForLLM, want) {
+					t.Errorf("error %q missing %q", result.ForLLM, want)
+				}
+			}
+			if calls != 1 {
+				t.Errorf("calls = %d, want 1", calls)
+			}
+		})
+	}
+}
+
+func TestWebTool_KeenableSearch_KeyFailover(t *testing.T) {
+	var seen []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Header.Get("X-API-Key")
+		seen = append(seen, key)
+		w.Header().Set("Content-Type", "application/json")
+		if key == "key1" {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"rate limit exceeded"}`))
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"title": "Result", "url": "https://example.com/1", "snippet": "Snippet"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	tool, err := NewWebSearchTool(WebSearchToolOptions{
+		KeenableEnabled:    true,
+		KeenableAPIKeys:    []string{"key1", "key2"},
+		KeenableBaseURL:    server.URL,
+		KeenableMaxResults: 5,
+	})
+	if err != nil {
+		t.Fatalf("NewWebSearchTool() error: %v", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{"query": "test query"})
+	if result.IsError {
+		t.Fatalf("expected success after failover, got: %s", result.ForLLM)
+	}
+	if len(seen) != 2 || seen[0] != "key1" || seen[1] != "key2" {
+		t.Fatalf("keys tried = %v, want [key1 key2]", seen)
+	}
+	if !strings.Contains(result.ForUser, "https://example.com/1") {
+		t.Fatalf("unexpected output: %s", result.ForUser)
+	}
+}

--- a/pkg/tools/integration_facade.go
+++ b/pkg/tools/integration_facade.go
@@ -26,6 +26,7 @@ type (
 	SearchResultItem         = integrationtools.SearchResultItem
 	BraveSearchProvider      = integrationtools.BraveSearchProvider
 	TavilySearchProvider     = integrationtools.TavilySearchProvider
+	KeenableSearchProvider   = integrationtools.KeenableSearchProvider
 	SogouSearchProvider      = integrationtools.SogouSearchProvider
 	DuckDuckGoSearchProvider = integrationtools.DuckDuckGoSearchProvider
 	GeminiSearchProvider     = integrationtools.GeminiSearchProvider

--- a/web/backend/api/tools.go
+++ b/web/backend/api/tools.go
@@ -478,6 +478,14 @@ func (h *Handler) handleUpdateWebSearchConfig(w http.ResponseWriter, r *http.Req
 			cfg.Tools.Web.Kagi.SetAPIKeys(keys)
 		}
 	}
+	if settings, ok := req.Settings["keenable"]; ok {
+		cfg.Tools.Web.Keenable.Enabled = settings.Enabled
+		cfg.Tools.Web.Keenable.MaxResults = settings.MaxResults
+		cfg.Tools.Web.Keenable.BaseURL = strings.TrimSpace(settings.BaseURL)
+		if keys, ok := normalizeWebSearchAPIKeys(settings.APIKeys, settings.APIKey); ok {
+			cfg.Tools.Web.Keenable.SetAPIKeys(keys)
+		}
+	}
 	if settings, ok := req.Settings["perplexity"]; ok {
 		cfg.Tools.Web.Perplexity.Enabled = settings.Enabled
 		cfg.Tools.Web.Perplexity.MaxResults = settings.MaxResults
@@ -526,6 +534,7 @@ func normalizeWebSearchProvider(provider string) string {
 		"brave",
 		"tavily",
 		"kagi",
+		"keenable",
 		"duckduckgo",
 		"gemini",
 		"perplexity",
@@ -598,6 +607,12 @@ func buildWebSearchConfigResponse(cfg *config.Config) webSearchConfigResponse {
 			BaseURL:    cfg.Tools.Web.Kagi.BaseURL,
 			APIKeySet:  len(cfg.Tools.Web.Kagi.APIKeys.Values()) > 0,
 		},
+		"keenable": {
+			Enabled:    cfg.Tools.Web.Keenable.Enabled,
+			MaxResults: cfg.Tools.Web.Keenable.MaxResults,
+			BaseURL:    cfg.Tools.Web.Keenable.BaseURL,
+			APIKeySet:  len(cfg.Tools.Web.Keenable.APIKeys.Values()) > 0,
+		},
 		"perplexity": {
 			Enabled:    cfg.Tools.Web.Perplexity.Enabled,
 			MaxResults: cfg.Tools.Web.Perplexity.MaxResults,
@@ -669,6 +684,12 @@ func buildWebSearchConfigResponse(cfg *config.Config) webSearchConfigResponse {
 			Configured:   picotools.WebSearchProviderReady(opts, "kagi"),
 			Current:      current == "kagi",
 			RequiresAuth: true,
+		},
+		{
+			ID:         "keenable",
+			Label:      "Keenable",
+			Configured: picotools.WebSearchProviderReady(opts, "keenable"),
+			Current:    current == "keenable",
 		},
 		{
 			ID:           "perplexity",

--- a/web/frontend/src/components/agent/tools/web-search-provider-settings.tsx
+++ b/web/frontend/src/components/agent/tools/web-search-provider-settings.tsx
@@ -22,6 +22,7 @@ interface WebSearchProviderSettingsProps {
 const baseUrlProviders = new Set([
   "tavily",
   "kagi",
+  "keenable",
   "searxng",
   "glm_search",
   "baidu_search",
@@ -31,6 +32,7 @@ const apiKeyProviders = new Set([
   "brave",
   "tavily",
   "kagi",
+  "keenable",
   "perplexity",
   "gemini",
   "glm_search",


### PR DESCRIPTION
## 📝 Description

Adds Keenable (<https://keenable.ai>) as a `web_search` provider. It works with no API key on a fresh install: set `tools.web.keenable.enabled` to `true` and the tool calls Keenable's public endpoint (`POST /v1/search/public`, which requires an `X-Keenable-Title` header, sent as `picoclaw`). That endpoint is rate limited per IP (10 requests/second, 1000 per hour). Configuring `api_keys` switches to `POST /v1/search` with `X-API-Key` and lifts those limits; nothing else changes. Keys rotate through the existing `APIKeyPool` like Brave, Tavily and Kagi.

I work at Keenable.

What changed, following the Kagi provider (#3037):

- `pkg/tools/integration/web.go`: `KeenableSearchProvider`; `keenable` in the known and auto provider lists; `providerReady` needs only `Enabled`; the `range` argument maps to `published_after`. Results render in the same `Results for: ... (via Keenable)` shape as the other providers, reading `snippet` and falling back to `description`, collapsed to one line per result. Non-200 responses are errors, never an empty success; a 429 on the keyless endpoint says to retry later or configure a key, and 429/401/403/5xx rotate to the next configured key as in Tavily.
- `pkg/config`: `KeenableConfig` (`enabled`, `api_keys`, `base_url`, `max_results`), defaults, the `api_keys` lists in the security docs, and a case in the `.security.yml` integration test.
- Web UI (`web/backend/api/tools.go`, provider settings component): settings block and provider entry with `requires_auth: false`, base URL and API key fields.
- Docs: a `### Keenable` section in `tools_configuration.md`, a README table row, a `config.example.json` block.

In the auto chain `keenable` comes after `gemini`, so any configured keyed provider still wins; it is picked only when enabled and nothing keyed is configured. The default provider (`auto`, Sogou) is unchanged and `enabled` defaults to `false`. No new dependency.

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

None.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://docs.keenable.ai/api-reference
- **Reasoning:** every provider in the table today needs a key or a self-hosted instance, except the Sogou and DuckDuckGo HTML scrapers. This adds an API-backed option that needs neither, with the key as an optional upgrade rather than a prerequisite.

## 🧪 Test Environment
- **Hardware:** PC (Apple Silicon Mac)
- **OS:** macOS 26
- **Model/Provider:** none; the provider was exercised directly through `WebSearchTool.Execute`
- **Channels:** none

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```
go build -tags goolm,stdjson ./...                                   ok
go test  -tags goolm,stdjson ./pkg/tools/integration/ ./pkg/config/  ok
cd web/backend && go test ./...                                      ok
golangci-lint run --build-tags=goolm,stdjson ./pkg/tools/... ./pkg/config/...   0 issues
golangci-lint fmt --diff (touched packages)                          clean
scripts/lint-docs.sh                                                 docs lint: OK
```

New tests (`go test -run Keenable`): `published_after` mapping; ready without a key; auto order (Keenable before Sogou, Tavily before Keenable); keyless request goes to `/v1/search/public` with `X-Keenable-Title` and no `X-API-Key`; keyed request goes to `/v1/search` with `X-API-Key`; `snippet` then `description`, multi-paragraph snippets collapsed; 429 keyless and keyed and a non-retried 400; two-key failover.

Live call with no key configured, query `rust programming language`, `count` 5: 5 results, 5 non-empty snippets (462 to 548 chars), 0.32 s.

Not run here: `pnpm lint` in `web/frontend`, because `pnpm install --frozen-lockfile` fails on the checked-in lockfile (`duplicated mapping key` at line 3577 with pnpm 10.33). The frontend change is two string literals in existing sets. `pkg/tools` has three `TestShellTool_*` failures on macOS that are identical on `main`.

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
