### PR TITLE
fix(config): guard lazy sensitive-data cache against concurrent init

### DIFF
--- a/pkg/config/security.go
+++ b/pkg/config/security.go
@@ -209,22 +209,35 @@ type SensitiveDataCache struct {
 	once     sync.Once
 }
 
+// sensitiveCacheMu guards the lazy creation of Config.sensitiveCache. It is a
+// package-level lock rather than a Config field because Config is shallow-copied
+// by value (cmd/picoclaw/internal/mcp/helpers.go), which a lock field would make
+// invalid. It is only held while the pointer is created; building the replacer
+// happens outside it, inside sync.Once.
+var sensitiveCacheMu sync.Mutex
+
 // SensitiveDataReplacer returns the strings.Replacer for filtering sensitive data.
 // It is computed once on first access via sync.Once.
 func (sec *Config) SensitiveDataReplacer() *strings.Replacer {
-	sec.initSensitiveCache()
-	return sec.sensitiveCache.replacer
+	return sec.initSensitiveCache().replacer
 }
 
-// initSensitiveCache initializes the sensitive data cache if not already done.
-func (sec *Config) initSensitiveCache() {
-	if sec.sensitiveCache == nil {
-		sec.sensitiveCache = &SensitiveDataCache{}
+// initSensitiveCache initializes the sensitive data cache if not already done
+// and returns it. The caller must use the returned cache rather than re-reading
+// sec.sensitiveCache, so that it always observes the cache its sync.Once ran on.
+func (sec *Config) initSensitiveCache() *SensitiveDataCache {
+	sensitiveCacheMu.Lock()
+	cache := sec.sensitiveCache
+	if cache == nil {
+		cache = &SensitiveDataCache{}
+		sec.sensitiveCache = cache
 	}
-	sec.sensitiveCache.once.Do(func() {
+	sensitiveCacheMu.Unlock()
+
+	cache.once.Do(func() {
 		values := sec.collectSensitiveValues()
 		if len(values) == 0 {
-			sec.sensitiveCache.replacer = strings.NewReplacer()
+			cache.replacer = strings.NewReplacer()
 			return
 		}
 
@@ -236,11 +249,12 @@ func (sec *Config) initSensitiveCache() {
 			}
 		}
 		if len(pairs) == 0 {
-			sec.sensitiveCache.replacer = strings.NewReplacer()
+			cache.replacer = strings.NewReplacer()
 			return
 		}
-		sec.sensitiveCache.replacer = strings.NewReplacer(pairs...)
+		cache.replacer = strings.NewReplacer(pairs...)
 	})
+	return cache
 }
 
 // collectSensitiveValues collects all sensitive strings from SecurityConfig using reflection.

--- a/pkg/config/security_test.go
+++ b/pkg/config/security_test.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/caarlos0/env/v11"
@@ -269,4 +271,82 @@ skills:
 		assert.Equal(t, "brave_key_env", envCfg.Tools.Web.Brave.APIKeys[0].raw)
 		assert.Equal(t, "abc", envCfg.Tools.Web.Brave.APIKeys[1].raw)
 	})
+}
+
+// TestSensitiveDataReplacer_ConcurrentFirstUse covers the lazy initialization of
+// the sensitive-data cache from several goroutines at once, which happens as soon
+// as more than one turn filters tool output through the same *Config.
+// A caller must never observe a nil replacer. Run with -race.
+func TestSensitiveDataReplacer_ConcurrentFirstUse(t *testing.T) {
+	const goroutines = 8
+
+	// A fresh *Config per iteration: the cache is initialized once per Config,
+	// so the only interesting window is the first concurrent use.
+	for i := 0; i < 200; i++ {
+		cfg := &Config{
+			ModelList: SecureModelList{
+				&ModelConfig{
+					ModelName: "m",
+					Model:     "openai/m",
+					APIKeys:   SimpleSecureStrings("sk-long-key-12345"),
+				},
+			},
+		}
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		got := make([]*strings.Replacer, goroutines)
+		for g := 0; g < goroutines; g++ {
+			wg.Add(1)
+			go func(g int) {
+				defer wg.Done()
+				<-start
+				got[g] = cfg.SensitiveDataReplacer()
+			}(g)
+		}
+		close(start)
+		wg.Wait()
+
+		for g, r := range got {
+			require.NotNil(t, r, "iteration %d, goroutine %d: nil replacer", i, g)
+		}
+	}
+}
+
+// TestFilterSensitiveData_ConcurrentFirstUse is the same race seen through the
+// public entry point used by the agent pipeline. Run with -race.
+func TestFilterSensitiveData_ConcurrentFirstUse(t *testing.T) {
+	const goroutines = 8
+
+	for i := 0; i < 200; i++ {
+		cfg := &Config{
+			Tools: ToolsConfig{FilterSensitiveData: true},
+			ModelList: SecureModelList{
+				&ModelConfig{
+					ModelName: "m",
+					Model:     "openai/m",
+					APIKeys:   SimpleSecureStrings("sk-long-key-12345"),
+				},
+			},
+		}
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		got := make([]string, goroutines)
+		for g := 0; g < goroutines; g++ {
+			wg.Add(1)
+			go func(g int) {
+				defer wg.Done()
+				<-start
+				got[g] = cfg.FilterSensitiveData("key is sk-long-key-12345 here")
+			}(g)
+		}
+		close(start)
+		wg.Wait()
+
+		for g, s := range got {
+			assert.Equal(t, "key is [FILTERED] here", s,
+				"iteration %d, goroutine %d", i, g)
+		}
+	}
 }


