### PR TITLE
feat(providers): add opencode-go provider with session header support

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -63,6 +63,24 @@
       "api_keys": ["sk-your-deepseek-key"]
     },
     {
+      "_comment": "OpenCode Go - chat/completions family (api_base optional, defaults to https://opencode.ai/zen/go/v1)",
+      "model_name": "go-kimi",
+      "model": "opencode-go/kimi-k3",
+      "api_keys": ["your-opencode-go-api-key"]
+    },
+    {
+      "_comment": "OpenCode Go - Responses family (grok-4.6, gpt-5.6-luna, muse-spark-*) routes to /responses automatically",
+      "model_name": "go-grok",
+      "model": "opencode-go/grok-4.6",
+      "api_keys": ["your-opencode-go-api-key"]
+    },
+    {
+      "_comment": "OpenCode Go - Messages family (minimax-*, qwen3.*) routes to /messages automatically",
+      "model_name": "go-qwen",
+      "model": "opencode-go/qwen3.7-plus",
+      "api_keys": ["your-opencode-go-api-key"]
+    },
+    {
       "model_name": "venice-uncensored",
       "model": "venice/venice-uncensored",
       "api_keys": ["your-venice-api-key"]

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -77,6 +77,7 @@ This design also enables **multi-agent support** with flexible provider selectio
 | **Azure OpenAI**    | `azure`           | `https://{resource}.openai.azure.com`               | Azure     | [Get Key](https://portal.azure.com)                              |
 | **Antigravity**     | `antigravity`     | Google Cloud                                        | Custom    | OAuth only                                                       |
 | **GitHub Copilot**  | `github-copilot`  | `localhost:4321`                                    | gRPC      | -                                                                |
+| **OpenCode Go**     | `opencode-go`     | `https://opencode.ai/zen/go/v1`                     | Multi     | [Get Key](https://opencode.ai/docs/go/)                          |
 
 #### Basic Configuration
 
@@ -347,6 +348,29 @@ For direct Anthropic API access or custom endpoints that only support Anthropic'
 > - The existing `anthropic` protocol returns 404 errors (indicating the endpoint doesn't support OpenAI-compatible format)
 >
 > **Note:** The `anthropic` protocol uses OpenAI-compatible format (`/v1/chat/completions`), while `anthropic-messages` uses Anthropic's native format (`/v1/messages`). Choose based on your endpoint's supported format.
+
+**OpenCode Go**
+
+OpenCode Go exposes three endpoint families and PicoClaw routes each model
+to the correct one automatically based on the model ID:
+
+- `/responses` for `grok-4.6`, `gpt-5.6-luna`, `claude-opus-4-6` and `muse-spark-*` models
+- `/messages` for `minimax-*` and `qwen3.*` models
+- `/chat/completions` for everything else
+
+```json
+{
+  "model_name": "go-kimi",
+  "provider": "opencode-go",
+  "model": "kimi-k3",
+  "api_keys": ["your-opencode-go-key"]
+}
+```
+
+> `api_base` is optional and defaults to `https://opencode.ai/zen/go/v1`.
+> PicoClaw sends the `x-opencode-session` header automatically, set to the
+> active conversation session key. An explicit `custom_headers` entry for
+> that header always takes precedence.
 
 **Ollama (local)**
 

--- a/pkg/agent/pipeline_llm.go
+++ b/pkg/agent/pipeline_llm.go
@@ -72,6 +72,7 @@ func (p *Pipeline) CallLLM(
 		"max_tokens":       ts.agent.MaxTokens,
 		"temperature":      ts.agent.Temperature,
 		"prompt_cache_key": ts.agent.ID,
+		"session_key":      ts.sessionKey,
 	}
 	if exec.useNativeSearch {
 		exec.llmOpts["native_search"] = true

--- a/pkg/agent/turn_coord.go
+++ b/pkg/agent/turn_coord.go
@@ -454,6 +454,9 @@ func (al *AgentLoop) askSideQuestion(
 		"temperature":      agent.Temperature,
 		"prompt_cache_key": agent.ID + ":btw",
 	}
+	if opts != nil {
+		llmOpts["session_key"] = opts.SessionKey
+	}
 
 	hookModelChanged := false
 	sideSuppressReasoning := false

--- a/pkg/providers/anthropic_messages/headers_test.go
+++ b/pkg/providers/anthropic_messages/headers_test.go
@@ -1,0 +1,39 @@
+package anthropicmessages
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const headersTestBody = `{"id":"msg-1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","model":"m","usage":{"input_tokens":1,"output_tokens":1}}`
+
+func TestChat_SessionAndCustomHeaders(t *testing.T) {
+	var gotSession, gotCustom string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSession = r.Header.Get("x-opencode-session")
+		gotCustom = r.Header.Get("X-Custom")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(headersTestBody))
+	}))
+	defer srv.Close()
+
+	p := NewProviderWithOptions("k", srv.URL, "ua", 0,
+		WithCustomHeaders(map[string]string{"X-Custom": "yes"}),
+		WithSessionHeaderName("x-opencode-session"),
+	)
+	resp, err := p.Chat(context.Background(), nil, nil, "m", map[string]any{"session_key": "sess-1", "max_tokens": 1024})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if gotSession != "sess-1" {
+		t.Fatalf("x-opencode-session = %q, want sess-1", gotSession)
+	}
+	if gotCustom != "yes" {
+		t.Fatalf("X-Custom = %q, want yes", gotCustom)
+	}
+	if resp == nil || resp.Content != "ok" {
+		t.Fatalf("resp = %+v, want content ok", resp)
+	}
+}

--- a/pkg/providers/anthropic_messages/provider.go
+++ b/pkg/providers/anthropic_messages/provider.go
@@ -39,10 +39,30 @@ const (
 // Provider implements Anthropic Messages API via HTTP (without SDK).
 // It supports custom endpoints that use Anthropic's native message format.
 type Provider struct {
-	apiKey     string
-	apiBase    string
-	httpClient *http.Client
-	userAgent  string
+	apiKey            string
+	apiBase           string
+	httpClient        *http.Client
+	customHeaders     map[string]string
+	sessionHeaderName string // Optional per-conversation session header (e.g. x-opencode-session)
+	userAgent         string
+}
+
+// Option configures a Provider.
+type Option func(*Provider)
+
+// WithCustomHeaders injects additional headers into every HTTP request.
+func WithCustomHeaders(customHeaders map[string]string) Option {
+	return func(p *Provider) {
+		p.customHeaders = customHeaders
+	}
+}
+
+// WithSessionHeaderName enables a per-conversation session header whose value
+// comes from options["session_key"]. An explicit custom_headers value wins.
+func WithSessionHeaderName(headerName string) Option {
+	return func(p *Provider) {
+		p.sessionHeaderName = strings.TrimSpace(headerName)
+	}
 }
 
 // NewProvider creates a new Anthropic Messages API provider.
@@ -66,6 +86,17 @@ func NewProviderWithTimeout(apiKey, apiBase, userAgent string, timeoutSeconds in
 			Timeout: timeout,
 		},
 	}
+}
+
+// NewProviderWithOptions creates a provider with custom request timeout and options.
+func NewProviderWithOptions(apiKey, apiBase, userAgent string, timeoutSeconds int, opts ...Option) *Provider {
+	p := NewProviderWithTimeout(apiKey, apiBase, userAgent, timeoutSeconds)
+	for _, opt := range opts {
+		if opt != nil {
+			opt(p)
+		}
+	}
+	return p
 }
 
 // Chat sends messages to the Anthropic Messages API and returns the response.
