### PR TITLE
fix(config): make the reaction tool configurable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1131,6 +1131,7 @@ type ToolsConfig struct {
 	ListDir         ToolConfig         `json:"list_dir"          yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_LIST_DIR_"`
 	LoadImage       ToolConfig         `json:"load_image"        yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_LOAD_IMAGE_"`
 	Message         MessageToolsConfig `json:"message"           yaml:"-"`
+	Reaction        ToolConfig         `json:"reaction"          yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_REACTION_"`
 	ReadFile        ReadFileToolConfig `json:"read_file"         yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_READ_FILE_"`
 	Serial          ToolConfig         `json:"serial"            yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_SERIAL_"`
 	SendFile        ToolConfig         `json:"send_file"         yaml:"-"                                                       envPrefix:"PICOCLAW_TOOLS_SEND_FILE_"`
@@ -1887,6 +1888,8 @@ func (t *ToolsConfig) IsToolEnabled(name string) bool {
 		return t.LoadImage.Enabled
 	case "message":
 		return t.Message.Enabled
+	case "reaction":
+		return t.Reaction.Enabled
 	case "read_file":
 		return t.ReadFile.Enabled
 	case "serial":

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1535,6 +1535,36 @@ func TestLoadConfig_LoadImageCanBeDisabled(t *testing.T) {
 	}
 }
 
+func TestDefaultConfig_ReactionEnabled(t *testing.T) {
+	cfg := DefaultConfig()
+	if !cfg.Tools.Reaction.Enabled {
+		t.Fatal("DefaultConfig().Tools.Reaction.Enabled should be true")
+	}
+	if !cfg.Tools.IsToolEnabled("reaction") {
+		t.Fatal("DefaultConfig().Tools.IsToolEnabled(reaction) should be true")
+	}
+}
+
+func TestLoadConfig_ReactionCanBeDisabled(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	raw := "{\n  \"version\": 2,\n  \"tools\": {\n    \"reaction\": {\n      \"enabled\": false\n    }\n  }\n}\n"
+	if err := os.WriteFile(configPath, []byte(raw), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error: %v", err)
+	}
+	if cfg.Tools.Reaction.Enabled {
+		t.Fatal("LoadConfig().Tools.Reaction.Enabled should be false")
+	}
+	if cfg.Tools.IsToolEnabled("reaction") {
+		t.Fatal("LoadConfig().Tools.IsToolEnabled(reaction) should be false")
+	}
+}
+
 func TestDefaultConfig_MessageMediaDisabled(t *testing.T) {
 	cfg := DefaultConfig()
 	if !cfg.Tools.Message.Enabled {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -466,6 +466,9 @@ func DefaultConfig() *Config {
 				},
 				MediaEnabled: false,
 			},
+			Reaction: ToolConfig{
+				Enabled: true,
+			},
 			ReadFile: ReadFileToolConfig{
 				Enabled:         true,
 				Mode:            ReadFileModeBytes,


### PR DESCRIPTION
## 📝 Description

This PR fixes the `reaction` tool configuration path.

`reaction` is conditionally registered in `agent_init.go`, but `ToolsConfig.IsToolEnabled("reaction")` had no dedicated branch and fell through to the default `true` case. In addition, `ToolsConfig` had no `reaction` field, so there was no way to control the tool from `config.json` — and because config decoding rejects unknown fields, adding `"reaction": {"enabled": false}` made the config fail to load instead.

This change:
- adds `tools.reaction` to `ToolsConfig`
- wires `IsToolEnabled("reaction")` to that config field
- preserves the current default behavior by setting `reaction` to enabled in `DefaultConfig()`
- adds tests covering both the default-enabled case and the explicit disabled case

This is the same fix, in the same shape, as #2879 for `load_image`.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

No open issue. Prior attempt: #2888 covered this among other changes but was closed without review (CLA unsigned). Same class of bug as #2878, fixed for `load_image` by #2879.

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** https://github.com/sipeed/picoclaw/pull/2879
- **Reasoning:** The runtime already checked `IsToolEnabled("reaction")` (`pkg/agent/agent_init.go:221`), but the config layer did not define a `reaction` tool entry or a corresponding switch branch (`pkg/config/config.go:1109` `ToolsConfig`, `pkg/config/config.go:1862` `IsToolEnabled`, default at `:1912`). Because of that mismatch the guard always evaluated to `true`. The tool could not be disabled by omission either: unknown config fields are rejected at load (`pkg/config/diagnostics.go:25`), so writing `tools.reaction` in `config.json` produced an "unknown field(s)" error rather than disabling the tool. The only workaround was to keep the tool on.

## 🧪 Test Environment
- **Hardware:** PC (local development machine, Apple Silicon)
- **OS:** macOS 15.7.4
- **Model/Provider:** N/A (config-level tests only)
- **Channels:** N/A (config-level tests only)

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

```text
go version go1.25.13 darwin/arm64

$ go test ./pkg/config/ -run 'TestDefaultConfig_ReactionEnabled|TestLoadConfig_ReactionCanBeDisabled' -count=1
ok   github.com/sipeed/picoclaw/pkg/config

$ go test ./pkg/config/ ./pkg/agent/
ok   github.com/sipeed/picoclaw/pkg/config
ok   github.com/sipeed/picoclaw/pkg/agent
(1040 tests passed across both packages, 0 failed)
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