### PR DESCRIPTION
## 📝 Description

`Config.sensitiveCache` was created lazily without synchronization, so the `sync.Once` it contains
could not protect its own creation:

```go
// pkg/config/security.go:219-224 before
func (sec *Config) initSensitiveCache() {
	if sec.sensitiveCache == nil {                 // unsynchronized read
		sec.sensitiveCache = &SensitiveDataCache{} // unsynchronized write
	}
	sec.sensitiveCache.once.Do(func() { ... })
}
```

Two goroutines can both see `nil`, each allocate a cache, and the second write wins. Because
`SensitiveDataReplacer` then re-read the field, it could return the replacer of a cache whose `Once`
had not run yet — a **nil `*strings.Replacer`**. `FilterSensitiveData` calls `.Replace()` on that
(`pkg/config/config.go:209`), which panics.

This change:
- guards the pointer creation with a package-level mutex
- returns the cache from `initSensitiveCache`, so the caller always uses the cache its `Once` ran on
- keeps the reflection walk in `collectSensitiveValues` outside the lock, inside `sync.Once`
- adds two `-race` tests for concurrent first use, via the accessor and via `FilterSensitiveData`

The lock is package level rather than a `Config` field on purpose: `Config` is shallow-copied by
value in `cmd/picoclaw/internal/mcp/helpers.go:130` (`clone := *cfg`), so any field containing
`sync.Once` / `sync.Mutex` / `atomic.Pointer` fails `go vet` copylocks. If you would rather remove
that shallow copy and make the cache a plain value field, say so and I will redo it that way.

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🤖 AI Code Generation
- [ ] 🤖 Fully AI-generated (100% AI, 0% Human)
- [x] 🛠️ Mostly AI-generated (AI draft, Human verified/modified)
- [ ] 👨‍💻 Mostly Human-written (Human lead, AI assisted or none)

## 🔗 Related Issue

Fixes #3374

## 📚 Technical Context (Skip for Docs)
- **Reference URL:** N/A
- **Reasoning:** The `sync.Once` lives inside the object being lazily created, so it cannot guard its
  own allocation. The failure needs two turns filtering tool output through the same `*Config`, i.e.
  more than one turn in flight; the worker pool defaults to 1 (`pkg/agent/agent_init.go:60-64`), so a
  single-turn setup is not exposed. Callers on the hot path are
  `pkg/agent/pipeline_execute.go:295,303,388,527,690,776` and `pkg/agent/turn_coord.go:148`.

## 🧪 Test Environment
- **Hardware:** PC (local development machine, Apple Silicon)
- **OS:** macOS 15.7.4
- **Model/Provider:** N/A (config-level tests only)
- **Channels:** N/A (config-level tests only)

## 📸 Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

Before the fix, the new tests fail under `-race`:

```text
WARNING: DATA RACE
Read at 0x00c000123130 by goroutine 11:
  config.(*Config).initSensitiveCache()   pkg/config/security.go:221
  config.(*Config).SensitiveDataReplacer() pkg/config/security.go:215
Previous write at 0x00c000123130 by goroutine 12:
  config.(*Config).initSensitiveCache()   pkg/config/security.go:222
  config.(*Config).SensitiveDataReplacer() pkg/config/security.go:215
```

The corrupted result is also observable without `-race`. Stressing
`SensitiveDataReplacer` with 32 goroutines over 200000 fresh `*Config` (6.4M calls):

```text
before: nil replacers = 1, wrong output = 0
after:  nil replacers = 0, wrong output = 0
```

After the fix:

```text
$ go test ./pkg/config/ -race -count=1
ok   github.com/sipeed/picoclaw/pkg/config    (344 tests passed)

$ go test ./pkg/config/ -count=1
ok   github.com/sipeed/picoclaw/pkg/config    (344 tests passed)

$ go vet ./pkg/config/ ./cmd/picoclaw/internal/mcp/
(clean)
```

</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.