@@ -110,6 +141,15 @@ func (p *Provider) Chat(
 	req.Header.Set("Anthropic-Version", defaultAPIVersion)
 	if p.userAgent != "" {
 		req.Header.Set("User-Agent", p.userAgent)
+	}
+	for k, v := range p.customHeaders {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+	if p.sessionHeaderName != "" {
+		common.ApplySessionHeader(req.Header, options, p.sessionHeaderName)
 	}
 
 	// Execute request

--- a/pkg/providers/common/common.go
+++ b/pkg/providers/common/common.go
@@ -38,6 +38,40 @@ type (
 
 const DefaultRequestTimeout = 120 * time.Second
 
+// SessionOptionKey is the llmOpts key carrying the stable conversation session
+// key from the agent loop. Providers that need a per-conversation session
+// header (e.g. OpenCode Go's x-opencode-session) read it from options.
+const SessionOptionKey = "session_key"
+
+// SessionKeyFromOptions extracts the trimmed session key from provider options.
+// Returns "" when absent or empty.
+func SessionKeyFromOptions(options map[string]any) string {
+	if options == nil {
+		return ""
+	}
+	sessionKey, ok := options[SessionOptionKey].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(sessionKey)
+}
+
+// ApplySessionHeader sets headerName to the session key from options when the
+// session key is non-empty and the header is not already set. Existing values
+// (e.g. explicit custom_headers) always win.
+func ApplySessionHeader(header http.Header, options map[string]any, headerName string) {
+	headerName = strings.TrimSpace(headerName)
+	if headerName == "" || header == nil {
+		return
+	}
+	if strings.TrimSpace(header.Get(headerName)) != "" {
+		return
+	}
+	if sessionKey := SessionKeyFromOptions(options); sessionKey != "" {
+		header.Set(headerName, sessionKey)
+	}
+}
+
 // NewHTTPClient creates an *http.Client with an optional proxy and the default timeout.
 func NewHTTPClient(proxy string) *http.Client {
 	client := &http.Client{

--- a/pkg/providers/common/session_header_test.go
+++ b/pkg/providers/common/session_header_test.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSessionKeyFromOptions(t *testing.T) {
+	if got := SessionKeyFromOptions(nil); got != "" {
+		t.Fatalf("nil options = %q, want empty", got)
+	}
+	if got := SessionKeyFromOptions(map[string]any{"session_key": "  abc-123  "}); got != "abc-123" {
+		t.Fatalf("session_key = %q, want trimmed value", got)
+	}
+	if got := SessionKeyFromOptions(map[string]any{"session_key": 42}); got != "" {
+		t.Fatalf("non-string session_key = %q, want empty", got)
+	}
+}
+
+func TestApplySessionHeader(t *testing.T) {
+	header := http.Header{}
+	ApplySessionHeader(header, map[string]any{"session_key": "sess-1"}, "x-opencode-session")
+	if got := header.Get("x-opencode-session"); got != "sess-1" {
+		t.Fatalf("header = %q, want sess-1", got)
+	}
+
+	// Existing value wins over options.
+	header.Set("x-opencode-session", "explicit")
+	ApplySessionHeader(header, map[string]any{"session_key": "sess-2"}, "x-opencode-session")
+	if got := header.Get("x-opencode-session"); got != "explicit" {
+		t.Fatalf("header = %q, want explicit", got)
+	}
+
+	// Empty session key sets nothing.
+	empty := http.Header{}
+	ApplySessionHeader(empty, map[string]any{}, "x-opencode-session")
+	if got := empty.Get("x-opencode-session"); got != "" {
+		t.Fatalf("header = %q, want empty", got)
+	}
+
+	// Empty header name is a no-op.
+	ApplySessionHeader(http.Header{}, map[string]any{"session_key": "sess-1"}, "")
+}

--- a/pkg/providers/factory_provider.go
+++ b/pkg/providers/factory_provider.go
@@ -16,7 +16,56 @@ import (
 	"github.com/sipeed/picoclaw/pkg/providers/azure"
 	"github.com/sipeed/picoclaw/pkg/providers/bedrock"
 	"github.com/sipeed/picoclaw/pkg/providers/common"
+	openairesponses "github.com/sipeed/picoclaw/pkg/providers/openai_responses"
 )
+
+// OpenCode Go (https://opencode.ai/docs/go/) exposes three endpoint families
+// under https://opencode.ai/zen/go/v1:
+//
+//   - /responses, OpenAI Responses API (e.g. grok-4.6, gpt-5.6-luna, muse-spark-*)
+//   - /chat/completions, OpenAI-compatible (default for the remaining models)
+//   - /messages, Anthropic Messages API (e.g. minimax-*, qwen3.*)
+//
+// All families share the Go API key (Bearer) and require a stable
+// x-opencode-session header per conversation.
+const (
+	opencodeGoDefaultAPIBase = "https://opencode.ai/zen/go/v1"
+	opencodeGoSessionHeader  = "x-opencode-session"
+)
+
+// opencodeGoResponsesModels routes to the Responses API endpoint.
+var opencodeGoResponsesModels = map[string]struct{}{
+	"grok-4.6":                   {},
+	"gpt-5.6-luna":               {},
+	"muse-spark-1.3-contributor": {},
+	"muse-spark-1.2-contributor": {},
+	"muse-spark-1.3":             {},
+	"muse-spark-1.2":             {},
+}
+
+// opencodeGoMessagesModels routes to the Anthropic Messages API endpoint.
+var opencodeGoMessagesModels = map[string]struct{}{
+	"minimax-m3":    {},
+	"minimax-m2.7":  {},
+	"minimax-m2.5":  {},
+	"qwen3.8-max":   {},
+	"qwen3.8-flash": {},
+	"qwen3.7-max":   {},
+	"qwen3.7-plus":  {},
+	"qwen3.6-plus":  {},
+}
+
+// OpenCodeGoEndpointFamily classifies an OpenCode Go model into its endpoint family.
+func OpenCodeGoEndpointFamily(modelID string) string {
+	normalized := strings.ToLower(strings.TrimSpace(modelID))
+	if _, ok := opencodeGoResponsesModels[normalized]; ok {
+		return "responses"
+	}
+	if _, ok := opencodeGoMessagesModels[normalized]; ok {
+		return "messages"
+	}
+	return "chat"
+}
 
 // createClaudeAuthProvider creates a Claude provider using OAuth credentials from auth store.
 func createClaudeAuthProvider() (LLMProvider, error) {
@@ -224,6 +273,54 @@ func CreateProviderFromConfig(cfg *config.ModelConfig) (LLMProvider, string, err
 		)
 		provider.SetProviderName(protocol)
 		return finalizeProviderFromConfig(provider, modelID, cfg)
+
+	case "opencode-go":
+		// OpenCode Go routes each model to one of three endpoint families:
+		// /responses, /chat/completions (default), or /messages.
+		if cfg.APIKey() == "" && cfg.APIBase == "" {
+			return nil, "", fmt.Errorf("api_key is required for opencode-go protocol (model: %s)", cfg.Model)
+		}
+		apiBase := cfg.APIBase
+		if apiBase == "" {
+			apiBase = getDefaultAPIBase(protocol)
+		}
+		switch OpenCodeGoEndpointFamily(modelID) {
+		case "responses":
+			provider := openairesponses.NewProviderWithTimeout(
+				cfg.APIKey(),
+				strings.TrimRight(apiBase, "/"),
+				cfg.Proxy,
+				userAgent,
+				cfg.RequestTimeout,
+				openairesponses.WithCustomHeaders(cfg.CustomHeaders),
+				openairesponses.WithSessionHeaderName(opencodeGoSessionHeader),
+			)
+			return finalizeProviderFromConfig(provider, modelID, cfg)
+		case "messages":
+			provider := anthropicmessages.NewProviderWithOptions(
+				cfg.APIKey(),
+				strings.TrimRight(apiBase, "/"),
+				userAgent,
+				cfg.RequestTimeout,
+				anthropicmessages.WithCustomHeaders(cfg.CustomHeaders),
+				anthropicmessages.WithSessionHeaderName(opencodeGoSessionHeader),
+			)
+			return finalizeProviderFromConfig(provider, modelID, cfg)
+		default:
+			provider := NewHTTPProviderWithMaxTokensFieldAndRequestTimeout(
+				cfg.APIKey(),
+				strings.TrimRight(apiBase, "/"),
+				cfg.Proxy,
+				cfg.MaxTokensField,
+				userAgent,
+				cfg.RequestTimeout,
+				cfg.ExtraBody,
+				cfg.CustomHeaders,
+			)
+			provider.SetProviderName(protocol)
+			provider.SetSessionHeaderName(opencodeGoSessionHeader)
+			return finalizeProviderFromConfig(provider, modelID, cfg)
+		}
 
 	case "gemini":
 		if cfg.APIKey() == "" && cfg.APIBase == "" {

--- a/pkg/providers/httpapi/http_provider.go
+++ b/pkg/providers/httpapi/http_provider.go
@@ -102,3 +102,12 @@ func (p *HTTPProvider) SetProviderName(providerName string) {
 	}
 	p.delegate.SetProviderName(providerName)
 }
+
+// SetSessionHeaderName enables a per-conversation session header whose value
+// comes from options["session_key"].
+func (p *HTTPProvider) SetSessionHeaderName(headerName string) {
+	if p == nil || p.delegate == nil {
+		return
+	}
+	p.delegate.SetSessionHeaderName(headerName)
+}

--- a/pkg/providers/openai_compat/provider.go
+++ b/pkg/providers/openai_compat/provider.go
@@ -34,14 +34,15 @@ type (
 )
 
 type Provider struct {
-	apiKey         string
-	apiBase        string
-	providerName   string
-	maxTokensField string // Field name for max tokens (e.g., "max_completion_tokens" for o1/glm models)
-	httpClient     *http.Client
-	extraBody      map[string]any // Additional fields to inject into request body
-	customHeaders  map[string]string
-	userAgent      string
+	apiKey            string
+	apiBase           string
+	providerName      string
+	maxTokensField    string // Field name for max tokens (e.g., "max_completion_tokens" for o1/glm models)
+	httpClient        *http.Client
+	extraBody         map[string]any // Additional fields to inject into request body
+	customHeaders     map[string]string
+	sessionHeaderName string // Optional per-conversation session header (e.g. x-opencode-session)
+	userAgent         string
 }
 
 type Option func(*Provider)
@@ -106,6 +107,14 @@ func WithCustomHeaders(customHeaders map[string]string) Option {
 func WithProviderName(providerName string) Option {
 	return func(p *Provider) {
 		p.providerName = strings.ToLower(strings.TrimSpace(providerName))
+	}
+}
+
+// WithSessionHeaderName enables a per-conversation session header whose value
+// comes from options["session_key"]. An explicit custom_headers value wins.
+func WithSessionHeaderName(headerName string) Option {
+	return func(p *Provider) {
+		p.sessionHeaderName = strings.TrimSpace(headerName)
 	}
 }
 
@@ -332,8 +341,23 @@ func (p *Provider) applyCustomHeaders(req *http.Request) {
 	}
 }
 
+// applySessionHeader injects the per-conversation session header (if configured)
+// from options["session_key"]. Explicit custom_headers values win.
+func (p *Provider) applySessionHeader(req *http.Request, options map[string]any) {
+	if p.sessionHeaderName == "" {
+		return
+	}
+	common.ApplySessionHeader(req.Header, options, p.sessionHeaderName)
+}
+
 func (p *Provider) SetProviderName(providerName string) {
 	p.providerName = strings.ToLower(strings.TrimSpace(providerName))
+}
+
+// SetSessionHeaderName enables the per-conversation session header whose value
+// comes from options["session_key"].
+func (p *Provider) SetSessionHeaderName(headerName string) {
+	p.sessionHeaderName = strings.TrimSpace(headerName)
 }
 
 func (p *Provider) SupportsThinking() bool {
@@ -488,6 +512,7 @@ func (p *Provider) Chat(
 		req.Header.Set("Authorization", "Bearer "+p.apiKey)
 	}
 	p.applyCustomHeaders(req)
+	p.applySessionHeader(req, options)
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
@@ -560,6 +585,7 @@ func (p *Provider) ChatStreamEvents(
 		req.Header.Set("Authorization", "Bearer "+p.apiKey)
 	}
 	p.applyCustomHeaders(req)
+	p.applySessionHeader(req, options)
 
 	// Use a client without Timeout for streaming — the http.Client.Timeout covers
 	// the entire request lifecycle including body reads, which would kill long streams.

--- a/pkg/providers/openai_compat/session_header_test.go
+++ b/pkg/providers/openai_compat/session_header_test.go
@@ -1,0 +1,48 @@
+package openai_compat
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestChat_SessionHeader(t *testing.T) {
+	var gotSession string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSession = r.Header.Get("x-opencode-session")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer srv.Close()
+
+	p := NewProvider("k", srv.URL, "", WithSessionHeaderName("x-opencode-session"))
+	resp, err := p.Chat(context.Background(), nil, nil, "m", map[string]any{"session_key": "sess-9"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if gotSession != "sess-9" {
+		t.Fatalf("x-opencode-session = %q, want sess-9", gotSession)
+	}
+	if resp == nil || resp.Content != "ok" {
+		t.Fatalf("resp = %+v, want content ok", resp)
+	}
+}
+
+func TestChat_NoSessionHeaderByDefault(t *testing.T) {
+	var gotSession string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSession = r.Header.Get("x-opencode-session")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer srv.Close()
+
+	p := NewProvider("k", srv.URL, "")
+	if _, err := p.Chat(context.Background(), nil, nil, "m", map[string]any{"session_key": "sess-9"}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if gotSession != "" {
+		t.Fatalf("x-opencode-session = %q, want empty", gotSession)
+	}
+}

--- a/pkg/providers/openai_responses/provider.go
+++ b/pkg/providers/openai_responses/provider.go
@@ -1,0 +1,220 @@
+// PicoClaw - Ultra-lightweight personal AI agent
+// License: MIT
+//
+// Copyright (c) 2026 PicoClaw contributors
+
+// Package openairesponses implements the OpenAI Responses API over plain HTTP
+// with Bearer API-key auth. It targets OpenAI-compatible gateways that expose
+// a /responses endpoint (e.g. OpenCode Go) without requiring OAuth.
+package openairesponses
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+
+	"github.com/sipeed/picoclaw/pkg/providers/common"
+	orc "github.com/sipeed/picoclaw/pkg/providers/openai_responses_common"
+	"github.com/sipeed/picoclaw/pkg/providers/protocoltypes"
+)
+
+type (
+	ToolCall               = protocoltypes.ToolCall
+	FunctionCall           = protocoltypes.FunctionCall
+	LLMResponse            = protocoltypes.LLMResponse
+	UsageInfo              = protocoltypes.UsageInfo
+	Message                = protocoltypes.Message
+	ToolDefinition         = protocoltypes.ToolDefinition
+	ToolFunctionDefinition = protocoltypes.ToolFunctionDefinition
+)
+
+const defaultRequestTimeout = 120 * time.Second
+
+// Provider implements the OpenAI Responses API via HTTP with an API key.
+type Provider struct {
+	apiKey            string
+	apiBase           string
+	httpClient        *http.Client
+	customHeaders     map[string]string
+	sessionHeaderName string // Optional per-conversation session header (e.g. x-opencode-session)
+	userAgent         string
+	defaultModel      string
+}
+
+// Option configures a Provider.
+type Option func(*Provider)
+
+// WithRequestTimeout sets the HTTP request timeout.
+func WithRequestTimeout(timeout time.Duration) Option {
+	return func(p *Provider) {
+		if timeout > 0 {
+			p.httpClient.Timeout = timeout
+		}
+	}
+}
+
+// WithCustomHeaders injects additional headers into every HTTP request.
+func WithCustomHeaders(customHeaders map[string]string) Option {
+	return func(p *Provider) {
+		p.customHeaders = customHeaders
+	}
+}
+
+// WithSessionHeaderName enables a per-conversation session header whose value
+// comes from options["session_key"]. An explicit custom_headers value wins.
+func WithSessionHeaderName(headerName string) Option {
+	return func(p *Provider) {
+		p.sessionHeaderName = strings.TrimSpace(headerName)
+	}
+}
+
+// WithUserAgent sets the User-Agent header.
+func WithUserAgent(userAgent string) Option {
+	return func(p *Provider) {
+		p.userAgent = userAgent
+	}
+}
+
+// WithDefaultModel sets the model returned by GetDefaultModel.
+func WithDefaultModel(model string) Option {
+	return func(p *Provider) {
+		p.defaultModel = model
+	}
+}
+
+// NewProvider creates a Responses API provider. apiBase should be the full
+// endpoint including the /responses path segment (e.g.
+// https://opencode.ai/zen/go/v1/responses).
+func NewProvider(apiKey, apiBase, userAgent string, opts ...Option) *Provider {
+	p := &Provider{
+		apiKey:     apiKey,
+		apiBase:    strings.TrimRight(apiBase, "/"),
+		httpClient: common.NewHTTPClient(""),
+		userAgent:  userAgent,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(p)
+		}
+	}
+	return p
+}
+
+// NewProviderWithTimeout creates a provider with a proxy and request timeout.
+func NewProviderWithTimeout(
+	apiKey, apiBase, proxy, userAgent string,
+	requestTimeoutSeconds int,
+	opts ...Option,
+) *Provider {
+	p := NewProvider(apiKey, apiBase, userAgent, opts...)
+	p.httpClient = common.NewHTTPClient(proxy)
+	if requestTimeoutSeconds > 0 {
+		p.httpClient.Timeout = time.Duration(requestTimeoutSeconds) * time.Second
+	}
+	return p
+}
+
+// Chat sends a request to the Responses API endpoint.
+func (p *Provider) Chat(
+	ctx context.Context,
+	messages []Message,
+	tools []ToolDefinition,
+	model string,
+	options map[string]any,
+) (*LLMResponse, error) {
+	if p.apiKey == "" {
+		return nil, fmt.Errorf("API key not configured")
+	}
+	if p.apiBase == "" {
+		return nil, fmt.Errorf("API base not configured")
+	}
+
+	requestURL, err := url.JoinPath(p.apiBase, "responses")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request URL: %w", err)
+	}
+
+	input, instructions := orc.TranslateMessages(messages)
+
+	requestBody := responses.ResponseNewParams{
+		Model: model,
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: input,
+		},
+		Store: openai.Opt(false),
+	}
+
+	if instructions != "" {
+		requestBody.Instructions = openai.Opt(instructions)
+	}
+
+	if len(tools) > 0 {
+		enableWebSearch, _ := options["native_search"].(bool)
+		requestBody.Tools = orc.TranslateTools(tools, enableWebSearch)
+		requestBody.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: openai.Opt(responses.ToolChoiceOptionsAuto),
+		}
+	}
+
+	if maxTokens, ok := common.AsInt(options["max_tokens"]); ok {
+		requestBody.MaxOutputTokens = openai.Opt(int64(maxTokens))
+	}
+
+	if temperature, ok := common.AsFloat(options["temperature"]); ok {
+		requestBody.Temperature = openai.Opt(temperature)
+	}
+
+	if cacheKey, ok := options["prompt_cache_key"].(string); ok && cacheKey != "" {
+		requestBody.PromptCacheKey = openai.Opt(cacheKey)
+	}
+
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", requestURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	if p.userAgent != "" {
+		req.Header.Set("User-Agent", p.userAgent)
+	}
+	for k, v := range p.customHeaders {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+	if p.sessionHeaderName != "" {
+		common.ApplySessionHeader(req.Header, options, p.sessionHeaderName)
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, common.HandleErrorResponse(resp, p.apiBase)
+	}
+
+	return orc.ParseResponseBody(resp.Body)
+}
+
+// GetDefaultModel returns the configured default model (may be empty).
+func (p *Provider) GetDefaultModel() string {
+	return p.defaultModel
+}

--- a/pkg/providers/openai_responses/provider_test.go
+++ b/pkg/providers/openai_responses/provider_test.go
@@ -1,0 +1,81 @@
+package openairesponses
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func successBody() string {
+	return `{"id":"resp_1","object":"response","created_at":1,"model":"grok-4.6","output":[{"type":"message","id":"m1","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"status":"completed","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`
+}
+
+func TestChat_ResponsesPathAndSessionHeader(t *testing.T) {
+	var gotPath, gotAuth, gotSession, gotModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotSession = r.Header.Get("x-opencode-session")
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		gotModel, _ = body["model"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(successBody()))
+	}))
+	defer srv.Close()
+
+	p := NewProvider("go-key", srv.URL, "test-agent", WithSessionHeaderName("x-opencode-session"))
+	resp, err := p.Chat(context.Background(), nil, nil, "grok-4.6", map[string]any{
+		"session_key": "sess-abc",
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if gotPath != "/responses" {
+		t.Fatalf("path = %q, want /responses", gotPath)
+	}
+	if gotAuth != "Bearer go-key" {
+		t.Fatalf("auth = %q, want Bearer go-key", gotAuth)
+	}
+	if gotSession != "sess-abc" {
+		t.Fatalf("x-opencode-session = %q, want sess-abc", gotSession)
+	}
+	if gotModel != "grok-4.6" {
+		t.Fatalf("model = %q, want grok-4.6", gotModel)
+	}
+	if resp == nil || resp.Content != "hello" {
+		t.Fatalf("resp = %+v, want content hello", resp)
+	}
+}
+
+func TestChat_ExplicitCustomHeaderWins(t *testing.T) {
+	var gotSession string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSession = r.Header.Get("x-opencode-session")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(successBody()))
+	}))
+	defer srv.Close()
+
+	p := NewProvider("go-key", srv.URL, "test-agent",
+		WithCustomHeaders(map[string]string{"x-opencode-session": "pinned"}),
+		WithSessionHeaderName("x-opencode-session"),
+	)
+	if _, err := p.Chat(context.Background(), nil, nil, "grok-4.6", map[string]any{"session_key": "sess-abc"}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if gotSession != "pinned" {
+		t.Fatalf("x-opencode-session = %q, want pinned", gotSession)
+	}
+}
+
+func TestChat_MissingAPIKey(t *testing.T) {
+	p := NewProvider("", "https://opencode.ai/zen/go/v1", "test-agent")
+	if _, err := p.Chat(context.Background(), nil, nil, "grok-4.6", nil); err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+}

--- a/pkg/providers/opencode_go_test.go
+++ b/pkg/providers/opencode_go_test.go
@@ -1,0 +1,140 @@
+package providers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sipeed/picoclaw/pkg/config"
+	anthropicmessages "github.com/sipeed/picoclaw/pkg/providers/anthropic_messages"
+	openairesponses "github.com/sipeed/picoclaw/pkg/providers/openai_responses"
+)
+
+func TestOpenCodeGoEndpointFamily(t *testing.T) {
+	cases := map[string]string{
+		"grok-4.6":                   "responses",
+		"gpt-5.6-luna":               "responses",
+		"muse-spark-1.3-contributor": "responses",
+		"minimax-m3":                 "messages",
+		"qwen3.7-plus":               "messages",
+		"kimi-k3":                    "chat",
+		"glm-5.3":                    "chat",
+		"some-future-model":          "chat",
+	}
+	for model, want := range cases {
+		if got := OpenCodeGoEndpointFamily(model); got != want {
+			t.Fatalf("OpenCodeGoEndpointFamily(%q) = %q, want %q", model, got, want)
+		}
+	}
+}
+
+func TestOpenCodeGoCatalogEntry(t *testing.T) {
+	option, ok := modelProviderOptionForName("opencode-go")
+	if !ok {
+		t.Fatal("opencode-go catalog entry missing")
+	}
+	if option.DefaultAPIBase != "https://opencode.ai/zen/go/v1" {
+		t.Fatalf("default_api_base = %q", option.DefaultAPIBase)
+	}
+	if !option.CreateAllowed || len(option.CommonModels) == 0 {
+		t.Fatal("opencode-go should be creatable with common models")
+	}
+}
+
+func openCodeGoResponsesBody() string {
+	return `{"id":"resp_1","object":"response","created_at":1,"model":"grok-4.6","output":[{"type":"message","id":"m1","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"status":"completed","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`
+}
+
+func openCodeGoMessagesBody() string {
+	return `{"id":"msg_1","type":"message","role":"assistant","model":"qwen3.7-plus","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`
+}
+
+func openCodeGoChatBody() string {
+	return `{"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"kimi-k3","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+}
+
+func TestCreateProviderFromConfig_OpenCodeGo(t *testing.T) {
+	tests := []struct {
+		name         string
+		model        string
+		responseBody string
+		wantPath     string
+		wantType     string
+	}{
+		{"responses family", "opencode-go/grok-4.6", openCodeGoResponsesBody(), "/responses", "*openairesponses.Provider"},
+		{"messages family", "opencode-go/qwen3.7-plus", openCodeGoMessagesBody(), "/messages", "*anthropicmessages.Provider"},
+		{"chat family", "opencode-go/kimi-k3", openCodeGoChatBody(), "/chat/completions", "*httpapi.HTTPProvider"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath, gotSession, gotAuth string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotSession = r.Header.Get("x-opencode-session")
+				gotAuth = r.Header.Get("Authorization")
+				if tt.wantType == "*anthropicmessages.Provider" {
+					gotAuth = r.Header.Get("X-API-Key")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			cfg := &config.ModelConfig{
+				ModelName: "test-opencode-go",
+				Model:     tt.model,
+				APIBase:   server.URL,
+			}
+			cfg.SetAPIKey("go-test-key")
+
+			provider, modelID, err := CreateProviderFromConfig(cfg)
+			if err != nil {
+				t.Fatalf("CreateProviderFromConfig() error = %v", err)
+			}
+
+			switch tt.wantType {
+			case "*openairesponses.Provider":
+				if _, ok := provider.(*openairesponses.Provider); !ok {
+					t.Fatalf("provider type = %T, want *openairesponses.Provider", provider)
+				}
+			case "*anthropicmessages.Provider":
+				if _, ok := provider.(*anthropicmessages.Provider); !ok {
+					t.Fatalf("provider type = %T, want *anthropicmessages.Provider", provider)
+				}
+			case "*httpapi.HTTPProvider":
+				if _, ok := provider.(*HTTPProvider); !ok {
+					t.Fatalf("provider type = %T, want *HTTPProvider", provider)
+				}
+			}
+
+			resp, err := provider.Chat(
+				t.Context(),
+				[]Message{{Role: "user", Content: "hi"}},
+				nil,
+				modelID,
+				map[string]any{"session_key": "sess-convo-1", "max_tokens": 1024},
+			)
+			if err != nil {
+				t.Fatalf("Chat() error = %v", err)
+			}
+			if !strings.HasSuffix(gotPath, tt.wantPath) {
+				t.Fatalf("path = %q, want suffix %q", gotPath, tt.wantPath)
+			}
+			if gotSession != "sess-convo-1" {
+				t.Fatalf("x-opencode-session = %q, want sess-convo-1", gotSession)
+			}
+			if tt.wantType == "*anthropicmessages.Provider" {
+				if gotAuth != "go-test-key" {
+					t.Fatalf("X-API-Key = %q, want go-test-key", gotAuth)
+				}
+			} else if gotAuth != "Bearer go-test-key" {
+				t.Fatalf("Authorization = %q, want Bearer go-test-key", gotAuth)
+			}
+			if resp == nil || resp.Content != "ok" {
+				t.Fatalf("resp = %+v, want content ok", resp)
+			}
+		})
+	}
+}

--- a/pkg/providers/provider_metadata.go
+++ b/pkg/providers/provider_metadata.go
@@ -580,6 +580,22 @@ var modelProviderOptionsByName = map[string]ModelProviderOption{
 		Aliases:             []string{"dashscope-us"},
 		httpAPI:             true,
 	},
+	"opencode-go": {
+		ID:                  "opencode-go",
+		DisplayName:         "OpenCode Go",
+		IconSlug:            "opencode",
+		Domain:              "opencode.ai",
+		DefaultAPIBase:      "https://opencode.ai/zen/go/v1",
+		CreateAllowed:       true,
+		DefaultModelAllowed: true,
+		SupportsFetch:       true,
+		Priority:            33,
+		CommonModels: []string{
+			"kimi-k3", "grok-4.6", "glm-5.3",
+			"qwen3.7-plus", "minimax-m3", "mimo-v2.5",
+		},
+		httpAPI: true,
+	},
 }
 
 var normalizedModelProviderAliasesByName = buildModelProviderAliasMap()


### PR DESCRIPTION
## Description

Adds a dedicated `opencode-go` provider (`https://opencode.ai/zen/go/v1`) so PicoClaw can keep using OpenCode Go. Each model is routed automatically to the correct endpoint family based on its model ID, and the `x-opencode-session` header is sent with the active conversation session key.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes, no api changes)

## AI Code Generation
- [ ] Fully AI-generated (100% AI, 0% Human)
- [x] Mostly AI-generated (AI draft, Human verified/modified)
- [ ] Mostly Human-written (Human lead, AI assisted or none)

## Related Issue

Closes #3369

## Technical Context (Skip for Docs)
- **Reference URL:** https://opencode.ai/docs/go/
- **Reasoning:** OpenCode Go exposes three protocol families (`/responses`, `/chat/completions`, `/messages`), so routing by model ID is required instead of forcing everything through Chat Completions, which would break `muse-spark-*`, `minimax-*` and `qwen3.*` models. Header injection is opt-in per provider (only `opencode-go` configures `x-opencode-session`), leaving standard OpenCode Zen and all other providers unaffected. The change is kept in a single PR because the routing depends on the session-header plumbing.

## Test Environment
- **Hardware:** PC (x86_64)
- **OS:** Windows 11
- **Model/Provider:** opencode-go (kimi-k3, grok-4.6, qwen3.7-plus, minimax-m3, mimo-v2.5)
- **Channels:** none (provider-level change, no channels involved)

## Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```
go build -tags "goolm,stdjson" ./pkg/... ./cmd/...   # clean
go vet -tags "goolm,stdjson" ./... (excl. web)        # clean
scripts/lint-docs.sh                                  # docs lint: OK
go test -tags "goolm,stdjson" \
  ./pkg/providers/ ./pkg/providers/common/ \
  ./pkg/providers/openai_responses/ \
  ./pkg/providers/anthropic_messages/ \
  ./pkg/providers/openai_compat/ ./pkg/providers/httpapi/
# ok across all six packages, including new tests:
# routing (OpenCodeGoEndpointFamily), session headers,
# Bearer auth and endpoint paths
```

Pre-existing failures in `pkg/agent` (seahorse) and `pkg/config` (security) were confirmed unrelated by re-running them on the clean tree via `git stash`, where they fail identically.

</details>

## Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
